### PR TITLE
Export run time semantics to a file

### DIFF
--- a/src/main/scala/ai/privado/cache/AuditCache.scala
+++ b/src/main/scala/ai/privado/cache/AuditCache.scala
@@ -54,10 +54,15 @@ object AuditCache {
 
   def getPathFromId(pathId: String): Path = dataflowMapByPathId(pathId)
 
-  def addIntoBeforeSemantics(cpg: Cpg, privadoScanConfig: PrivadoInput, ruleCache: RuleCache): Unit = {
+  def addIntoBeforeSemantics(
+    cpg: Cpg,
+    privadoScanConfig: PrivadoInput,
+    ruleCache: RuleCache,
+    repoPath: String
+  ): Unit = {
     val newPrivadoScanConfig = PrivadoInput(disableRunTimeSemantics = true)
     val engineContext: EngineContext = EngineContext(
-      semantics = JavaSemanticGenerator.getSemantics(cpg, newPrivadoScanConfig, ruleCache),
+      semantics = JavaSemanticGenerator.getSemantics(cpg, newPrivadoScanConfig, ruleCache, repoPath),
       config = EngineConfig(4)
     )
     val sources = Dataflow.getSources(cpg)

--- a/src/main/scala/ai/privado/dataflow/Dataflow.scala
+++ b/src/main/scala/ai/privado/dataflow/Dataflow.scala
@@ -53,15 +53,15 @@ class Dataflow(cpg: Cpg) {
     * @return
     *   \- Map of PathId -> Path corresponding to source to sink path
     */
-  def dataflow(privadoScanConfig: PrivadoInput, ruleCache: RuleCache): Map[String, Path] = {
+  def dataflow(privadoScanConfig: PrivadoInput, ruleCache: RuleCache, repoPath: String): Map[String, Path] = {
 
     if (privadoScanConfig.generateAuditReport && privadoScanConfig.enableAuditSemanticsFilter) {
-      AuditCache.addIntoBeforeSemantics(cpg, privadoScanConfig, ruleCache)
+      AuditCache.addIntoBeforeSemantics(cpg, privadoScanConfig, ruleCache, repoPath)
     }
 
     logger.info("Generating dataflow")
     implicit val engineContext: EngineContext =
-      EngineContext(semantics = getSemantics(cpg, privadoScanConfig, ruleCache), config = EngineConfig(4))
+      EngineContext(semantics = getSemantics(cpg, privadoScanConfig, ruleCache, repoPath), config = EngineConfig(4))
     val sources = Dataflow.getSources(cpg)
     val sinks   = Dataflow.getSinks(cpg)
 
@@ -186,10 +186,10 @@ class Dataflow(cpg: Cpg) {
       .toMap
   }
 
-  def getSemantics(cpg: Cpg, privadoScanConfig: PrivadoInput, ruleCache: RuleCache): Semantics = {
+  def getSemantics(cpg: Cpg, privadoScanConfig: PrivadoInput, ruleCache: RuleCache, repoPath: String): Semantics = {
     val lang = AppCache.repoLanguage
     lang match {
-      case Language.JAVA   => JavaSemanticGenerator.getSemantics(cpg, privadoScanConfig, ruleCache)
+      case Language.JAVA   => JavaSemanticGenerator.getSemantics(cpg, privadoScanConfig, ruleCache, repoPath)
       case Language.PYTHON => PythonSemanticGenerator.getSemantics(cpg, ruleCache)
       case _               => JavaSemanticGenerator.getDefaultSemantics
     }

--- a/src/main/scala/ai/privado/dataflow/Dataflow.scala
+++ b/src/main/scala/ai/privado/dataflow/Dataflow.scala
@@ -190,7 +190,7 @@ class Dataflow(cpg: Cpg) {
     val lang = AppCache.repoLanguage
     lang match {
       case Language.JAVA   => JavaSemanticGenerator.getSemantics(cpg, privadoScanConfig, ruleCache, repoPath)
-      case Language.PYTHON => PythonSemanticGenerator.getSemantics(cpg, ruleCache)
+      case Language.PYTHON => PythonSemanticGenerator.getSemantics(cpg, ruleCache, repoPath)
       case _               => JavaSemanticGenerator.getDefaultSemantics
     }
   }

--- a/src/main/scala/ai/privado/languageEngine/java/processor/JavaProcessor.scala
+++ b/src/main/scala/ai/privado/languageEngine/java/processor/JavaProcessor.scala
@@ -109,7 +109,7 @@ object JavaProcessor {
             s"${TimeMetric.getNewTime()} - Tagging source code is done in \t\t\t- ${TimeMetric.setNewTimeToLastAndGetTimeDiff()}"
           )
           println(s"${Calendar.getInstance().getTime} - Finding source to sink flow of data...")
-          val dataflowMap = cpg.dataflow(ScanProcessor.config, ruleCache)
+          val dataflowMap = cpg.dataflow(ScanProcessor.config, ruleCache, sourceRepoLocation)
           println(s"${TimeMetric.getNewTime()} - Finding source to sink flow is done in \t\t- ${TimeMetric
               .setNewTimeToLastAndGetTimeDiff()} - Processed final flows - ${DataFlowCache.finalDataflow.size}")
           println(

--- a/src/main/scala/ai/privado/languageEngine/java/semantic/JavaSemanticGenerator.scala
+++ b/src/main/scala/ai/privado/languageEngine/java/semantic/JavaSemanticGenerator.scala
@@ -94,9 +94,6 @@ object JavaSemanticGenerator extends SemanticGenerator {
     customSinkSemantics.foreach(logger.debug)
     logger.debug("\nCustom semanticFromConfig semantics")
     semanticFromConfig.foreach(logger.debug)
-
-    val list =
-      customNonTaintDefaultSemantics ++ specialNonTaintDefaultSemantics ++ customStringSemantics ++ customNonPersonalMemberSemantics ++ customSinkSemantics ++ semanticFromConfig
     semanticExporter(
       repoPath,
       headers = List(
@@ -116,6 +113,8 @@ object JavaSemanticGenerator extends SemanticGenerator {
         semanticFromConfig
       )
     )
+    val list =
+      customNonTaintDefaultSemantics ++ specialNonTaintDefaultSemantics ++ customStringSemantics ++ customNonPersonalMemberSemantics ++ customSinkSemantics ++ semanticFromConfig
 
     val parsed         = new Parser().parse(list.mkString("\n"))
     val finalSemantics = JavaSemanticGenerator.getDefaultSemantics.elements ++ parsed

--- a/src/main/scala/ai/privado/languageEngine/javascript/processor/JavascriptProcessor.scala
+++ b/src/main/scala/ai/privado/languageEngine/javascript/processor/JavascriptProcessor.scala
@@ -81,7 +81,7 @@ object JavascriptProcessor {
         val taggerCache = new TaggerCache
         cpg.runTagger(ruleCache, taggerCache)
         println(s"${Calendar.getInstance().getTime} - Finding source to sink flow of data...")
-        val dataflowMap = cpg.dataflow(ScanProcessor.config, ruleCache)
+        val dataflowMap = cpg.dataflow(ScanProcessor.config, ruleCache, sourceRepoLocation)
         println(s"\n${TimeMetric.getNewTime()} - Finding source to sink flow is done in \t\t- ${TimeMetric
             .setNewTimeToLastAndGetTimeDiff()} - Processed final flows - ${DataFlowCache.finalDataflow.size}")
         println(s"\n${TimeMetric.getNewTime()} - Code scanning is done in \t\t\t- ${TimeMetric.getTheTotalTime()}\n")

--- a/src/main/scala/ai/privado/languageEngine/python/processor/PythonProcessor.scala
+++ b/src/main/scala/ai/privado/languageEngine/python/processor/PythonProcessor.scala
@@ -113,7 +113,7 @@ object PythonProcessor {
           )
 
           println(s"${Calendar.getInstance().getTime} - Finding source to sink flow of data...")
-          val dataflowMap = cpg.dataflow(ScanProcessor.config, ruleCache)
+          val dataflowMap = cpg.dataflow(ScanProcessor.config, ruleCache, sourceRepoLocation)
           println(s"\n${TimeMetric.getNewTime()} - Finding source to sink flow is done in \t\t- ${TimeMetric
               .setNewTimeToLastAndGetTimeDiff()} - Processed final flows - ${DataFlowCache.finalDataflow.size}")
           println(s"\n${TimeMetric.getNewTime()} - Code scanning is done in \t\t\t- ${TimeMetric.getTheTotalTime()}\n")

--- a/src/main/scala/ai/privado/languageEngine/python/semantic/PythonSemanticGenerator.scala
+++ b/src/main/scala/ai/privado/languageEngine/python/semantic/PythonSemanticGenerator.scala
@@ -3,6 +3,7 @@ package ai.privado.languageEngine.python.semantic
 import ai.privado.cache.RuleCache
 import ai.privado.model.{CatLevelOne, Constants}
 import ai.privado.semantic.SemanticGenerator
+import ai.privado.utility.Utilities.semanticExporter
 import io.joern.dataflowengineoss.semanticsloader.{Parser, Semantics}
 import io.shiftleft.codepropertygraph.generated.Cpg
 import io.shiftleft.semanticcpg.language._
@@ -12,7 +13,7 @@ object PythonSemanticGenerator extends SemanticGenerator {
 
   private val logger = LoggerFactory.getLogger(getClass)
 
-  def getSemantics(cpg: Cpg, ruleCache: RuleCache) = {
+  def getSemantics(cpg: Cpg, ruleCache: RuleCache, sourceRepoLocation: String) = {
     val customSinkSemantics = getMaximumFlowSemantic(
       cpg.call
         .where(_.tag.nameExact(Constants.catLevelOne).valueExact(CatLevelOne.SINKS.name))
@@ -26,6 +27,12 @@ object PythonSemanticGenerator extends SemanticGenerator {
     customSinkSemantics.foreach(logger.debug)
     logger.debug("\nCustom semanticFromConfig semantics")
     semanticFromConfig.foreach(logger.debug)
+
+    semanticExporter(
+      sourceRepoLocation,
+      List("Custom customSinkSemantics semantics", "Custom semanticFromConfig semantics"),
+      List(customSinkSemantics, semanticFromConfig)
+    )
 
     val list           = customSinkSemantics ++ semanticFromConfig
     val parsed         = new Parser().parse(list.mkString("\n"))

--- a/src/main/scala/ai/privado/languageEngine/ruby/processor/RubyProcessor.scala
+++ b/src/main/scala/ai/privado/languageEngine/ruby/processor/RubyProcessor.scala
@@ -77,7 +77,7 @@ object RubyProcessor {
         println(s"${Calendar.getInstance().getTime} - Tagging source code with rules...")
         cpg.runTagger(ruleCache)
         println(s"${Calendar.getInstance().getTime} - Finding source to sink flow of data...")
-        val dataflowMap = cpg.dataflow(ScanProcessor.config, ruleCache)
+        val dataflowMap = cpg.dataflow(ScanProcessor.config, ruleCache, sourceRepoLocation)
         println(s"${Calendar.getInstance().getTime} - No of flows found -> ${dataflowMap.size}")
         println(s"${Calendar.getInstance().getTime} - Brewing result...")
         MetricHandler.setScanStatus(true)

--- a/src/main/scala/ai/privado/model/Constants.scala
+++ b/src/main/scala/ai/privado/model/Constants.scala
@@ -93,6 +93,7 @@ object Constants {
   val privadoLanguageEngineVersion = "privadoLanguageEngineVersion"
   val cpgOutputFileName            = "cpg.bin"
   val outputAuditFileName          = "audit-report.xlsx"
+  val outputSemanticFileName       = "semantic.txt"
 
   // database details
   val dbName      = "dbName"

--- a/src/main/scala/ai/privado/utility/Utilities.scala
+++ b/src/main/scala/ai/privado/utility/Utilities.scala
@@ -37,8 +37,10 @@ import org.slf4j.LoggerFactory
 import overflowdb.{BatchedUpdate, DetachedNodeData}
 import overflowdb.traversal.Traversal
 
+import java.io.PrintWriter
 import java.math.BigInteger
 import java.net.URL
+import java.nio.charset.StandardCharsets
 import java.nio.file.Paths
 import java.security.MessageDigest
 import java.util.regex.{Pattern, PatternSyntaxException}
@@ -370,5 +372,25 @@ object Utilities {
   def addNodeWithFileEdge(builder: BatchedUpdate.DiffGraphBuilder, node: DetachedNodeData, fileNode: NewFile): Unit = {
     builder.addNode(node)
     builder.addEdge(node, fileNode, EdgeTypes.SOURCE_FILE)
+  }
+
+  def semanticExporter(sourceRepoLocation: String, headers: List[String], semantics: List[Seq[String]]): Unit = {
+    if (headers.length != semantics.length) {
+      logger.debug(
+        "Semantic Exporter failed: Headers and semantics mismatch, please provide matching number of headers and semantics."
+      )
+      return;
+    }
+
+    new PrintWriter(s"${sourceRepoLocation}/$outputDirectoryName/${Constants.outputSemanticFileName}") {
+      for ((semanticArray, i) <- semantics.view.zipWithIndex) {
+        write(s"${headers(i)}\n")
+        for (semantic <- semanticArray) {
+          write(s"$semantic\n")
+        }
+        write("---------------------------------------------\n\n")
+      }
+      close()
+    }
   }
 }

--- a/src/test/scala/ai/privado/languageEngine/java/SemanticFirstLevelDerivationTest.scala
+++ b/src/test/scala/ai/privado/languageEngine/java/SemanticFirstLevelDerivationTest.scala
@@ -35,7 +35,7 @@ class SemanticFirstLevelDerivationTest extends JavaTaggingTestBase {
     super.beforeAll()
     new IdentifierTagger(cpg, ruleCache, taggerCache).createAndApply()
     new InSensitiveCallTagger(cpg, ruleCache, taggerCache).createAndApply()
-    semantics = JavaSemanticGenerator.getSemantics(cpg, privadoScanConfig, ruleCache)
+    semantics = JavaSemanticGenerator.getSemantics(cpg, privadoScanConfig, ruleCache, ".")
   }
   override val javaFileContents =
     """

--- a/src/test/scala/ai/privado/languageEngine/java/SemanticSecondLevelDerivationTest.scala
+++ b/src/test/scala/ai/privado/languageEngine/java/SemanticSecondLevelDerivationTest.scala
@@ -36,7 +36,7 @@ class SemanticSecondLevelDerivationTest extends JavaTaggingTestBase {
     super.beforeAll()
     new IdentifierTagger(cpg, ruleCache, taggerCache).createAndApply()
     new InSensitiveCallTagger(cpg, ruleCache, taggerCache).createAndApply()
-    semantics = JavaSemanticGenerator.getSemantics(cpg, privadoScanConfig, ruleCache)
+    semantics = JavaSemanticGenerator.getSemantics(cpg, privadoScanConfig, ruleCache, ".")
   }
   override val javaFileContents =
     """

--- a/src/test/scala/ai/privado/languageEngine/java/audit/DataFlowReportTest.scala
+++ b/src/test/scala/ai/privado/languageEngine/java/audit/DataFlowReportTest.scala
@@ -31,7 +31,7 @@ class DataFlowReportTest extends DataFlowReportTestBase {
     new IdentifierTagger(cpg, ruleCache, taggerCache).createAndApply()
     new RegularSinkTagger(cpg, ruleCache).createAndApply()
     new InSensitiveCallTagger(cpg, ruleCache, taggerCache).createAndApply()
-    new Dataflow(cpg).dataflow(privadoInput, ruleCache)
+    new Dataflow(cpg).dataflow(privadoInput, ruleCache, ".")
   }
 
   def getContent(): Map[String, String] = {


### PR DESCRIPTION
Exporting run-time semantics to the .privado folder