### PR TITLE
Pass for processing `.properties` files

### DIFF
--- a/install-local-joern.sh
+++ b/install-local-joern.sh
@@ -70,7 +70,6 @@ sbt clean stage
 
 echo "Installing jars into: ${JAR_INSTALL_DIR}"
 rm ${JAR_INSTALL_DIR}/io.shiftleft.codepropertygraph-domain-classes*
-cp target/universal/stage/lib/org.codeminers.standalone-* ${JAR_INSTALL_DIR}
-cp target/universal/stage/lib/org.codeminers.*domain* ${JAR_INSTALL_DIR}
+cp target/universal/stage/lib/ai.privado* ${JAR_INSTALL_DIR}
 
 echo "All done, you're ready to go in $JOERN_INSTALL"

--- a/schema/src/main/scala/CpgExtSchema.scala
+++ b/schema/src/main/scala/CpgExtSchema.scala
@@ -6,6 +6,7 @@ import overflowdb.schema.SchemaBuilder
 class CpgExtSchema(builder: SchemaBuilder, cpgSchema: CpgSchema) {
   import cpgSchema.ast._
   import cpgSchema.base._
+  import cpgSchema.fs._
 
   // Add node types, edge types, and properties here
 
@@ -45,6 +46,7 @@ class CpgExtSchema(builder: SchemaBuilder, cpgSchema: CpgSchema) {
   val isUsedAt = builder
     .addEdgeType("IS_USED_AT")
 
+  property.addOutEdge(edge = sourceFile, inNode = file)
   property.addOutEdge(edge = isUsedAt, inNode = literal)
 
 }

--- a/src/main/scala/ai/privado/entrypoint/ScanProcessor.scala
+++ b/src/main/scala/ai/privado/entrypoint/ScanProcessor.scala
@@ -4,6 +4,7 @@ import ai.privado.cache.{AppCache, RuleCache}
 import ai.privado.dataflow.DuplicateFlowProcessor
 import ai.privado.exporter.JSONExporter
 import ai.privado.model._
+import ai.privado.passes.config.PropertiesFilePass
 import ai.privado.semantic.Language._
 import ai.privado.utility.Utilities.isValidRule
 import better.files.File
@@ -189,6 +190,7 @@ object ScanProcessor extends CommandProcessor {
     }
     xtocpg match {
       case Success(cpgWithoutDataflow) =>
+        new PropertiesFilePass(cpgWithoutDataflow, sourceRepoLocation).createAndApply()
         println("Parsing source code...")
         logger.info("Applying default overlays")
         cpgWithoutDataflow.close()

--- a/src/main/scala/ai/privado/language/package.scala
+++ b/src/main/scala/ai/privado/language/package.scala
@@ -1,7 +1,7 @@
 package ai.privado
 
 import io.shiftleft.codepropertygraph.generated.{Cpg, EdgeTypes, NodeTypes}
-import io.shiftleft.codepropertygraph.generated.nodes.{JavaProperty, Literal}
+import io.shiftleft.codepropertygraph.generated.nodes.{File, JavaProperty, Literal}
 import overflowdb.traversal._
 
 package object language {
@@ -14,6 +14,7 @@ package object language {
   implicit class StepsForProperty(val trav: Traversal[JavaProperty]) extends AnyVal {
 
     def usedAt: Traversal[Literal] = trav.out(EdgeTypes.IS_USED_AT).cast[Literal]
+    def file: Traversal[File]      = trav.out(EdgeTypes.SOURCE_FILE).cast[File]
 
   }
 

--- a/src/test/scala/ai/privado/passes/config/PropertiesFilePassTest.scala
+++ b/src/test/scala/ai/privado/passes/config/PropertiesFilePassTest.scala
@@ -1,7 +1,7 @@
 package ai.privado.passes.config
 
 import better.files.File
-import io.shiftleft.codepropertygraph.generated.{Cpg, EdgeTypes}
+import io.shiftleft.codepropertygraph.generated.Cpg
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
@@ -42,6 +42,11 @@ class PropertiesFilePassTest extends AnyWordSpec with Matchers with BeforeAndAft
       val properties = cpg.property.map(x => (x.name, x.value)).toMap
       properties.get("accounts.datasource.url").contains("jdbc:mariadb://localhost:3306/accounts?useSSL=false") shouldBe true
       properties.get("internal.logger.api.base").contains("https://logger.privado.ai/")
+    }
+
+    "connect property nodes to file" in {
+      val List(filename: String) =  cpg.property.file.name.dedup.l
+      filename.endsWith("/test.properties") shouldBe true
     }
 
     "connect property node to literal via `IS_USED_AT` edge" in {


### PR DESCRIPTION
* For all `.properties` files, a `FILE` node is created.
* For each property, a `JAVA_PROPERTY` is created.
* `JAVA_PROPERTY` nodes are connected to `FILE` nodes via `SOURCE_FILE` edges
* A small language is defined to traverse between files and properties
* We look for calls to `getProperty` and connect them to `JAVA_PROPERTY` nodes via incoming `IS_USED_AT` edges
* A small language is defined to traverse between properties and literals in `getProperty` calls
* Unit tests for all of these features