### PR TITLE
Second Level derivation Implementation for Python

### DIFF
--- a/src/main/scala/ai/privado/languageEngine/python/processor/PythonProcessor.scala
+++ b/src/main/scala/ai/privado/languageEngine/python/processor/PythonProcessor.scala
@@ -1,6 +1,6 @@
 package ai.privado.languageEngine.python.processor
 
-import ai.privado.cache.{AppCache, DataFlowCache}
+import ai.privado.cache.{AppCache, DataFlowCache, TaggerCache}
 import ai.privado.entrypoint.{ScanProcessor, TimeMetric}
 import ai.privado.exporter.JSONExporter
 import ai.privado.languageEngine.python.semantic.Language._
@@ -33,8 +33,8 @@ import io.joern.javasrc2cpg.Config
 import java.util.Calendar
 import scala.jdk.CollectionConverters.CollectionHasAsScala
 import scala.util.{Failure, Success, Try}
-
 import ai.privado.languageEngine.python.passes.config.PythonPropertyFilePass
+
 import java.nio.file.{Files, Paths}
 
 object PythonProcessor {
@@ -81,7 +81,8 @@ object PythonProcessor {
 
           // Run tagger
           println(s"${Calendar.getInstance().getTime} - Tagging source code with rules...")
-          cpg.runTagger(processedRules)
+          val taggerCache = new TaggerCache
+          cpg.runTagger(processedRules, taggerCache)
           println(
             s"${TimeMetric.getNewTime()} - Tagging source code is done in \t\t\t- ${TimeMetric.setNewTimeToLastAndGetTimeDiff()}"
           )
@@ -110,7 +111,7 @@ object PythonProcessor {
                 Right(())
             }
           }
-          JSONExporter.fileExport(cpg, outputFileName, sourceRepoLocation, dataflowMap) match {
+          JSONExporter.fileExport(cpg, outputFileName, sourceRepoLocation, dataflowMap, taggerCache) match {
             case Left(err) =>
               MetricHandler.otherErrorsOrWarnings.addOne(err)
               Left(err)

--- a/src/main/scala/ai/privado/languageEngine/python/tagger/PrivadoTagger.scala
+++ b/src/main/scala/ai/privado/languageEngine/python/tagger/PrivadoTagger.scala
@@ -1,6 +1,6 @@
 package ai.privado.languageEngine.python.tagger
 
-import ai.privado.cache.{DatabaseDetailsCache, RuleCache}
+import ai.privado.cache.{DatabaseDetailsCache, RuleCache, TaggerCache}
 import ai.privado.entrypoint.TimeMetric
 import ai.privado.languageEngine.java.tagger.sink.CustomInheritTagger
 import ai.privado.languageEngine.python.tagger.sink.PythonAPITagger
@@ -21,7 +21,7 @@ import java.util.Calendar
 class PrivadoTagger(cpg: Cpg) extends PrivadoBaseTagger {
   private val logger = LoggerFactory.getLogger(this.getClass)
 
-  override def runTagger(rules: ConfigAndRules): Traversal[Tag] = {
+  override def runTagger(rules: ConfigAndRules, taggerCache: TaggerCache): Traversal[Tag] = {
 
     logger.info("Starting tagging")
 
@@ -31,7 +31,7 @@ class PrivadoTagger(cpg: Cpg) extends PrivadoBaseTagger {
       s"${TimeMetric.getNewTime()} - --LiteralTagger is done in \t\t\t- ${TimeMetric.setNewTimeToStageLastAndGetTimeDiff()}"
     )
     println(s"${Calendar.getInstance().getTime} - --IdentifierTagger invoked...")
-    new IdentifierTagger(cpg).createAndApply()
+    new IdentifierTagger(cpg, taggerCache).createAndApply()
     println(
       s"${TimeMetric.getNewTime()} - --IdentifierTagger is done in \t\t\t- ${TimeMetric.setNewTimeToStageLastAndGetTimeDiff()}"
     )

--- a/src/main/scala/ai/privado/languageEngine/python/tagger/source/IdentifierTagger.scala
+++ b/src/main/scala/ai/privado/languageEngine/python/tagger/source/IdentifierTagger.scala
@@ -95,7 +95,7 @@ class IdentifierTagger(cpg: Cpg, taggerCache: TaggerCache) extends ForkJoinParal
       .distinctBy(_._1.fullName)
       .foreach(typeDeclValEntry => {
         typeDeclValEntry._2.foreach(typeDeclMember => {
-          val typeDeclVal = typeDeclValEntry._1.fullName.stripSuffix("<meta>")
+          val typeDeclVal = typeDeclValEntry._1.fullName.stripSuffix("<meta>").replaceAll(":<module>.", ":<module>.*")
 
           // updating cache
           taggerCache.addItemToTypeDeclMemberCache(typeDeclVal, ruleInfo.id, typeDeclMember)
@@ -104,7 +104,7 @@ class IdentifierTagger(cpg: Cpg, taggerCache: TaggerCache) extends ForkJoinParal
           // Note: Partially Matching the typeFullName with typeDecl fullName
           // typeFullName: /models.py:<module>.Profile.Profile<body>
           // typeDeclVal: models.py:<module>.Profile
-          val impactedObjects = cpg.identifier.where(_.typeFullName("\\/" + typeDeclVal + ".*"))
+          val impactedObjects = cpg.identifier.where(_.typeFullName(".*" + typeDeclVal + ".*"))
           impactedObjects
             .whereNot(_.code("this|self|cls"))
             .foreach(impactedObject => {


### PR DESCRIPTION
**Second Level derivation Implementation for Python**

- Tag identifier of all the typeDeclaration who have a PII as member
- Filter out **__iter__** and **__next__** calls from source tagging.
- Add isImport filter on astSiblings of Identifier to remove below **cookies** like identifiers
`from http import cookies`