### PR TITLE
fix - dedup on api flows

### DIFF
--- a/src/main/scala/ai/privado/dataflow/DuplicateFlowProcessor.scala
+++ b/src/main/scala/ai/privado/dataflow/DuplicateFlowProcessor.scala
@@ -118,18 +118,20 @@ object DuplicateFlowProcessor {
     pathIds.diff(visitedFlows) // This will give us all the Path ids which are super set of overlapping paths
   }
 
-
   /** For a given list of paths discards the sub-flow by using the dedup algorithm, returning unique flows
     *
-    * @param dataflowPaths - list of path
+    * @param dataflowPaths
+    *   \- list of path
     * @return
     */
   def getUniquePathsAfterDedup(dataflowPaths: List[Path]): List[Path] = {
-      val flows = dataflowPaths.map(path => {
+    val flows = dataflowPaths
+      .map(path => {
         (DuplicateFlowProcessor.calculatePathId(path).getOrElse(""), path)
-      }).toMap
-      val uniquePathIds = DuplicateFlowProcessor.pathIdsPerSourceIdAfterDedup(flows.keySet)
-      uniquePathIds.map(pathId => flows(pathId)).toList
+      })
+      .toMap
+    val uniquePathIds = DuplicateFlowProcessor.pathIdsPerSourceIdAfterDedup(flows.keySet)
+    uniquePathIds.map(pathId => flows(pathId)).toList
   }
 
   /** Generates a pathId for a given path, based on node Id

--- a/src/main/scala/ai/privado/dataflow/DuplicateFlowProcessor.scala
+++ b/src/main/scala/ai/privado/dataflow/DuplicateFlowProcessor.scala
@@ -118,6 +118,20 @@ object DuplicateFlowProcessor {
     pathIds.diff(visitedFlows) // This will give us all the Path ids which are super set of overlapping paths
   }
 
+
+  /** For a given list of paths discards the sub-flow by using the dedup algorithm, returning unique flows
+    *
+    * @param dataflowPaths - list of path
+    * @return
+    */
+  def getUniquePathsAfterDedup(dataflowPaths: List[Path]): List[Path] = {
+      val flows = dataflowPaths.map(path => {
+        (DuplicateFlowProcessor.calculatePathId(path).getOrElse(""), path)
+      }).toMap
+      val uniquePathIds = DuplicateFlowProcessor.pathIdsPerSourceIdAfterDedup(flows.keySet)
+      uniquePathIds.map(pathId => flows(pathId)).toList
+  }
+
   /** Generates a pathId for a given path, based on node Id
     * @param flow
     * @return

--- a/src/main/scala/ai/privado/tagger/utility/APITaggerUtility.scala
+++ b/src/main/scala/ai/privado/tagger/utility/APITaggerUtility.scala
@@ -28,7 +28,14 @@ import ai.privado.dataflow.DuplicateFlowProcessor
 import ai.privado.entrypoint.ScanProcessor
 import ai.privado.languageEngine.java.language.NodeToProperty
 import ai.privado.model.{Constants, RuleInfo}
-import ai.privado.utility.Utilities.{addRuleTags, getDefaultSemantics, getDomainFromString, getFileNameForNode, isFileProcessable, storeForTag}
+import ai.privado.utility.Utilities.{
+  addRuleTags,
+  getDefaultSemantics,
+  getDomainFromString,
+  getFileNameForNode,
+  isFileProcessable,
+  storeForTag
+}
 import io.shiftleft.codepropertygraph.generated.nodes.{AstNode, CfgNode}
 import overflowdb.BatchedUpdate
 import io.joern.dataflowengineoss.language._
@@ -48,7 +55,7 @@ object APITaggerUtility {
     if (apis.nonEmpty && filteredSourceNode.nonEmpty) {
       val apiFlows = {
         val flows = apis.reachableByFlows(filteredSourceNode).l
-        if(ScanProcessor.config.disableDeDuplication)
+        if (ScanProcessor.config.disableDeDuplication)
           flows
         else
           DuplicateFlowProcessor.getUniquePathsAfterDedup(flows)


### PR DESCRIPTION
Solving the problem were `slackWebHookUrl` point to the URL `hooks.slack.com` and we show 2 API's

The flow of slackWebHookUrl is a sub-flow of the flow starting from hooks.slack.com and hence will be discarded by deduplication logic