### PR TITLE
patch - remove the dataflow's reachableBy implementation from Read pass

### DIFF
--- a/src/main/scala/ai/privado/entrypoint/CommandParser.scala
+++ b/src/main/scala/ai/privado/entrypoint/CommandParser.scala
@@ -40,6 +40,7 @@ case class PrivadoInput(
   disableThisFiltering: Boolean = false,
   disableFlowSeparationByDataElement: Boolean = false,
   disable2ndLevelClosure: Boolean = false,
+  disableReadDataflow: Boolean = false,
   enableAPIDisplay: Boolean = false,
   ignoreExcludeRules: Boolean = false,
   ignoreSinkSkipRules: Boolean = false,
@@ -73,6 +74,8 @@ object CommandConstants {
   val DISABLE_FLOW_SEPERATION_BY_DATA_ELEMENT_ABBR = "dfsde"
   val DISABLE_2ND_LEVEL_CLOSURE                    = "disable-2nd-level-closure"
   val DISABLE_2ND_LEVEL_CLOSURE_ABBR               = "d2lc"
+  val DISABLE_READ_DATAFLOW                        = "disable-read-dataflow"
+  val DISABLE_READ_DATAFLOW_ABBR                   = "drd"
   val ENABLE_API_DISPLAY                           = "enable-api-display"
   val ENABLE_API_DISPLAY_ABBR                      = "ead"
   val IGNORE_EXCLUDE_RULES                         = "ignore-exclude-rules"
@@ -164,6 +167,11 @@ object CommandParser {
               .optional()
               .action((_, c) => c.copy(disable2ndLevelClosure = true))
               .text("Disable 2nd level closure"),
+            opt[Unit](CommandConstants.DISABLE_READ_DATAFLOW)
+              .abbr(CommandConstants.DISABLE_READ_DATAFLOW_ABBR)
+              .optional()
+              .action((_, c) => c.copy(disableReadDataflow = true))
+              .text("Disable database read dataflow"),
             opt[Unit](CommandConstants.ENABLE_API_DISPLAY)
               .abbr(CommandConstants.ENABLE_API_DISPLAY_ABBR)
               .optional()

--- a/src/main/scala/ai/privado/languageEngine/java/passes/read/DatabaseQueryReadPass.scala
+++ b/src/main/scala/ai/privado/languageEngine/java/passes/read/DatabaseQueryReadPass.scala
@@ -1,17 +1,19 @@
 package ai.privado.languageEngine.java.passes.read
 
 import ai.privado.cache.{RuleCache, TaggerCache}
+import ai.privado.entrypoint.PrivadoInput
 import ai.privado.languageEngine.java.passes.read.DatabaseReadUtility.{fromRegexPattern, selectRegexPattern}
 import ai.privado.tagger.PrivadoParallelCpgPass
-import io.shiftleft.codepropertygraph.generated.nodes._
+import io.shiftleft.codepropertygraph.generated.nodes.*
 import io.shiftleft.codepropertygraph.generated.{Cpg, Operators}
-import io.shiftleft.semanticcpg.language._
+import io.shiftleft.semanticcpg.language.*
 import org.slf4j.{Logger, LoggerFactory}
 
 class DatabaseQueryReadPass(
   cpg: Cpg,
   ruleCache: RuleCache,
   taggerCache: TaggerCache,
+  privadoInputConfig: PrivadoInput,
   classTableMapping: Map[String, TypeDecl]
 ) extends PrivadoParallelCpgPass[Expression](cpg) {
 
@@ -33,6 +35,14 @@ class DatabaseQueryReadPass(
   }
 
   override def runOnPart(builder: DiffGraphBuilder, node: Expression): Unit = {
-    DatabaseReadUtility.processDBReadNode(builder, ruleCache, taggerCache, classTableMapping, cpg, node)
+    DatabaseReadUtility.processDBReadNode(
+      builder,
+      ruleCache,
+      taggerCache,
+      classTableMapping,
+      cpg,
+      node,
+      privadoInputConfig
+    )
   }
 }

--- a/src/main/scala/ai/privado/languageEngine/java/passes/read/DatabaseReadUtility.scala
+++ b/src/main/scala/ai/privado/languageEngine/java/passes/read/DatabaseReadUtility.scala
@@ -25,13 +25,14 @@ package ai.privado.languageEngine.java.passes.read
 
 import ai.privado.cache.{RuleCache, TaggerCache}
 import ai.privado.dataflow.Dataflow
+import ai.privado.entrypoint.PrivadoInput
 import ai.privado.model.InternalTag
 import ai.privado.model.sql.SQLQuery
 import ai.privado.utility.SQLParser
-import ai.privado.utility.Utilities._
+import ai.privado.utility.Utilities.*
 import io.shiftleft.codepropertygraph.generated.nodes.{AnnotationLiteral, AstNode, CfgNode, TypeDecl}
 import overflowdb.BatchedUpdate.DiffGraphBuilder
-import io.shiftleft.semanticcpg.language._
+import io.shiftleft.semanticcpg.language.*
 import io.shiftleft.codepropertygraph.generated.Cpg
 
 object DatabaseReadUtility {
@@ -45,7 +46,8 @@ object DatabaseReadUtility {
     taggerCache: TaggerCache,
     classTableMapping: Map[String, TypeDecl],
     cpg: Cpg,
-    node: AstNode
+    node: AstNode,
+    privadoInputConfig: PrivadoInput
   ) = {
 
     val queryCode = node.code
@@ -119,23 +121,23 @@ object DatabaseReadUtility {
                 }
                */
               // TODO Need to find a optimized way to solve this
-              /*
-              val dataElementSinks =
-                Dataflow
-                  .getSources(cpg)
-                  .filter(_.isInstanceOf[CfgNode])
-                  .map(_.asInstanceOf[CfgNode])
-                  .l
+              if (!privadoInputConfig.disableReadDataflow) {
+                val dataElementSinks =
+                  Dataflow
+                    .getSources(cpg)
+                    .filter(_.isInstanceOf[CfgNode])
+                    .map(_.asInstanceOf[CfgNode])
+                    .l
 
-              val readFlow = Dataflow.dataflowForSourceSinkPair(referencingQueryNodes, dataElementSinks)
-              if (readFlow.nonEmpty) {
-                // As a flow is present from Select query to a Data element we can say, the data element is read from the query
-                readFlow
-                  .flatMap(_.elements.last.tag.value("Data.Sensitive.*"))
-                  .value
-                  .foreach(ruleId => addTagsToNode(ruleCache, ruleId, referencingQueryNodes, builder))
+                val readFlow = Dataflow.dataflowForSourceSinkPair(referencingQueryNodes, dataElementSinks)
+                if (readFlow.nonEmpty) {
+                  // As a flow is present from Select query to a Data element we can say, the data element is read from the query
+                  readFlow
+                    .flatMap(_.elements.last.tag.value("Data.Sensitive.*"))
+                    .value
+                    .foreach(ruleId => addTagsToNode(ruleCache, ruleId, referencingQueryNodes, builder))
+                }
               }
-               */
             }
           } else {
             ruleCache.getRule.sources

--- a/src/main/scala/ai/privado/languageEngine/java/passes/read/DatabaseReadUtility.scala
+++ b/src/main/scala/ai/privado/languageEngine/java/passes/read/DatabaseReadUtility.scala
@@ -118,6 +118,8 @@ object DatabaseReadUtility {
                     System.out.println("ID: " + id + ", Name: " + firstName + ", Age: " + age)
                 }
                */
+              // TODO Need to find a optimized way to solve this
+              /*
               val dataElementSinks =
                 Dataflow
                   .getSources(cpg)
@@ -133,6 +135,7 @@ object DatabaseReadUtility {
                   .value
                   .foreach(ruleId => addTagsToNode(ruleCache, ruleId, referencingQueryNodes, builder))
               }
+               */
             }
           } else {
             ruleCache.getRule.sources

--- a/src/main/scala/ai/privado/languageEngine/java/tagger/PrivadoTagger.scala
+++ b/src/main/scala/ai/privado/languageEngine/java/tagger/PrivadoTagger.scala
@@ -79,7 +79,8 @@ class PrivadoTagger(cpg: Cpg) extends PrivadoBaseTagger {
       new MessagingConsumerReadPass(cpg, taggerCache).createAndApply()
     }
 
-    new DatabaseQueryReadPass(cpg, ruleCache, taggerCache, EntityMapper.getClassTableMapping(cpg)).createAndApply()
+    new DatabaseQueryReadPass(cpg, ruleCache, taggerCache, privadoInputConfig, EntityMapper.getClassTableMapping(cpg))
+      .createAndApply()
 
     new DatabaseRepositoryReadPass(cpg, taggerCache).createAndApply()
 

--- a/src/test/scala/ai/privado/languageEngine/java/passes/read/JavaSQLDatabaseReadTest.scala
+++ b/src/test/scala/ai/privado/languageEngine/java/passes/read/JavaSQLDatabaseReadTest.scala
@@ -24,12 +24,13 @@
 package ai.privado.languageEngine.java.passes.read
 
 import ai.privado.cache.{RuleCache, TaggerCache}
+import ai.privado.entrypoint.PrivadoInput
 import ai.privado.languageEngine.java.tagger.source.IdentifierTagger
-import ai.privado.model._
+import ai.privado.model.*
 import better.files.File
 import io.joern.javasrc2cpg.{Config, JavaSrc2Cpg}
 import io.shiftleft.codepropertygraph.generated.Cpg
-import io.shiftleft.semanticcpg.language._
+import io.shiftleft.semanticcpg.language.*
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
@@ -299,7 +300,8 @@ abstract class DatabaseReadPassTestBase extends AnyWordSpec with Matchers with B
       ConfigAndRules(sourceRule, List(), collectionRule, List(), List(), List(), List(), List(), List(), List())
     ruleCache.setRule(rule)
     new IdentifierTagger(cpg, ruleCache, taggerCache).createAndApply()
-    new DatabaseQueryReadPass(cpg, ruleCache, taggerCache, EntityMapper.getClassTableMapping(cpg)).createAndApply()
+    new DatabaseQueryReadPass(cpg, ruleCache, taggerCache, PrivadoInput(), EntityMapper.getClassTableMapping(cpg))
+      .createAndApply()
     super.beforeAll()
   }
 


### PR DESCRIPTION
 There is a piece of code in `databaseReadPass` which runs Dataflow in runOnPart which is a resource-intensive task and becomes a bottleneck for repos like `openmrs-core` , I currently have added a flag  `disable-read-dataflow` and am able to get the repo scanned on the laptop using that flag. 
 
 Default behaviour is to run the read dataflow, but for repos which need a higher configuration `disable-read-dataflow` can be used to skip the intensive task
 
 The optimized version will be available in a follow-up PR