### PR TITLE
Fix for failing use case

### DIFF
--- a/src/main/scala/ai/privado/tagger/collection/WebFormsCollectionTagger.scala
+++ b/src/main/scala/ai/privado/tagger/collection/WebFormsCollectionTagger.scala
@@ -44,8 +44,10 @@ class WebFormsCollectionTagger(cpg: Cpg, ruleCache: RuleCache) extends PrivadoPa
       * rows={4} name="message" onChange={handleChange} /> <Button type="submit">Submit</Button> </form> );
       */
     ruleCache.getRule.sources.foreach(sourceRule => {
-      val rule =
-        s"${collectionRuleInfo.combinedRulePattern}.*(?:name|id|label|value)=(?:\\{|t){0,2}(?:\"|\'|`)(${sourceRule.combinedRulePattern})(?:\"|\'|`).*"
+      val inputFieldFilterRule = s"${collectionRuleInfo.combinedRulePattern}"
+      val srcRule =
+        s".*(?:name|id|label|value)=(?:\\{|t){0,2}(?:\"|\'|`|\\{)(${sourceRule.combinedRulePattern})(?:\"|\'|`|\\}).*"
+
       cpg.templateDom
         // Each HTML element/template element translates into multiple CPG nodes.
         // Like
@@ -61,7 +63,8 @@ class WebFormsCollectionTagger(cpg: Cpg, ruleCache: RuleCache) extends PrivadoPa
         .name(
           s"${Constants.jsxOpenElement}|${Constants.jsxElement}|${Constants.HTMLOpenElement}|${Constants.HTMLElement}"
         )
-        .code(rule)
+        .code(inputFieldFilterRule)
+        .code(srcRule)
         .foreach(element => {
           if (element.name == Constants.jsxOpenElement || element.name == Constants.HTMLOpenElement) {
             storeForTag(builder, element, ruleCache)(Constants.collectionSource, sourceRule.id)


### PR DESCRIPTION
If the tag is split into multiple lines then the existing regex was failing to detect the element. Like the below code sample. Handled respective use case along with the addition of corresponding unit test

```
<ComplexInputField
                    name={FIELDS.SURNAME}
                    label={messages.surName.placeholder}
                    value={values?.surname}
                    error={errors.surname}
                  />
```