### PR TITLE
ead patch

### DIFF
--- a/src/main/scala/ai/privado/languageEngine/java/tagger/sink/JavaAPITagger.scala
+++ b/src/main/scala/ai/privado/languageEngine/java/tagger/sink/JavaAPITagger.scala
@@ -132,12 +132,17 @@ class JavaAPITagger(cpg: Cpg) extends ForkJoinParallelCpgPass[RuleInfo](cpg) {
         println(s"${Calendar.getInstance().getTime} - --API TAGGER V1 invoked...")
         sinkTagger(
           apiInternalSources ++ propertySources ++ identifierSource,
-          apis ++ grpcSinks,
+          apis,
           builder,
           ruleInfo,
           ScanProcessor.config.enableAPIDisplay
         )
-        sinkTagger(apiInternalSources ++ propertySources ++ identifierSource, feignAPISinks, builder, ruleInfo)
+        sinkTagger(
+          apiInternalSources ++ propertySources ++ identifierSource,
+          feignAPISinks ++ grpcSinks,
+          builder,
+          ruleInfo
+        )
       case APITaggerVersionJava.V2Tagger =>
         logger.debug("Using Enhanced API tagger to find API sinks")
         println(s"${Calendar.getInstance().getTime} - --API TAGGER V2 invoked...")


### PR DESCRIPTION
Patching API sink call tagging in V1 so that `-ead` flag does not have to be used for gRPC sinks