### PR TITLE
segregation of FP flag between language

### DIFF
--- a/src/main/scala/ai/privado/cache/AppCache.scala
+++ b/src/main/scala/ai/privado/cache/AppCache.scala
@@ -21,6 +21,8 @@
  */
 
 package ai.privado.cache
+import ai.privado.model.Language
+import ai.privado.model.Language.Language
 import ai.privado.utility.Utilities._
 
 import scala.collection.mutable
@@ -32,6 +34,7 @@ object AppCache {
   var localScanPath: String       = ""
   var scanPath: String            = ""
   var repoName: String            = ""
+  var repoLanguage: Language      = Language.UNKNOWN
   var isLombokPresent             = false
   var privadoVersionMain: String  = ""
   var fpByOverlappingDE           = 0

--- a/src/main/scala/ai/privado/dataflow/Dataflow.scala
+++ b/src/main/scala/ai/privado/dataflow/Dataflow.scala
@@ -27,7 +27,7 @@ import ai.privado.cache.{AppCache, DataFlowCache}
 import ai.privado.entrypoint.{PrivadoInput, ScanProcessor, TimeMetric}
 import ai.privado.exporter.ExporterUtility
 import ai.privado.languageEngine.java.semantic.SemanticGenerator
-import ai.privado.model.{CatLevelOne, Constants}
+import ai.privado.model.{CatLevelOne, Constants, Language}
 import io.joern.dataflowengineoss.language._
 import io.joern.dataflowengineoss.queryengine.{EngineConfig, EngineContext}
 import io.shiftleft.codepropertygraph.generated.Cpg
@@ -105,7 +105,7 @@ class Dataflow(cpg: Cpg) {
       println(s"${Calendar.getInstance().getTime} - --Filtering flows 1 invoked...")
       AppCache.totalFlowFromReachableBy = dataflowPathsUnfiltered.size
       val dataflowPaths = {
-        if (ScanProcessor.config.disableThisFiltering)
+        if (ScanProcessor.config.disableThisFiltering || AppCache.repoLanguage != Language.JAVA)
           dataflowPathsUnfiltered
         else
           dataflowPathsUnfiltered

--- a/src/main/scala/ai/privado/dataflow/DuplicateFlowProcessor.scala
+++ b/src/main/scala/ai/privado/dataflow/DuplicateFlowProcessor.scala
@@ -25,7 +25,7 @@ package ai.privado.dataflow
 import ai.privado.cache.{AppCache, DataFlowCache, RuleCache}
 import ai.privado.entrypoint.ScanProcessor
 import ai.privado.metric.MetricHandler
-import ai.privado.model.{CatLevelOne, Constants, DataFlowPathModel, NodeType}
+import ai.privado.model.{CatLevelOne, Constants, DataFlowPathModel, Language, NodeType}
 import io.joern.dataflowengineoss.language.Path
 import io.shiftleft.codepropertygraph.generated.Operators
 import io.shiftleft.codepropertygraph.generated.nodes.{AstNode, CfgNode, Expression, Identifier}
@@ -329,7 +329,7 @@ object DuplicateFlowProcessor {
             )
         }
         sinkCatLevelTwoCustomTag.value.foreach(sinkId => {
-          if (ScanProcessor.config.disableFlowSeparationByDataElement)
+          if (ScanProcessor.config.disableFlowSeparationByDataElement || AppCache.repoLanguage != Language.JAVA)
             DataFlowCache.setDataflow(
               DataFlowPathModel(pathSourceId, sinkId, dataflowSinkType, dataflowNodeType, sinkPathId)
             )


### PR DESCRIPTION
- Caching the language the repo contains, so that we can use the cache latter
- Adding a condition, so that the FP flags `disable-this-filtering` and `disable-segregation-by-dataelement` is only done for JAVA language, and it doesn't filter out flows in other Languages