### PR TITLE
Add sample types in snippet highlighted line

### DIFF
--- a/src/main/scala/ai/privado/exporter/ExporterUtility.scala
+++ b/src/main/scala/ai/privado/exporter/ExporterUtility.scala
@@ -78,7 +78,8 @@ object ExporterUtility {
     if (fileName == "<empty>" || sample == "<empty>")
       None
     else {
-      val excerpt = dump(absoluteFileName, node.lineNumber)
+      val methodFullName = Traversal(node).isCall.methodFullName.headOption.getOrElse("")
+      val excerpt        = dump(absoluteFileName, node.lineNumber, methodFullName)
       Some(DataFlowSubCategoryPathExcerptModel(sample, lineNumber, columnNumber, fileName, excerpt))
     }
   }

--- a/src/main/scala/ai/privado/languageEngine/java/threatEngine/ThreatUtility.scala
+++ b/src/main/scala/ai/privado/languageEngine/java/threatEngine/ThreatUtility.scala
@@ -102,7 +102,7 @@ object ThreatUtility {
   ): DataFlowSubCategoryPathExcerptModel = {
 
     val lineNumber = getLineNumberOfMatchingEditText(filename, matchingTextForLine)
-    val excerpt    = Utilities.dump(filename, Some(lineNumber)) + "\n" + excerptPostfix + "\n"
+    val excerpt    = Utilities.dump(filename, Some(lineNumber), "") + "\n" + excerptPostfix + "\n"
     DataFlowSubCategoryPathExcerptModel(sample, lineNumber, -1, filename, excerpt)
   }
 

--- a/src/main/scala/ai/privado/utility/Utilities.scala
+++ b/src/main/scala/ai/privado/utility/Utilities.scala
@@ -209,8 +209,9 @@ object Utilities {
     * `lineToHighlight` is defined, then a line containing an arrow (as a source code comment) is included right before
     * that line.
     */
-  def dump(filename: String, lineToHighlight: Option[Integer]): String = {
-    val arrow: CharSequence = "/* <=== */ "
+  def dump(filename: String, lineToHighlight: Option[Integer], methodFullName: String = ""): String = {
+    val methodType          = methodFullName.split(":").headOption.getOrElse("")
+    val arrow: CharSequence = "/* <=== " + methodType + " */ "
     try {
       if (!filename.equals("<empty>")) {
         val lines = IOUtils.readLinesInFile(Paths.get(filename))


### PR DESCRIPTION
We added functionality to show the type of the sample which getting highlighted in the code snippet.

![image](https://user-images.githubusercontent.com/5364736/209063131-57650051-a595-498f-bdc9-f1a93fb77bfa.png)
