### PR TITLE
Patch inherit semantic

### DIFF
--- a/src/main/scala/ai/privado/utility/Utilities.scala
+++ b/src/main/scala/ai/privado/utility/Utilities.scala
@@ -417,8 +417,13 @@ object Utilities {
     val semanticList = ListBuffer[String]()
 
     TaggerCache.typeDeclMemberCache.keys.foreach(typeDeclValue => {
-      val typeDeclNode       = cpg.typeDecl.where(_.fullName(typeDeclValue)).l
-      val allMembers         = typeDeclNode.member.name.toSet
+      val typeDeclNode = cpg.typeDecl.where(_.fullName(typeDeclValue)).l
+      // Need to considers members of classes which inherits via extends/implements, as hence are also a member
+      val inheritedMembers =
+        typeDeclNode.inheritsFromTypeFullName
+          .flatMap(inheritFullName => cpg.typeDecl.fullName(inheritFullName).member.name.toSet)
+          .toSet
+      val allMembers         = typeDeclNode.member.name.toSet ++ inheritedMembers
       val personalMembers    = TaggerCache.typeDeclMemberCache(typeDeclValue).values.name.toSet
       val nonPersonalMembers = allMembers.diff(personalMembers)
 


### PR DESCRIPTION
```
@Getter
class Abstract BaseClass {
private String id;
private String firstName;
}

@Getter
class Payment {
private String paymentMethod;
}


log.info(payment.getId());
```
 

Payment class here has only 1 member which is `paymentMethod` but `id` is not a member of `Payment` class, but it happens to extend `BaseClass` which has a member `id` and the function `getId` is now exposed to `Payment` as it has inherited `BaseClass`. So we were not able to generate a semantic for this case as `id` was not a member of Payment.