### PR TITLE
Support for curly brace imports

### DIFF
--- a/src/main/scala/ai/privado/javascript/passes/methodfullname/MethodFullName.scala
+++ b/src/main/scala/ai/privado/javascript/passes/methodfullname/MethodFullName.scala
@@ -54,7 +54,25 @@ class MethodFullName(cpg: Cpg) extends ConcurrentWriterCpgPass[(String, String, 
           )
           .argument(1)
           .isIdentifier
-          .map(item => (item.name, dependencyName, item.file.name.head, "pkg."))
+          .flatMap(item => {
+            // handles const {WebClient} = require('@slack/web-api')
+            if (item.name.matches("_tmp_.*")) {
+              cpg.identifier
+                .nameExact(item.name)
+                .where(_.file.nameExact(item.file.name.head))
+                .astParent
+                .astParent
+                .isCall
+                .argument(1)
+                .isIdentifier
+                .map(curlyItem => (curlyItem.name, dependencyName, curlyItem.file.name.head, "pkg."))
+                .l
+            }
+            // handles const WebClient = require('@slack/web-api')
+            else {
+              List((item.name, dependencyName, item.file.name.head, "pkg."))
+            }
+          })
       })
       .toArray
 

--- a/src/main/scala/ai/privado/javascript/passes/methodfullname/MethodFullNameFromIdentifier.scala
+++ b/src/main/scala/ai/privado/javascript/passes/methodfullname/MethodFullNameFromIdentifier.scala
@@ -106,7 +106,10 @@ class MethodFullNameFromIdentifier(cpg: Cpg) extends ConcurrentWriterCpgPass[(Ex
 
     // From pkg.log4js.getLogger we need to tag new call node as pkg.log4js.debug
     val methodFullNameAfterSplit = methodFullname.split("\\.")
-    val newMethodFullName        = methodFullNameAfterSplit.slice(0, methodFullNameAfterSplit.length - 1).mkString(".")
+    var newMethodFullName        = methodFullNameAfterSplit.slice(0, methodFullNameAfterSplit.length - 1).mkString(".")
+    // To handle pkg.@slack/web-api.<operator>.new case
+    if (newMethodFullName.endsWith("operator>"))
+      newMethodFullName = methodFullNameAfterSplit.slice(0, methodFullNameAfterSplit.length - 2).mkString(".")
     builder.setNodeProperty(callNode, PropertyNames.MethodFullName, newMethodFullName + "." + callNode.name)
   }
 }

--- a/src/main/scala/ai/privado/javascript/passes/methodfullname/MethodFullNameFromIdentifier.scala
+++ b/src/main/scala/ai/privado/javascript/passes/methodfullname/MethodFullNameFromIdentifier.scala
@@ -57,9 +57,23 @@ class MethodFullNameFromIdentifier(cpg: Cpg) extends ConcurrentWriterCpgPass[(Ex
   override def generateParts(): Array[(Expression, Expression)] = {
     cpg
       .call(Operators.assignment)
-      .whereNot(_.argument(2).isCall.methodFullName(ANY_VALUE))
       .where(_.argument(1).isIdentifier)
-      .map(assignmentCall => { (assignmentCall.argument(1), assignmentCall.argument(2)) })
+      .flatMap(assignmentCall => {
+        val argument2 = assignmentCall.argument(2)
+        // handles const webClient = WebClient();
+        if (argument2.isCall && Traversal(argument2).isCall.methodFullNameNot(ANY_VALUE).nonEmpty)
+          Some((assignmentCall.argument(1), assignmentCall.argument(2)))
+        // handles const webClient = new WebClient();
+        else if (argument2.isBlock && Traversal(argument2).isBlock.astChildren.isCall.name("<operator>.new").nonEmpty)
+          Some(
+            (
+              assignmentCall.argument(1),
+              assignmentCall.argument(2).astChildren.isCall.where(_.name("<operator>.new")).head
+            )
+          )
+        else
+          None
+      })
       .toArray
   }
 
@@ -81,9 +95,8 @@ class MethodFullNameFromIdentifier(cpg: Cpg) extends ConcurrentWriterCpgPass[(Ex
     cpg.identifier
       .nameExact(identifierName)
       .filter(_.file.name.head.equals(identifierFileName))
-      .astParent
-      .isCall
-      .nameNot(Operators.ALL.asScala.toSeq: _*)
+      .repeat(_.astParent)(_.until(_.isCall.nameNot(".*operator.*")))
+      .isCall // This will take care of field chaining ex - web.chat.postMessage()
       .or(_.filter(_.methodFullName.isEmpty), _.where(_.methodFullName(ANY_VALUE)))
       .foreach(callNode => updateCallNode(builder, callNode, callNodeMethodFullName))
 

--- a/src/main/scala/ai/privado/javascript/tagger/sink/RegularSinkTagger.scala
+++ b/src/main/scala/ai/privado/javascript/tagger/sink/RegularSinkTagger.scala
@@ -31,8 +31,8 @@ import overflowdb.BatchedUpdate
 
 import scala.jdk.CollectionConverters.CollectionHasAsScala
 
-class RegularSinkTagger(cpg: Cpg) extends PrivadoSimplePass(cpg){
-  lazy val cacheCall = cpg.call.or(_.nameNot(Operators.ALL.asScala.toSeq:_*)).l
+class RegularSinkTagger(cpg: Cpg) extends PrivadoSimplePass(cpg) {
+  lazy val cacheCall = cpg.call.or(_.nameNot(Operators.ALL.asScala.toSeq: _*)).l
   override def run(builder: BatchedUpdate.DiffGraphBuilder): Unit = {
     val sinks = cacheCall.methodFullName("pkg.(" + ruleInfo.patterns.head + ").*").l
 

--- a/src/main/scala/ai/privado/tagger/sink/RegularSinkTagger.scala
+++ b/src/main/scala/ai/privado/tagger/sink/RegularSinkTagger.scala
@@ -32,7 +32,7 @@ import overflowdb.BatchedUpdate
 import scala.jdk.CollectionConverters.CollectionHasAsScala
 
 class RegularSinkTagger(cpg: Cpg) extends PrivadoSimplePass(cpg) {
-  lazy val cacheCall = cpg.call.or(_.nameNot(Operators.ALL.asScala.toSeq:_*)).l
+  lazy val cacheCall = cpg.call.or(_.nameNot(Operators.ALL.asScala.toSeq: _*)).l
   override def run(builder: BatchedUpdate.DiffGraphBuilder): Unit = {
     val sinks = cacheCall.methodFullName(ruleInfo.patterns.head).l
 


### PR DESCRIPTION
add - support for  `const {WebClient}  = require('@slack/web-api')`
add - support for adding methodFullName in chaining via fieldAccess - Ex- `web.chat.postMessage()`