### PR TITLE
Export the probable sinks to privado.json file

### DIFF
--- a/sampletestrules/config/sinkskiplist/java.yaml
+++ b/sampletestrules/config/sinkskiplist/java.yaml
@@ -2,39 +2,9 @@ sinkSkipList:
   - id: SinkSkipList.ThirdParties
     name: Skip Third Party Sinks
     patterns:
-      - "android\\..*"
-        "javax\\..*"
-        "androidx\\..*"
-        "okhttp3\\..*"
-        "io.grpc\\..*"
-        "io.netty\\..*"
-        "org.apache.http\\..*"
-        "org.json.*"
-        "org.junit\\..*"
-        "org.apache.commons\\..*"
-        "org.apache.tomcat.*"
-        "org.springframework\\..*"
-        "com.fasterxml.jackson\\..*"
-        "org.apache.hadoop\\..*"
-        "org.apache.giraph\\..*"
-        "org.javatuples\\..*"
-        "org.antlr\\..*"
-        "junit.framework\\..*"
-        "io.reactivex\\..*"
-        "com.bumptech.glide.*"
-        "com.google.protobuf.*"
-        "com.google.testing.*"
-        "com.google.common.*"
+      - "(?i)(android\\.|javax\\.|androidx\\.|com.sun.jna|com.sun.tools|sun.management|org.apache.kafka|okhttp3\\.|io.grpc\\.|io.netty\\.|org.apache.http\\.|org.json|org.junit\\.|org.apache.commons\\.|org.apache.tomcat|org.springframework\\.|tools.fastlane\\.|com.fasterxml.jackson\\.|com.alibaba.fastjson\\.|org.apache.hadoop\\.|org.apache.giraph\\.|org.javatuples\\.|org.antlr\\.|junit.framework\\.|io.reactivex\\.|com.bumptech.glide|com.google.protobuf|com.google.testing|com.google.common.*|com.google.android\\.|com.google.protobuf\\.|reactor.core\\.|io.grpc\\.).*"
 
   - id: SinkSkipList.BuiltInLib
     name: Skip built in language libraries
     patterns:
-      - "<empty>"
-        "iterator.*"
-        "assert.*"
-        "void\\..*"
-        "java\\..*"
-        "ANY\\..*"
-        "<operator>\\..*"
-        "<operators>\\..*"
-        "<unresolvedNamespace.*>."
+      - "(?i)(<empty>|iterator|assert|void\\.|int|byte|java\\.|ANY\\.|<operator>\\.|<operators>\\.|<unresolvedNamespace.*>.).*"

--- a/sampletestrules/config/sinkskiplist/java.yaml
+++ b/sampletestrules/config/sinkskiplist/java.yaml
@@ -1,0 +1,40 @@
+sinkSkipList:
+  - id: SinkSkipList.ThirdParties
+    name: Skip Third Party Sinks
+    patterns:
+      - "android\\..*"
+        "javax\\..*"
+        "androidx\\..*"
+        "okhttp3\\..*"
+        "io.grpc\\..*"
+        "io.netty\\..*"
+        "org.apache.http\\..*"
+        "org.json.*"
+        "org.junit\\..*"
+        "org.apache.commons\\..*"
+        "org.apache.tomcat.*"
+        "org.springframework\\..*"
+        "com.fasterxml.jackson\\..*"
+        "org.apache.hadoop\\..*"
+        "org.apache.giraph\\..*"
+        "org.javatuples\\..*"
+        "org.antlr\\..*"
+        "junit.framework\\..*"
+        "io.reactivex\\..*"
+        "com.bumptech.glide.*"
+        "com.google.protobuf.*"
+        "com.google.testing.*"
+        "com.google.common.*"
+
+  - id: SinkSkipList.BuiltInLib
+    name: Skip built in language libraries
+    patterns:
+      - "<empty>"
+        "iterator.*"
+        "assert.*"
+        "void\\..*"
+        "java\\..*"
+        "ANY\\..*"
+        "<operator>\\..*"
+        "<operators>\\..*"
+        "<unresolvedNamespace.*>."

--- a/src/main/resources/ai/privado/rulevalidator/schema/sinkSkipList.json
+++ b/src/main/resources/ai/privado/rulevalidator/schema/sinkSkipList.json
@@ -1,0 +1,70 @@
+{
+  "definitions": {},
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://github.com/Privado-Inc/privado-core/tree/main/src/main/resources/ai/privado/rulevalidator/schema/sinkSkipList.json",
+  "title": "Root",
+  "type": "object",
+  "required": [
+    "sinkSkipList"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "sinkSkipList": {
+      "$id": "#root/sinkSkipList",
+      "title": "SinkSkipList",
+      "type": "array",
+      "default": [],
+      "items":{
+        "$id": "#root/sinkSkipList/items",
+        "title": "Items",
+        "type": "object",
+        "required": [
+          "id",
+          "name",
+          "patterns"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "id": {
+            "$id": "#root/sinkSkipList/items/id",
+            "title": "Id",
+            "type": "string",
+            "default": "",
+            "examples": [
+              "SinkSkipList.ThirdParties"
+            ],
+            "pattern": "^.*$"
+          },
+          "name": {
+            "$id": "#root/sinkSkipList/items/name",
+            "title": "Name",
+            "type": "string",
+            "default": "",
+            "examples": [
+              "Skip Third Party Sinks"
+            ],
+            "pattern": "^.*$"
+          },
+          "patterns": {
+            "$id": "#root/sinkSkipList/items/patterns",
+            "title": "Patterns",
+            "type": "array",
+            "default": [],
+            "items":{
+              "$id": "#root/sinkSkipList/items/patterns/items",
+              "title": "Items",
+              "type": "string",
+              "format": "regex",
+              "default": "",
+              "examples": [
+                ".*(AmazonS3).*"
+              ],
+              "pattern": "^.*$"
+            }
+          }
+        }
+      }
+
+    }
+  }
+}

--- a/src/main/scala/ai/privado/cache/RuleCache.scala
+++ b/src/main/scala/ai/privado/cache/RuleCache.scala
@@ -30,7 +30,7 @@ import scala.collection.mutable
   */
 object RuleCache {
 
-  private var rule: ConfigAndRules = ConfigAndRules(List(), List(), List(), List(), List(), List(), List())
+  private var rule: ConfigAndRules = ConfigAndRules(List(), List(), List(), List(), List(), List(), List(), List())
   private val ruleInfoMap          = mutable.HashMap[String, RuleInfo]()
   private val policyOrThreatMap    = mutable.HashMap[String, PolicyOrThreat]()
   val internalRules                = mutable.HashMap[String, Int]()
@@ -77,6 +77,9 @@ object RuleCache {
       internalRules.addOne((rule.id, 0))
     }
     for (rule <- rules.exclusions) {
+      internalRules.addOne((rule.id, 0))
+    }
+    for (rule <- rules.sinkSkipList) {
       internalRules.addOne((rule.id, 0))
     }
   }

--- a/src/main/scala/ai/privado/entrypoint/CommandParser.scala
+++ b/src/main/scala/ai/privado/entrypoint/CommandParser.scala
@@ -37,6 +37,7 @@ case class PrivadoInput(
   skipDownloadDependencies: Boolean = false,
   disableDeDuplication: Boolean = false,
   ignoreExcludeRules: Boolean = false,
+  ignoreSinkSkipRules: Boolean = false,
   skipUpload: Boolean = false,
   upload: Boolean = false,
   enableJS: Boolean = false

--- a/src/main/scala/ai/privado/exporter/JSONExporter.scala
+++ b/src/main/scala/ai/privado/exporter/JSONExporter.scala
@@ -126,6 +126,9 @@ object JSONExporter {
         }
       )
 
+      logger.debug("------------ Sink Skip List ---------------")
+      val skipRules = RuleCache.getRule.sinkSkipList.map(sinkSkipRule => sinkSkipRule.patterns.head)
+      logger.debug(s"$skipRules")
       logger.debug("------------ Probable Sink Dependencies ---------------")
       logger.debug(s"$probableSinks")
 

--- a/src/main/scala/ai/privado/exporter/JSONExporter.scala
+++ b/src/main/scala/ai/privado/exporter/JSONExporter.scala
@@ -80,6 +80,8 @@ object JSONExporter {
       output.addOne(Constants.sinks -> sinks.asJson)
       val processingSinks = sinkExporter.getProcessing
       output.addOne(Constants.sinkProcessing -> processingSinks.asJson)
+      val probableSinks = sinkExporter.getProbableSinks
+      output.addOne(Constants.probableSinks -> probableSinks.asJson)
 
       val sinkSubCategories = mutable.HashMap[String, mutable.Set[String]]()
       RuleCache.getRule.sinks.foreach(sinkRule => {
@@ -123,6 +125,10 @@ object JSONExporter {
           case None               => false
         }
       )
+
+      logger.debug("------------ Probable Sink Dependencies ---------------")
+      logger.debug(s"$probableSinks")
+
       ConsoleExporter.exportConsoleSummary(
         dataflowsOutput,
         sources,

--- a/src/main/scala/ai/privado/exporter/SinkExporter.scala
+++ b/src/main/scala/ai/privado/exporter/SinkExporter.scala
@@ -49,10 +49,13 @@ class SinkExporter(cpg: Cpg) {
 
   def getProbableSinks: List[String] = {
     /** Get all the Methods which are tagged as SINKs  */
-    val taggedSinkMethods = cpg.tag.where(_.nameExact(Constants.catLevelOne).valueExact(CatLevelOne.SINKS.name)).call.l.map(i => i.methodFullName.split(":").head)
+    val taggedSinkMethods = cpg.tag.where(_.nameExact(Constants.catLevelOne).valueExact(CatLevelOne.SINKS.name))
+      .call.l
+      .map(i => i.methodFullName.split(":").headOption.getOrElse(""))
+      .distinct
 
     /** Get all the Methods which are external  */
-    val dependenciesTPs = cpg.method.external.l.map(i => i.fullName.split(":").head)
+    val dependenciesTPs = cpg.method.external.l.map(i => i.fullName.split(":").headOption.getOrElse(""))
     /** Actions:
      * by excluding taggedSinkMethods
      * check isPrivacySink
@@ -63,7 +66,13 @@ class SinkExporter(cpg: Cpg) {
       .filter(str => !taggedSinkMethods.contains(str))
       .filter((str) => isPrivacySink(str))
       .filter((str) => !str.endsWith(".println"))
-      .map((str) => str.split("\\.").take(3).mkString("."))
+      .map((str) => {
+        try {
+          str.split("\\.").take(3).mkString(".")
+        } catch {
+          case _: Exception => str
+        }
+      })
       .distinct
 
     filteredTPs

--- a/src/main/scala/ai/privado/exporter/SinkExporter.scala
+++ b/src/main/scala/ai/privado/exporter/SinkExporter.scala
@@ -28,6 +28,7 @@ import ai.privado.entrypoint.ScanProcessor
 import ai.privado.model.exporter.{SinkModel, SinkProcessingModel}
 import ai.privado.model.{CatLevelOne, Constants, DatabaseDetails, InternalTag}
 import ai.privado.semantic.Language.finder
+import ai.privado.utility.Utilities.isPrivacySink
 import io.shiftleft.codepropertygraph.generated.Cpg
 import io.shiftleft.codepropertygraph.generated.nodes.{Call, CfgNode, FieldIdentifier, Identifier, Literal, MethodParameterIn, StoredNode, Tag}
 import io.shiftleft.semanticcpg.language._
@@ -47,57 +48,20 @@ class SinkExporter(cpg: Cpg) {
   }
 
   def getProbableSinks: List[String] = {
-    var blackListedGroupIds: List[String] = List(
-      "<operator>.",
-      "<operators>.",
-      "iterator",
-      "assert",
-      "void.",
-      "java.",
-      "javax.",
-      "ANY.",
-      "android.",
-      "androidx.",
-      "okhttp3.",
-      "io.grpc.",
-      "io.netty.",
-      "org.apache.http.",
-      "org.json",
-      "org.junit.",
-      "org.apache.commons.",
-      "org.apache.tomcat",
-      "org.springframework.",
-      "com.fasterxml.jackson.",
-      "org.apache.hadoop.",
-      "org.apache.giraph.",
-      "org.javatuples.",
-      "org.antlr.",
-      "junit.framework.",
-      "io.reactivex.",
-      "com.bumptech.glide",
-      "com.google.protobuf",
-      "com.google.testing",
-      "com.google.common",
-      "<unresolvedNamespace>."
-    )
     /** Get all the Methods which are tagged as SINKs  */
     val taggedSinkMethods = cpg.tag.where(_.nameExact(Constants.catLevelOne).valueExact(CatLevelOne.SINKS.name)).call.l.map(i => i.methodFullName.split(":").head)
 
     /** Get all the Methods which are external  */
     val dependenciesTPs = cpg.method.external.l.map(i => i.fullName.split(":").head)
-
     /** Actions:
      * by excluding taggedSinkMethods
-     * using blackListedGroupIds
+     * check isPrivacySink
      * transform method FullName close to groupIds
      * remove duplicates
      */
     val filteredTPs = dependenciesTPs
       .filter(str => !taggedSinkMethods.contains(str))
-      .filter((str) => {
-        val res = blackListedGroupIds.filter(blackListGroup => str.startsWith(blackListGroup))
-        (res.length == 0)
-      })
+      .filter((str) => isPrivacySink(str))
       .filter((str) => !str.endsWith(".println"))
       .map((str) => str.split("\\.").take(3).mkString("."))
       .distinct

--- a/src/main/scala/ai/privado/model/Config.scala
+++ b/src/main/scala/ai/privado/model/Config.scala
@@ -52,7 +52,8 @@ case class ConfigAndRules(
   policies: List[PolicyOrThreat],
   threats: List[PolicyOrThreat],
   exclusions: List[RuleInfo],
-  semantics: List[Semantic]
+  semantics: List[Semantic],
+  sinkSkipList: List[RuleInfo]
 )
 
 case class DataFlow(sources: List[String], sinks: List[String])
@@ -136,13 +137,14 @@ object CirceEnDe {
 
   implicit val decodeRules: Decoder[ConfigAndRules] = new Decoder[ConfigAndRules] {
     override def apply(c: HCursor): Result[ConfigAndRules] = {
-      val sources     = c.downField(Constants.sources).as[List[RuleInfo]]
-      val sinks       = c.downField(Constants.sinks).as[List[RuleInfo]]
-      val collections = c.downField(Constants.collections).as[List[RuleInfo]]
-      val policies    = c.downField(Constants.policies).as[List[PolicyOrThreat]]
-      val exclusions  = c.downField(Constants.exclusions).as[List[RuleInfo]]
-      val threats     = c.downField(Constants.threats).as[List[PolicyOrThreat]]
-      val semantics   = c.downField(Constants.semantics).as[List[Semantic]]
+      val sources      = c.downField(Constants.sources).as[List[RuleInfo]]
+      val sinks        = c.downField(Constants.sinks).as[List[RuleInfo]]
+      val collections  = c.downField(Constants.collections).as[List[RuleInfo]]
+      val policies     = c.downField(Constants.policies).as[List[PolicyOrThreat]]
+      val exclusions   = c.downField(Constants.exclusions).as[List[RuleInfo]]
+      val threats      = c.downField(Constants.threats).as[List[PolicyOrThreat]]
+      val semantics    = c.downField(Constants.semantics).as[List[Semantic]]
+      val sinkSkipList = c.downField(Constants.sinkSkipList).as[List[RuleInfo]]
       Right(
         ConfigAndRules(
           sources = sources.getOrElse(List[RuleInfo]()),
@@ -151,7 +153,8 @@ object CirceEnDe {
           policies = policies.getOrElse(List[PolicyOrThreat]()),
           exclusions = exclusions.getOrElse(List[RuleInfo]()),
           threats = threats.getOrElse(List[PolicyOrThreat]()),
-          semantics = semantics.getOrElse(List[Semantic]())
+          semantics = semantics.getOrElse(List[Semantic]()),
+          sinkSkipList = sinkSkipList.getOrElse(List[RuleInfo]())
         )
       )
     }

--- a/src/main/scala/ai/privado/model/Constants.scala
+++ b/src/main/scala/ai/privado/model/Constants.scala
@@ -78,6 +78,7 @@ object Constants {
   val localScanPath       = "localScanPath"
   val processing          = "processing"
   val sinkProcessing      = "sinkProcessing"
+  val probableSinks       = "probableSinks"
   val outputFileName      = "privado.json"
   val outputDirectoryName = ".privado"
 

--- a/src/main/scala/ai/privado/model/Constants.scala
+++ b/src/main/scala/ai/privado/model/Constants.scala
@@ -51,6 +51,7 @@ object Constants {
   val exclusions    = "exclusions"
   val threats       = "threats"
   val semantics     = "semantics"
+  val sinkSkipList  = "sinkSkipList"
 
   val tags               = "tags"
   val description        = "description"

--- a/src/main/scala/ai/privado/model/PrivadoTag.scala
+++ b/src/main/scala/ai/privado/model/PrivadoTag.scala
@@ -141,7 +141,6 @@ object ConfigRuleType extends Enumeration {
   def withNameDefaultHandler(name: String): Value = {
     if (name != null)
       try {
-        println(s"Name is : $name")
         withName(name)
       } catch {
         case _: Throwable => null

--- a/src/main/scala/ai/privado/model/PrivadoTag.scala
+++ b/src/main/scala/ai/privado/model/PrivadoTag.scala
@@ -136,11 +136,13 @@ object ConfigRuleType extends Enumeration {
 
   val EXCLUSIONS = Value("exclusions")
   val SEMANTICS  = Value("semantics")
+  val SINK_SKIP_LIST = Value("sinkSkipList")
 
   def withNameDefaultHandler(name: String): Value = {
     if (name != null)
       try {
-        withName(name.toLowerCase())
+        println(s"Name is : $name")
+        withName(name)
       } catch {
         case _: Throwable => null
       }

--- a/src/main/scala/ai/privado/rulevalidator/YamlFileValidator.scala
+++ b/src/main/scala/ai/privado/rulevalidator/YamlFileValidator.scala
@@ -31,6 +31,8 @@ object YamlFileValidator {
     Source.fromInputStream(getClass.getResourceAsStream(s"${SCHEMA_DIR_PATH}exclusions.json")).mkString
   private val SEMANTICS =
     Source.fromInputStream(getClass.getResourceAsStream(s"${SCHEMA_DIR_PATH}semantics.json")).mkString
+  private val SINK_SKIP_LIST =
+    Source.fromInputStream(getClass.getResourceAsStream(s"${SCHEMA_DIR_PATH}sinkSkipList.json")).mkString
   val mapper = new ObjectMapper(new YAMLFactory())
 
   val factory: JsonSchemaFactory = JsonSchemaFactory
@@ -168,6 +170,7 @@ object YamlFileValidator {
     ConfigRuleType.withNameDefaultHandler(configTypeKey) match {
       case ConfigRuleType.SEMANTICS  => Right(SEMANTICS)
       case ConfigRuleType.EXCLUSIONS => Right(EXCLUSIONS)
+      case ConfigRuleType.SINK_SKIP_LIST => Right(SINK_SKIP_LIST)
       case _ =>
         if (callerCommand == CommandConstants.VALIDATE) println(PRETTY_LINE_SEPARATOR)
         println(f"File : ${ruleFile.pathAsString}: Config Invalid. Correct the rules and try again.")

--- a/src/main/scala/ai/privado/utility/Utilities.scala
+++ b/src/main/scala/ai/privado/utility/Utilities.scala
@@ -232,6 +232,28 @@ object Utilities {
       .foldLeft(true)((a, b) => a && b)
   }
 
+  /** Checks if given sinkName doesn't belong to the sink skip rule file regex
+   *
+   * @param sinkName
+   * @return
+   */
+  def isPrivacySink(sinkName: String): Boolean = {
+    RuleCache.getRule.sinkSkipList
+      .flatMap(sinkSkipRule => {
+        sinkSkipRule.patterns.headOption match {
+          case Some(pattern) =>
+            Try(!sinkName.matches(pattern)) match {
+              case Success(result) => Some(result)
+              case Failure(_) => None
+            }
+          case None => None
+        }
+      })
+      .foldLeft(true)((a, b) => a && b)
+  }
+
+
+
   /** Returns all files matching the given extensions
     * @param folderPath
     * @param extension
@@ -297,13 +319,14 @@ object Utilities {
     def getSemanticRuleByLang(rule: Semantic) =
       rule.language == lang || rule.language == Language.DEFAULT || rule.language == Language.UNKNOWN
 
-    val sources     = rules.sources.filter(getRuleByLang)
-    val sinks       = rules.sinks.filter(getRuleByLang)
-    val collections = rules.collections.filter(getRuleByLang)
-    val exclusions  = rules.exclusions.filter(getRuleByLang)
-    val semantics   = rules.semantics.filter(getSemanticRuleByLang)
+    val sources         = rules.sources.filter(getRuleByLang)
+    val sinks           = rules.sinks.filter(getRuleByLang)
+    val collections     = rules.collections.filter(getRuleByLang)
+    val exclusions      = rules.exclusions.filter(getRuleByLang)
+    val semantics       = rules.semantics.filter(getSemanticRuleByLang)
+    val sinkSkipList    =  rules.sinkSkipList.filter(getRuleByLang)
 
-    ConfigAndRules(sources, sinks, collections, rules.policies, rules.threats, exclusions, semantics)
+    ConfigAndRules(sources, sinks, collections, rules.policies, rules.threats, exclusions, semantics, sinkSkipList)
   }
 
   /** Returns file name for a node


### PR DESCRIPTION
- Currently we have limited set of rules written for Third Parties & Databases.
- So, after scanning it may be case that some Third Party is present but not detected via tool as rule missing.
- We will be exporting all the external packages in **probableSinks** key in privado.json