### PR TITLE
Update/free grpc sinks

### DIFF
--- a/src/main/scala/ai/privado/languageEngine/java/tagger/Utility/GRPCTaggerUtility.scala
+++ b/src/main/scala/ai/privado/languageEngine/java/tagger/Utility/GRPCTaggerUtility.scala
@@ -42,7 +42,7 @@ object GRPCTaggerUtility {
       val sinks = cpg
         .call(endpoint.name)
         .whereNot(
-          _.astParent.isCall
+          _.repeat(_.astParent.isCall)(_.emit)
             .name(onNext)
             .filter(_.argument.size == 1)
             .where(_.argument.typ.fullName(StreamObserverPattern))
@@ -83,7 +83,7 @@ object GRPCTaggerUtility {
         .where(_.argument.isCall.typeFullName(stubPattern))
         .whereNot(_.name(filterNotPattern))
         .whereNot(
-          _.astParent.isCall
+          _.repeat(_.astParent.isCall)(_.emit)
             .name(onNext)
             .filter(_.argument.size == 1)
             .where(_.argument.typ.fullName(StreamObserverPattern))

--- a/src/main/scala/ai/privado/languageEngine/java/tagger/Utility/GRPCTaggerUtility.scala
+++ b/src/main/scala/ai/privado/languageEngine/java/tagger/Utility/GRPCTaggerUtility.scala
@@ -82,6 +82,12 @@ object GRPCTaggerUtility {
         .filter(_.argument.size == 2)
         .where(_.argument.isCall.typeFullName(stubPattern))
         .whereNot(_.name(filterNotPattern))
+        .whereNot(
+          _.astParent.isCall
+            .name(onNext)
+            .filter(_.argument.size == 1)
+            .where(_.argument.typ.fullName(StreamObserverPattern))
+        )
         .l
     grpcSinkCalls = grpcSinkCalls ++ independentSinkCalls
 

--- a/src/main/scala/ai/privado/languageEngine/java/tagger/Utility/GRPCTaggerUtility.scala
+++ b/src/main/scala/ai/privado/languageEngine/java/tagger/Utility/GRPCTaggerUtility.scala
@@ -44,7 +44,6 @@ object GRPCTaggerUtility {
         .whereNot(
           _.repeat(_.astParent.isCall)(_.emit)
             .name(onNext)
-            .filter(_.argument.size == 1)
             .where(_.argument.typ.fullName(StreamObserverPattern))
         )
         .l
@@ -85,7 +84,6 @@ object GRPCTaggerUtility {
         .whereNot(
           _.repeat(_.astParent.isCall)(_.emit)
             .name(onNext)
-            .filter(_.argument.size == 1)
             .where(_.argument.typ.fullName(StreamObserverPattern))
         )
         .l


### PR DESCRIPTION

**Features**
- Add Independent tagging of grpc sink calls that does **not** rely on collection tagging
- Imrove `onNext` function detection to fix FPs in gRPC sink call detection

- Tested on `grpc-sample` repo so far
- This implementation is not perfect, may lead to some false negatives
- More intensive testing is required to qualify sink calls better

Testing repo links:
- https://github.com/anjeyy/grpc-sample