### PR TITLE
Update the HTMLParser to adopt identifying script tags

### DIFF
--- a/src/main/scala/ai/privado/model/Constants.scala
+++ b/src/main/scala/ai/privado/model/Constants.scala
@@ -157,6 +157,8 @@ object Constants {
   val HTMLElementAttribute = "HTMLElementAttribute"
   val HTMLScriptElement    = "HTMLScriptElement"
 
+  val UnknownDomain = "unknown-domain"
+
   val annotations       = "annotations"
   val default           = "default"
   val semanticDelimeter = "_A_"

--- a/src/main/scala/ai/privado/passes/HTMLParserPass.scala
+++ b/src/main/scala/ai/privado/passes/HTMLParserPass.scala
@@ -166,8 +166,14 @@ class HTMLParserPass(cpg: Cpg, projectRoot: String, ruleCache: RuleCache) extend
       if (element.isInstanceOf[HtmlScript]) {
         val scriptElement = element.asInstanceOf[HtmlScript]
         val scriptContent = scriptElement.getTextContent()
-        if (scriptContent.nonEmpty) {
-          val attributeStr = s"content=\"${scriptContent}\""
+
+        // Remove single-line comments
+        val scriptContentWithoutSingleLineComments = scriptContent.replaceAll("//.*?(\\n|$)", "")
+        // Remove multi-line comments
+        val scriptContentWithoutComments = scriptContentWithoutSingleLineComments.replaceAll("/\\*.*?\\*/", "")
+
+        if (scriptContentWithoutComments.nonEmpty) {
+          val attributeStr = s"content=\"${scriptContentWithoutComments}\""
           elementAttributesStr += " " + attributeStr
         }
       }

--- a/src/main/scala/ai/privado/utility/Utilities.scala
+++ b/src/main/scala/ai/privado/utility/Utilities.scala
@@ -391,7 +391,7 @@ object Utilities {
         (matched.matched, matched.group(3))
       case Failure(e) =>
         logger.debug("Exception : ", e)
-        ("unknown-domain", "unknown-domain")
+        (Constants.UnknownDomain, Constants.UnknownDomain)
     }
   }
 

--- a/src/test/scala/ai/privado/passes/HTMLParserPassTest.scala
+++ b/src/test/scala/ai/privado/passes/HTMLParserPassTest.scala
@@ -196,6 +196,54 @@ class HTMLParserPassTest extends AnyWordSpec with Matchers with BeforeAndAfterAl
     }
   }
 
+  "VanilaJS with inline-script tags" should {
+    val cpg = code("""
+        |<!DOCTYPE html>
+        |<html>
+        |<head>
+        |  <title>Script Loading Example</title>
+        |</head>
+        |<body>
+        |
+        |  <!-- Script tag to load another script -->
+        |  <script async src="//www.googletagservices.com/tag/js/gpt.js"></script>
+        |
+        |  <!-- Script tag with inline JavaScript code that loads third-party scripts -->
+        |  <script>
+        |    var div_1_sizes = [
+        |                [300, 250],
+        |                [300, 600]
+        |            ];
+        |            var div_2_sizes = [
+        |                [728, 90],
+        |                [970, 250]
+        |            ];
+        |  </script>
+        |</body>
+        |</html>
+        |""".stripMargin)
+    "Count of html elements" in {
+      // Considering the HtmlUnit will wrapp this html inside <html><head></head><body> above contents </body></html>
+      // The element count will be 8 + 3 = 11
+      cpg.templateDom.name(Constants.HTMLElement).l.size shouldBe 6
+      cpg.templateDom.name(Constants.HTMLOpenElement).l.size shouldBe 6
+      cpg.templateDom.name(Constants.HTMLClosingElement).l.size shouldBe 6
+      cpg.templateDom.name(Constants.HTMLElementAttribute).l.size shouldBe 2
+      // Checking only for single first node if the file node is attached.
+      cpg.templateDom.file.name.l.head should endWith("sample.html")
+    }
+
+    "Count of script tag elements + " in {
+      // Checking for Script tags
+      cpg.templateDom.name(Constants.HTMLOpenElement).code("(?i)[\\\"]*<(script).*").l.size shouldBe 2
+    }
+
+    "Content attribute should be present for script tag" in {
+      // Ensure inline script tag is with content attribute
+      cpg.templateDom.name(Constants.HTMLOpenElement).code("(?i)[\\\"]*<(script).*(content).*").l.size shouldBe 1
+    }
+  }
+
   def code(code: String): Cpg = {
     val inputDir = File.newTemporaryDirectory()
     inputDirs.addOne(inputDir)


### PR DESCRIPTION
- Update HTMLParser to get HTML Elements excluding the script tag errors
- Update JSAPITagger to adopt HTMLElement in parsing
- Convert Inline script tag code into `content` attribute