### PR TITLE
Ruby API Flows (#716)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,8 +6,8 @@ ThisBuild / version      := sys.env.getOrElse("BUILD_VERSION", "dev-SNAPSHOT")
 // parsed by project/Versions.scala, updated by updateDependencies.sh
 
 
-val cpgVersion        = "1.4.18"
-val joernVersion      = "2.0.52"
+val cpgVersion        = "1.4.22"
+val joernVersion      = "2.0.78"
 val overflowdbVersion = "1.181"
 val requests          = "0.8.0"
 val upickle           = "3.1.2"

--- a/src/main/scala/ai/privado/languageEngine/ruby/processor/RubyProcessor.scala
+++ b/src/main/scala/ai/privado/languageEngine/ruby/processor/RubyProcessor.scala
@@ -126,11 +126,13 @@ object RubyProcessor {
           println(
             s"${TimeMetric.getNewTime()} - Type hint linker done in \t\t\t- ${TimeMetric.setNewTimeToLastAndGetTimeDiff()}"
           )
+          /*
           println(s"${Calendar.getInstance().getTime} - Naive call linker started  ...")
           new NaiveCallLinker(cpg).createAndApply()
           println(
             s"${TimeMetric.getNewTime()} - Naive call linker done in \t\t\t- ${TimeMetric.setNewTimeToLastAndGetTimeDiff()}"
           )
+           */
           // Some of passes above create new methods, so, we
           // need to run the ASTLinkerPass one more time
           println(s"${Calendar.getInstance().getTime} - Ast linker started  ...")

--- a/src/main/scala/ai/privado/languageEngine/ruby/tagger/sink/APITagger.scala
+++ b/src/main/scala/ai/privado/languageEngine/ruby/tagger/sink/APITagger.scala
@@ -11,24 +11,38 @@ import ai.privado.tagger.utility.APITaggerUtility.sinkTagger
 import ai.privado.utility.Utilities
 import io.circe.Json
 import io.joern.dataflowengineoss.queryengine.{EngineConfig, EngineContext}
-import io.shiftleft.codepropertygraph.generated.Cpg
+import io.shiftleft.codepropertygraph.generated.nodes.Call
+import io.shiftleft.codepropertygraph.generated.{Cpg, Operators}
 import io.shiftleft.semanticcpg.language.*
 import org.slf4j.LoggerFactory
 
+import scala.jdk.CollectionConverters.CollectionHasAsScala
 import java.util.Calendar
 
 class APITagger(cpg: Cpg, ruleCache: RuleCache, privadoInput: PrivadoInput)
     extends PrivadoParallelCpgPass[RuleInfo](cpg) {
-  private val logger = LoggerFactory.getLogger(this.getClass)
-  val cacheCall      = cpg.call.where(_.nameNot("(<operator|<init).*")).l
+  private val logger        = LoggerFactory.getLogger(this.getClass)
+  val cacheCall: List[Call] = cpg.call.where(_.nameNot(Operators.ALL.asScala.toSeq: _*)).l
 
-  val APISINKS_REGEX = ruleCache.getSystemConfigByKey(Constants.apiSinks)
+  val APISINKS_REGEX: String = ruleCache.getSystemConfigByKey(Constants.apiSinks)
 
-  val apis = cacheCall.name(APISINKS_REGEX).l
+  val apis: List[Call] = cacheCall.name(APISINKS_REGEX).l
 
   MetricHandler.metricsData("apiTaggerVersion") = Json.fromString("Common HTTP Libraries Used")
   implicit val engineContext: EngineContext = Utilities.getEngineContext(4)
   val commonHttpPackages: String            = ruleCache.getSystemConfigByKey(Constants.apiHttpLibraries)
+
+  val httpApis: List[Call] = apis
+    .or(_.methodFullName(commonHttpPackages), _.filter(_.dynamicTypeHintFullName.exists(_.matches(commonHttpPackages))))
+    .l
+
+  val clientLikeApis: List[Call] = cacheCall
+    .code("(?i).*(client|connection).*[.](get|post|delete|put|patch).*")
+    .name("get|post|post_json|delete|put|patch")
+    .l
+
+  // Support to use `identifier` in API's
+  val identifierRegex: String = ruleCache.getSystemConfigByKey(Constants.apiIdentifier)
 
   override def generateParts(): Array[_ <: AnyRef] = {
     ruleCache.getRule.sinks
@@ -39,8 +53,7 @@ class APITagger(cpg: Cpg, ruleCache: RuleCache, privadoInput: PrivadoInput)
   override def runOnPart(builder: DiffGraphBuilder, ruleInfo: RuleInfo): Unit = {
     val apiInternalSources = cpg.literal.code("(?:\"|'){0,1}(" + ruleInfo.combinedRulePattern + ")(?:\"|'){0,1}").l
     val propertySources    = cpg.property.filter(p => p.value matches (ruleInfo.combinedRulePattern)).usedAt.l
-    // Support to use `identifier` in API's
-    val identifierRegex = ruleCache.getSystemConfigByKey(Constants.apiIdentifier)
+
     val identifierSource = {
       if (!ruleInfo.id.equals(Constants.internalAPIRuleId))
         cpg.identifier(identifierRegex).l ++ cpg.property.filter(p => p.name matches (identifierRegex)).usedAt.l
@@ -52,12 +65,7 @@ class APITagger(cpg: Cpg, ruleCache: RuleCache, privadoInput: PrivadoInput)
     println(s"${Calendar.getInstance().getTime} - --API TAGGER Common HTTP Libraries Used...")
     sinkTagger(
       apiInternalSources ++ propertySources ++ identifierSource,
-      apis
-        .or(
-          _.methodFullName(commonHttpPackages),
-          _.filter(_.dynamicTypeHintFullName.exists(_.matches(commonHttpPackages)))
-        )
-        .l,
+      (httpApis ++ clientLikeApis).distinct,
       builder,
       ruleInfo,
       ruleCache,

--- a/src/main/scala/ai/privado/languageEngine/ruby/tagger/source/IdentifierDerivedTagger.scala
+++ b/src/main/scala/ai/privado/languageEngine/ruby/tagger/source/IdentifierDerivedTagger.scala
@@ -39,7 +39,9 @@ class IdentifierDerivedTagger(cpg: Cpg, ruleCache: RuleCache) extends PrivadoPar
                 cpg.identifier
                   .or(
                     _.typeFullName(s"$typeDeclFullNameRegex.*"),
-                    _.filter(_.dynamicTypeHintFullName.exists(_.matches(s"$typeDeclFullNameRegex.*")))
+                    _.filter(_.dynamicTypeHintFullName.exists(_.matches(s"$typeDeclFullNameRegex.*"))),
+                    _.name(s"(?i)$cleanedTableName"),
+                    _.name(s"(?i)${tableNode.name.stripSuffix("s")}")
                   )
                   .foreach { impactedObject =>
 

--- a/src/main/scala/ai/privado/languageEngine/ruby/tagger/source/IdentifierTagger.scala
+++ b/src/main/scala/ai/privado/languageEngine/ruby/tagger/source/IdentifierTagger.scala
@@ -27,11 +27,18 @@ import ai.privado.cache.RuleCache
 import ai.privado.model.{InternalTag, RuleInfo}
 import ai.privado.tagger.PrivadoParallelCpgPass
 import ai.privado.utility.Utilities.{addRuleTags, storeForTag}
-import io.shiftleft.codepropertygraph.generated.Cpg
+import io.shiftleft.codepropertygraph.generated.nodes.Call
+import io.shiftleft.codepropertygraph.generated.{Cpg, Operators}
 import io.shiftleft.passes.ForkJoinParallelCpgPass
-import io.shiftleft.semanticcpg.language._
+import io.shiftleft.semanticcpg.language.*
+
+import scala.jdk.CollectionConverters.CollectionHasAsScala
 
 class IdentifierTagger(cpg: Cpg, ruleCache: RuleCache) extends PrivadoParallelCpgPass[RuleInfo](cpg) {
+
+  val cachedCall: List[Call] = cpg.call
+    .or(_.nameNot(Operators.ALL.asScala.toSeq: _*))
+    .l
 
   override def generateParts(): Array[RuleInfo] = ruleCache.getRule.sources.toArray
 

--- a/src/main/scala/ai/privado/model/Constants.scala
+++ b/src/main/scala/ai/privado/model/Constants.scala
@@ -162,5 +162,5 @@ object Constants {
   val semanticDelimeter = "_A_"
 
   // Ruby defaults
-  val defaultExpansionLimit = 20
+  val defaultExpansionLimit = 100
 }


### PR DESCRIPTION
- Removed NaiveCalLinker for Ruby
- Upgraded to language engine version 2.0.78
- Increased Dataflow parameter expansion constant from 20 to 100- 
- Refactor in API Tagger of Ruby