### PR TITLE
LE-260: Javascript methodFullName hack

### DIFF
--- a/src/main/scala/ai/privado/languageEngine/javascript/passes/methodfullname/MethodFullNameForEmptyNodes.scala
+++ b/src/main/scala/ai/privado/languageEngine/javascript/passes/methodfullname/MethodFullNameForEmptyNodes.scala
@@ -31,10 +31,10 @@ import io.shiftleft.semanticcpg.language._
 
 class MethodFullNameForEmptyNodes(cpg: Cpg) extends ForkJoinParallelCpgPass[Call](cpg) {
   override def generateParts(): Array[Call] = {
-    cpg.call.methodFullName("").toArray
+    cpg.call.methodFullName("").toArray ++ cpg.call.methodFullName("<unknownFullName>").toArray
   }
 
   override def runOnPart(builder: DiffGraphBuilder, callNode: Call): Unit = {
-    builder.setNodeProperty(callNode, PropertyNames.MethodFullName, callNode.name)
+    builder.setNodeProperty(callNode, PropertyNames.MethodFullName, callNode.methodFullName + callNode.name)
   }
 }

--- a/src/main/scala/ai/privado/languageEngine/javascript/passes/methodfullname/MethodFullNameForEmptyNodes.scala
+++ b/src/main/scala/ai/privado/languageEngine/javascript/passes/methodfullname/MethodFullNameForEmptyNodes.scala
@@ -35,6 +35,11 @@ class MethodFullNameForEmptyNodes(cpg: Cpg) extends ForkJoinParallelCpgPass[Call
   }
 
   override def runOnPart(builder: DiffGraphBuilder, callNode: Call): Unit = {
+    val prefix = if (callNode.methodFullName == "") {
+      ""
+    } else {
+      "<unknownFullName>."
+    }
     builder.setNodeProperty(callNode, PropertyNames.MethodFullName, callNode.methodFullName + callNode.name)
   }
 }

--- a/src/main/scala/ai/privado/languageEngine/javascript/passes/methodfullname/MethodFullNameForEmptyNodes.scala
+++ b/src/main/scala/ai/privado/languageEngine/javascript/passes/methodfullname/MethodFullNameForEmptyNodes.scala
@@ -40,6 +40,6 @@ class MethodFullNameForEmptyNodes(cpg: Cpg) extends ForkJoinParallelCpgPass[Call
     } else {
       "<unknownFullName>."
     }
-    builder.setNodeProperty(callNode, PropertyNames.MethodFullName, callNode.methodFullName + callNode.name)
+    builder.setNodeProperty(callNode, PropertyNames.MethodFullName, prefix + callNode.name)
   }
 }


### PR DESCRIPTION
### Description
Method full have resolution for JS is 65-70% through Joern. Passes have been out in `privado-core `to add more resolution. 

For nodes with methodFullName being `<unknownFullName>`, no method fullname gets generated/substituted causing regex for sink to not match. This results in sinks not being identified.

This change converts `<unknownFullName>` to `<unknownFullName>.functionName()` to allow regex matching on `functionName`