### PR TITLE
Fix: Parallel processing in JSON export.

### DIFF
--- a/src/main/scala/ai/privado/exporter/JSONExporter.scala
+++ b/src/main/scala/ai/privado/exporter/JSONExporter.scala
@@ -90,12 +90,12 @@ object JSONExporter {
 
       // Future creates a thread and starts resolving the function call asynchronously
       val sources = Future {
-        val _sources = sourceExporter.getSources
+        val _sources = Try(sourceExporter.getSources).getOrElse(List())
         output.addOne(Constants.sources -> _sources.asJson)
         _sources
       }
       val processing = Future {
-        val _processing = sourceExporter.getProcessing
+        val _processing = Try(sourceExporter.getProcessing).getOrElse(List())
         output.addOne(Constants.processing -> _processing.asJson)
         _processing
       }
@@ -105,17 +105,17 @@ object JSONExporter {
         _sinks
       }
       val processingSinks = Future {
-        val _processingSinks = sinkExporter.getProcessing
+        val _processingSinks = Try(sinkExporter.getProcessing).getOrElse(List())
         output.addOne(Constants.sinkProcessing -> _processingSinks.asJson)
         _processingSinks
       }
       val collections = Future {
-        val _collections = collectionExporter.getCollections
+        val _collections = Try(collectionExporter.getCollections).getOrElse(List())
         output.addOne(Constants.collections -> _collections.asJson)
         _collections
       }
 
-      val violationResult = policyAndThreatExporter.getViolations(repoPath)
+      val violationResult = Try(policyAndThreatExporter.getViolations(repoPath)).getOrElse(List())
       output.addOne(Constants.violations -> violationResult.asJson)
 
       val sinkSubCategories = mutable.HashMap[String, mutable.Set[String]]()

--- a/src/main/scala/ai/privado/exporter/JSONExporter.scala
+++ b/src/main/scala/ai/privado/exporter/JSONExporter.scala
@@ -89,7 +89,6 @@ object JSONExporter {
       output.addOne(Constants.probableSinks                -> probableSinkExporter.getProbableSinks.asJson)
 
       // Future creates a thread and starts resolving the function call asynchronously
-
       val sources = Future {
         val _sources = sourceExporter.getSources
         output.addOne(Constants.sources -> _sources.asJson)
@@ -118,58 +117,6 @@ object JSONExporter {
 
       val violationResult = policyAndThreatExporter.getViolations(repoPath)
       output.addOne(Constants.violations -> violationResult.asJson)
-
-      // Called when the asynchronous call is completed
-//      sources.onComplete({
-//        case Success(value) => {
-//          output.addOne(Constants.sources -> value.asJson)
-//          logger.info("Completed sources export.")
-//        }
-//        case Failure(e) => {
-//          println(e)
-//        }
-//      })
-//
-//      sinks.onComplete({
-//        case Success(value) => {
-//          output.addOne(Constants.sinks -> value.asJson)
-//          logger.info("Completed sinks export.")
-//        }
-//        case Failure(e) => {
-//          println(e)
-//        }
-//      })
-//
-//      processing.onComplete({
-//        case Success(value) => {
-//          output.addOne(Constants.processing -> value.asJson)
-//          logger.info("Completed processing export.")
-//
-//        }
-//        case Failure(e) => {
-//          println(e)
-//        }
-//      })
-//
-//      collections.onComplete({
-//        case Success(value) => {
-//          output.addOne(Constants.collections -> value.asJson)
-//          logger.info("Completed collections export.")
-//        }
-//        case Failure(e) => {
-//          println(e)
-//        }
-//      })
-//
-//      processingSinks.onComplete({
-//        case Success(value) => {
-//          output.addOne(Constants.sinkProcessing -> value.asJson)
-//          logger.info("Completed sinks export.")
-//        }
-//        case Failure(e) => {
-//          println(e)
-//        }
-//      })
 
       val sinkSubCategories = mutable.HashMap[String, mutable.Set[String]]()
       ruleCache.getRule.sinks.foreach(sinkRule => {


### PR DESCRIPTION
The scala future used in the exporting step currently might leave some keys out of `privado.json` as it does not wait for the future to complete the `onComplete` step. This PR combines the adding to hashmap step and the processing steps into a single future, to make it atomic.
