### PR TITLE
LE-242: Used null when the list is blank and associated null check

### DIFF
--- a/src/main/scala/ai/privado/languageEngine/java/passes/config/PropertiesFilePass.scala
+++ b/src/main/scala/ai/privado/languageEngine/java/passes/config/PropertiesFilePass.scala
@@ -93,6 +93,7 @@ class PropertiesFilePass(cpg: Cpg, projectRoot: String) extends ForkJoinParallel
     val membersAndValues = annotatedMembers()
 
     membersAndValues
+      .filter(_._1 != null)
       .filter { case (key, _) => propertyNode.name == key.code.slice(3, key.code.length - 2) }
       .foreach { case (_, value) =>
         builder.addEdge(propertyNode, value, EdgeTypes.IS_USED_AT)
@@ -118,7 +119,13 @@ class PropertiesFilePass(cpg: Cpg, projectRoot: String) extends ForkJoinParallel
   private def annotatedMembers() = cpg.annotation
     .fullName(".*Value.*")
     .where(_.member)
-    .map { x => (x.parameterAssign.head, x.member.head) }
+    .map { x =>
+      {
+        val param = if (x.parameterAssign.l.length > 0) { x.parameterAssign.head }
+        else { null }
+        (param, x.member.head)
+      }
+    }
     .l
   private def getMember(member: String, className: String) =
     cpg.member.where(_.typeDecl.fullName(className)).where(_.name(member)).toList


### PR DESCRIPTION
### Description

The exception is due to dereferencing the first element of a blank list. Example of code that causes this is [here](https://github.com/hiteshbedre/Finance-System/blob/4c855dd13b820f49d151ac77b99851a9d421c33f/accounts/src/main/java/com/bhanuchaddha/bank/accounts/Account.java#L21).

### Fix
Put a safety null check

### Testing done
Tested on the repo mentioned in the ticket. Also tested on `privado-accounts-api`