### PR TITLE
add - processing language specific rule

### DIFF
--- a/log4j2.xml
+++ b/log4j2.xml
@@ -6,7 +6,7 @@
         </Console>
     </Appenders>
     <Loggers>
-        <Root level="ERROR">
+        <Root level="DEBUG">
             <AppenderRef ref="Console" />
         </Root>
     </Loggers>

--- a/src/main/scala/ai/privado/dataflow/DuplicateFlowProcessor.scala
+++ b/src/main/scala/ai/privado/dataflow/DuplicateFlowProcessor.scala
@@ -24,6 +24,7 @@ package ai.privado.dataflow
 
 import ai.privado.model.Constants
 import io.joern.dataflowengineoss.language.Path
+import io.shiftleft.semanticcpg.language._
 import org.slf4j.LoggerFactory
 
 import scala.collection.mutable

--- a/src/main/scala/ai/privado/entrypoint/ScanProcessor.scala
+++ b/src/main/scala/ai/privado/entrypoint/ScanProcessor.scala
@@ -210,8 +210,6 @@ object ScanProcessor extends CommandProcessor {
         semantics = semantics.distinctBy(_.signature)
       )
     logger.trace(mergedRules.toString)
-    logger.info("Caching rules")
-    RuleCache.setRule(mergedRules)
     println("Configuration parsed...")
 
     RuleCache.internalPolicies.addAll(internalConfigAndRules.policies.map(policy => (policy.id)))

--- a/src/main/scala/ai/privado/java/exporter/ExporterUtility.scala
+++ b/src/main/scala/ai/privado/java/exporter/ExporterUtility.scala
@@ -29,7 +29,6 @@ import io.shiftleft.codepropertygraph.generated.nodes.CfgNode
 import io.shiftleft.semanticcpg.language.toExtendedNode
 import ai.privado.semantic.Language.finder
 
-
 object ExporterUtility {
 
   /** Convert List of path element schema object

--- a/src/main/scala/ai/privado/java/exporter/SourceExporter.scala
+++ b/src/main/scala/ai/privado/java/exporter/SourceExporter.scala
@@ -33,7 +33,6 @@ import ai.privado.model.exporter.{SourceModel, SourceProcessingModel}
 import overflowdb.traversal.Traversal
 import ai.privado.semantic.Language.finder
 
-
 import scala.collection.mutable
 
 class SourceExporter(cpg: Cpg) {

--- a/src/main/scala/ai/privado/model/PrivadoTag.scala
+++ b/src/main/scala/ai/privado/model/PrivadoTag.scala
@@ -82,8 +82,10 @@ object CatLevelOne extends Enumeration {
 object Language extends Enumeration {
   type Language = Value
 
-  val JAVA    = Value("java")
-  val UNKNOWN = Value("unknown")
+  val JAVA       = Value("java")
+  val JAVASCRIPT = Value("js")
+  val DEFAULT    = Value("default")
+  val UNKNOWN    = Value("unknown")
   def withNameWithDefault(name: String): Value = {
     try {
       withName(name)

--- a/src/main/scala/ai/privado/rulevalidator/YamlFileValidator.scala
+++ b/src/main/scala/ai/privado/rulevalidator/YamlFileValidator.scala
@@ -180,7 +180,8 @@ object YamlFileValidator {
     def validateJsonFile(schemaFile: String, jsonObj: JsonNode): mutable.Set[ValidationMessage] = {
       file
         .loadSchema(schemaFile)
-        .validate(jsonObj).asScala
+        .validate(jsonObj)
+        .asScala
     }
 
   }

--- a/src/main/scala/ai/privado/utility/Utilities.scala
+++ b/src/main/scala/ai/privado/utility/Utilities.scala
@@ -25,8 +25,7 @@ package ai.privado.utility
 import ai.privado.cache.RuleCache
 import ai.privado.metric.MetricHandler
 import ai.privado.model.CatLevelOne.CatLevelOne
-import ai.privado.model.Semantic
-import ai.privado.model.{Constants, RuleInfo}
+import ai.privado.model.{ConfigAndRules, Constants, Language, RuleInfo, Semantic}
 import better.files.File
 import io.joern.dataflowengineoss.semanticsloader.{Parser, Semantics}
 import io.joern.x2cpg.SourceFiles
@@ -42,7 +41,6 @@ import java.util.regex.{Pattern, PatternSyntaxException}
 import scala.io.Source
 import io.shiftleft.semanticcpg.language._
 import ai.privado.semantic.Language.finder
-
 
 import java.math.BigInteger
 import java.security.MessageDigest
@@ -259,5 +257,25 @@ object Utilities {
       Some(generatedSemantic.trim)
     } else
       None
+  }
+
+  /** Returns only rules which belong to the correponding passed language along with Default and Unknown
+    * @param rules
+    * @param lang
+    * @return
+    */
+  def filterRuleByLanguage(rules: ConfigAndRules, lang: Language.Value): ConfigAndRules = {
+    def getRuleByLang(rule: RuleInfo) =
+      rule.language == lang || rule.language == Language.DEFAULT || rule.language == Language.UNKNOWN
+    def getSemanticRuleByLang(rule: Semantic) =
+      rule.language == lang || rule.language == Language.DEFAULT || rule.language == Language.UNKNOWN
+
+    val sources     = rules.sources.filter(getRuleByLang)
+    val sinks       = rules.sinks.filter(getRuleByLang)
+    val collections = rules.collections.filter(getRuleByLang)
+    val exclusions  = rules.exclusions.filter(getRuleByLang)
+    val semantics   = rules.semantics.filter(getSemanticRuleByLang)
+
+    ConfigAndRules(sources, sinks, collections, rules.policies, rules.threats, exclusions, semantics)
   }
 }


### PR DESCRIPTION
- Process only language specific rules. (Make use of the `language.yaml`)
Ex - If scanning for `javascript`, `java` rules should not be considered
- Cache relevant rules only