### PR TITLE
[Fix] Dedup on intersecting path ids

### DIFF
--- a/src/main/scala/ai/privado/audit/DataFlowReport.scala
+++ b/src/main/scala/ai/privado/audit/DataFlowReport.scala
@@ -6,20 +6,21 @@ import scala.collection.mutable.ListBuffer
 
 object DataFlowReport {
 
-  def processDataFlowAudit(): List[List[String]] = {
+  def processDataFlowAudit(auditCache: AuditCache): List[List[String]] = {
     val workbookResult = ListBuffer[List[String]]()
 
-    AuditCache.getFlowBeforeSemantics.foreach(flow => {
-      val existInFirstFiltering  = if (AuditCache.checkFlowExistInFirstFiltering(flow)) "YES" else "--"
-      val existInSecondFiltering = if (AuditCache.checkFlowExistInSecondFiltering(flow)) "YES" else "--"
-      val existInFirstDedup      = if (AuditCache.checkFlowExistInFirstDedup(flow)) "YES" else "--"
-      val existInSecondDedup     = if (AuditCache.checkFlowExistInSecondDedup(flow)) "YES" else "--"
-      val existInFinal           = if (AuditCache.checkFlowExistInFinal(flow)) "YES" else "--"
+    auditCache.getFlowBeforeSemantics.foreach(flow => {
+      val existInFirstFiltering  = if (auditCache.checkFlowExistInFirstFiltering(flow)) "YES" else "--"
+      val existInSecondFiltering = if (auditCache.checkFlowExistInSecondFiltering(flow)) "YES" else "--"
+      val existInFirstDedup      = if (auditCache.checkFlowExistInFirstDedup(flow)) "YES" else "--"
+      val existInSecondDedup     = if (auditCache.checkFlowExistInSecondDedup(flow)) "YES" else "--"
+      val existInFinal           = if (auditCache.checkFlowExistInFinal(flow)) "YES" else "--"
+
       workbookResult += List(
         flow.sourceId,
         flow.sinkId,
         flow.pathId,
-        getShortPath(flow.pathId),
+        getShortPath(flow.pathId, auditCache),
         AuditReportConstants.AUDIT_CHECKED_VALUE,
         AuditReportConstants.AUDIT_CHECKED_VALUE,
         existInFirstFiltering,
@@ -47,12 +48,12 @@ object DataFlowReport {
     ) ++ workbookResult.toList.groupBy(_.head).values.toList.flatten
   }
 
-  private def getShortPath(pathId: String): String = {
+  private def getShortPath(pathId: String, auditCache: AuditCache): String = {
     val shortPathBuilder = new StringBuffer()
-    if (!AuditCache.pathIdExist(pathId)) {
+    if (!auditCache.pathIdExist(pathId)) {
       shortPathBuilder.append("NA")
     } else {
-      AuditCache
+      auditCache
         .getPathFromId(pathId)
         .elements
         .foreach(node => {

--- a/src/main/scala/ai/privado/audit/UnresolvedFlowReport.scala
+++ b/src/main/scala/ai/privado/audit/UnresolvedFlowReport.scala
@@ -10,8 +10,8 @@ import scala.collection.mutable.ListBuffer
 
 object UnresolvedFlowReport {
   val workbookResult: ListBuffer[List[String]] = ListBuffer[List[String]]()
-  def processUnresolvedFlow(): List[List[String]] = {
-    val expendedSourceSinkInfo = AuditCache.getUnfilteredFlow()
+  def processUnresolvedFlow(auditCache: AuditCache): List[List[String]] = {
+    val expendedSourceSinkInfo = auditCache.getUnfilteredFlow()
 
     expendedSourceSinkInfo.foreach(sourceSinkInfo => {
       workbookResult += List(

--- a/src/main/scala/ai/privado/cache/DataFlowCache.scala
+++ b/src/main/scala/ai/privado/cache/DataFlowCache.scala
@@ -40,7 +40,7 @@ import java.util.concurrent.{ConcurrentHashMap, ConcurrentMap}
 import scala.collection.mutable
 import scala.collection.mutable.ListBuffer
 
-object DataFlowCache {
+class DataFlowCache {
 
   val dataflowsMapByType: ConcurrentMap[String, Path] = new ConcurrentHashMap[String, Path]()
 

--- a/src/main/scala/ai/privado/cache/DataFlowCache.scala
+++ b/src/main/scala/ai/privado/cache/DataFlowCache.scala
@@ -138,7 +138,6 @@ class DataFlowCache(auditCache: AuditCache) {
     }
 
     if (ScanProcessor.config.generateAuditReport) {
-      println("Generate")
       auditCache.addIntoBeforeFirstDedup(dataflow)
     }
 

--- a/src/main/scala/ai/privado/dataflow/DuplicateFlowProcessor.scala
+++ b/src/main/scala/ai/privado/dataflow/DuplicateFlowProcessor.scala
@@ -164,7 +164,8 @@ object DuplicateFlowProcessor {
   def filterIrrelevantFlowsAndStoreInCache(
     dataflowMapByPathId: Map[String, Path],
     privadoScanConfig: PrivadoInput,
-    ruleCache: RuleCache
+    ruleCache: RuleCache,
+    dataFlowCache: DataFlowCache
   ): Unit = {
 
     val expendedSourceSinkInfo = processExpendedSourceSinkData(dataflowMapByPathId, privadoScanConfig, ruleCache)
@@ -181,7 +182,7 @@ object DuplicateFlowProcessor {
           !(flow.sinkId.startsWith(Constants.cookieWriteRuleId) && flow.pathSourceId
             .equals(Constants.cookieSourceRuleId))
         ) {
-          DataFlowCache.setDataflow(
+          dataFlowCache.setDataflow(
             DataFlowPathModel(
               flow.pathSourceId,
               flow.sinkId,
@@ -199,7 +200,8 @@ object DuplicateFlowProcessor {
           flow.dataflowNodeType,
           ruleCache,
           flow.sinkId,
-          flow.sinkPathId
+          flow.sinkPathId,
+          dataFlowCache
         )
       }
     })
@@ -352,7 +354,8 @@ object DuplicateFlowProcessor {
     dataflowNodeType: String,
     ruleCache: RuleCache,
     sinkId: String,
-    sinkPathId: String
+    sinkPathId: String,
+    dataFlowCache: DataFlowCache
   ) = {
     // Logic to filter flows which are interfering with the current source item
     // Ex - If traversing flow for email, discard flow which uses password
@@ -433,7 +436,7 @@ object DuplicateFlowProcessor {
         ruleCache
       )
     )
-      DataFlowCache.setDataflow(DataFlowPathModel(pathSourceId, sinkId, dataflowSinkType, dataflowNodeType, sinkPathId))
+      dataFlowCache.setDataflow(DataFlowPathModel(pathSourceId, sinkId, dataflowSinkType, dataflowNodeType, sinkPathId))
   }
 
   /** Check to classify if correct path Source Id is getting consumed in sink for derived sources

--- a/src/main/scala/ai/privado/dataflow/DuplicateFlowProcessor.scala
+++ b/src/main/scala/ai/privado/dataflow/DuplicateFlowProcessor.scala
@@ -22,7 +22,7 @@
 
 package ai.privado.dataflow
 
-import ai.privado.cache.AuditCache.SourcePathInfo
+import ai.privado.cache.SourcePathInfo
 import ai.privado.cache.{AppCache, AuditCache, DataFlowCache, RuleCache}
 import ai.privado.entrypoint.PrivadoInput
 import ai.privado.metric.MetricHandler
@@ -165,14 +165,15 @@ object DuplicateFlowProcessor {
     dataflowMapByPathId: Map[String, Path],
     privadoScanConfig: PrivadoInput,
     ruleCache: RuleCache,
-    dataFlowCache: DataFlowCache
+    dataFlowCache: DataFlowCache,
+    auditCache: AuditCache
   ): Unit = {
 
     val expendedSourceSinkInfo = processExpendedSourceSinkData(dataflowMapByPathId, privadoScanConfig, ruleCache)
 
     expendedSourceSinkInfo.foreach(flow => {
       if (privadoScanConfig.generateAuditReport) {
-        AuditCache.addIntoBeforeSecondFiltering(SourcePathInfo(flow.pathSourceId, flow.sinkId, flow.sinkPathId))
+        auditCache.addIntoBeforeSecondFiltering(SourcePathInfo(flow.pathSourceId, flow.sinkId, flow.sinkPathId))
       }
       if (
         privadoScanConfig.disableFlowSeparationByDataElement || (AppCache.repoLanguage != Language.JAVA && AppCache.repoLanguage != Language.JAVASCRIPT)

--- a/src/main/scala/ai/privado/exporter/DataflowExporter.scala
+++ b/src/main/scala/ai/privado/exporter/DataflowExporter.scala
@@ -34,7 +34,12 @@ import org.slf4j.{Logger, LoggerFactory}
 import scala.collection.mutable
 import scala.collection.mutable.ListBuffer
 
-class DataflowExporter(cpg: Cpg, dataflowsMap: Map[String, Path], taggerCache: TaggerCache) {
+class DataflowExporter(
+  cpg: Cpg,
+  dataflowsMap: Map[String, Path],
+  taggerCache: TaggerCache,
+  dataFlowCache: DataFlowCache
+) {
 
   val falsePositiveSources: List[String] = List[String](
     "Data.Sensitive.OnlineIdentifiers.Cookies",
@@ -48,9 +53,10 @@ class DataflowExporter(cpg: Cpg, dataflowsMap: Map[String, Path], taggerCache: T
   def getFlowByType(
     sinkSubCategory: String,
     sinkNodeTypes: Set[String],
-    ruleCache: RuleCache
+    ruleCache: RuleCache,
+    dataFlowCache: DataFlowCache
   ): Set[DataFlowSubCategoryModel] = {
-    val dataflowModelFilteredByType = DataFlowCache.getDataflow.filter(dataflowModel =>
+    val dataflowModelFilteredByType = dataFlowCache.getDataflow.filter(dataflowModel =>
       dataflowModel.sinkSubCategory.equals(sinkSubCategory) && sinkNodeTypes.contains(dataflowModel.sinkNodeType)
     )
     val dataflowModelBySourceId = dataflowModelFilteredByType.groupBy(_.sourceId)

--- a/src/main/scala/ai/privado/exporter/PolicyAndThreatExporter.scala
+++ b/src/main/scala/ai/privado/exporter/PolicyAndThreatExporter.scala
@@ -23,7 +23,7 @@
 
 package ai.privado.exporter
 
-import ai.privado.cache.{AppCache, RuleCache, TaggerCache}
+import ai.privado.cache.{AppCache, DataFlowCache, RuleCache, TaggerCache}
 import ai.privado.languageEngine.java.threatEngine.ThreatEngineExecutor
 import ai.privado.model.exporter.{ViolationDataFlowModel, ViolationModel, ViolationProcessingModel}
 import ai.privado.policyEngine.PolicyExecutor
@@ -34,13 +34,19 @@ import org.slf4j.LoggerFactory
 
 import scala.collection.mutable
 
-class PolicyAndThreatExporter(cpg: Cpg, ruleCache: RuleCache, dataflows: Map[String, Path], taggerCache: TaggerCache) {
+class PolicyAndThreatExporter(
+  cpg: Cpg,
+  ruleCache: RuleCache,
+  dataflows: Map[String, Path],
+  taggerCache: TaggerCache,
+  dataFlowCache: DataFlowCache
+) {
 
   private val logger = LoggerFactory.getLogger(getClass)
 
   def getViolations(repoPath: String): List[ViolationModel] = {
-    val policyExecutor = new PolicyExecutor(cpg, dataflows, AppCache.repoName, ruleCache)
-    val threatExecutor = new ThreatEngineExecutor(cpg, dataflows, repoPath, ruleCache, taggerCache)
+    val policyExecutor = new PolicyExecutor(cpg, dataFlowCache, AppCache.repoName, ruleCache)
+    val threatExecutor = new ThreatEngineExecutor(cpg, dataflows, repoPath, ruleCache, taggerCache, dataFlowCache)
 
     try {
       threatExecutor.getProcessingViolations(ruleCache.getAllThreat) ++ policyExecutor.getProcessingViolations

--- a/src/main/scala/ai/privado/languageEngine/default/processor/DefaultProcessor.scala
+++ b/src/main/scala/ai/privado/languageEngine/default/processor/DefaultProcessor.scala
@@ -62,7 +62,8 @@ object DefaultProcessor {
     xtocpg: Try[codepropertygraph.Cpg],
     ruleCache: RuleCache,
     sourceRepoLocation: String,
-    dataFlowCache: DataFlowCache
+    dataFlowCache: DataFlowCache,
+    auditCache: AuditCache
   ): Either[String, Unit] = {
     xtocpg match {
       case Success(cpg) => {
@@ -81,7 +82,7 @@ object DefaultProcessor {
             s"${TimeMetric.getNewTime()} - Tagging source code is done in \t\t\t- ${TimeMetric.setNewTimeToLastAndGetTimeDiff()}"
           )
           println(s"${Calendar.getInstance().getTime} - Finding source to sink flow of data...")
-          val dataflowMap = cpg.dataflow(ScanProcessor.config, ruleCache, dataFlowCache)
+          val dataflowMap = cpg.dataflow(ScanProcessor.config, ruleCache, dataFlowCache, auditCache)
           println(s"${TimeMetric.getNewTime()} - Finding source to sink flow is done in \t\t- ${TimeMetric
               .setNewTimeToLastAndGetTimeDiff()} - Processed final flows - ${dataFlowCache.finalDataflow.size}")
           println(
@@ -143,7 +144,8 @@ object DefaultProcessor {
   def createDefaultCpg(
     ruleCache: RuleCache,
     sourceRepoLocation: String,
-    dataFlowCache: DataFlowCache
+    dataFlowCache: DataFlowCache,
+    auditCache: AuditCache
   ): Either[String, Unit] = {
     println(s"${Calendar.getInstance().getTime} - Processing source code using default pass")
 
@@ -157,7 +159,7 @@ object DefaultProcessor {
 
     val xtocpg = withNewEmptyCpg(cpgOutputPath, cpgconfig: JavaConfig) { (cpg, config) => {} }
 
-    val msg = processCPG(xtocpg, ruleCache, sourceRepoLocation, dataFlowCache)
+    val msg = processCPG(xtocpg, ruleCache, sourceRepoLocation, dataFlowCache, auditCache)
     msg
   }
 }

--- a/src/main/scala/ai/privado/languageEngine/default/processor/DefaultProcessor.scala
+++ b/src/main/scala/ai/privado/languageEngine/default/processor/DefaultProcessor.scala
@@ -61,7 +61,8 @@ object DefaultProcessor {
   private def processCPG(
     xtocpg: Try[codepropertygraph.Cpg],
     ruleCache: RuleCache,
-    sourceRepoLocation: String
+    sourceRepoLocation: String,
+    dataFlowCache: DataFlowCache
   ): Either[String, Unit] = {
     xtocpg match {
       case Success(cpg) => {
@@ -80,9 +81,9 @@ object DefaultProcessor {
             s"${TimeMetric.getNewTime()} - Tagging source code is done in \t\t\t- ${TimeMetric.setNewTimeToLastAndGetTimeDiff()}"
           )
           println(s"${Calendar.getInstance().getTime} - Finding source to sink flow of data...")
-          val dataflowMap = cpg.dataflow(ScanProcessor.config, ruleCache)
+          val dataflowMap = cpg.dataflow(ScanProcessor.config, ruleCache, dataFlowCache)
           println(s"${TimeMetric.getNewTime()} - Finding source to sink flow is done in \t\t- ${TimeMetric
-              .setNewTimeToLastAndGetTimeDiff()} - Processed final flows - ${DataFlowCache.finalDataflow.size}")
+              .setNewTimeToLastAndGetTimeDiff()} - Processed final flows - ${dataFlowCache.finalDataflow.size}")
           println(
             s"\n\n${TimeMetric.getNewTime()} - Code scanning is done in \t\t\t- ${TimeMetric.getTheTotalTime()}\n\n"
           )
@@ -90,7 +91,15 @@ object DefaultProcessor {
           MetricHandler.setScanStatus(true)
           val errorMsg = new ListBuffer[String]()
           // Exporting Results
-          JSONExporter.fileExport(cpg, outputFileName, sourceRepoLocation, dataflowMap, ruleCache, taggerCache) match {
+          JSONExporter.fileExport(
+            cpg,
+            outputFileName,
+            sourceRepoLocation,
+            dataflowMap,
+            ruleCache,
+            taggerCache,
+            dataFlowCache
+          ) match {
             case Left(err) =>
               MetricHandler.otherErrorsOrWarnings.addOne(err)
               errorMsg += err
@@ -131,7 +140,11 @@ object DefaultProcessor {
     * @param lang
     * @return
     */
-  def createDefaultCpg(ruleCache: RuleCache, sourceRepoLocation: String): Either[String, Unit] = {
+  def createDefaultCpg(
+    ruleCache: RuleCache,
+    sourceRepoLocation: String,
+    dataFlowCache: DataFlowCache
+  ): Either[String, Unit] = {
     println(s"${Calendar.getInstance().getTime} - Processing source code using default pass")
 
     // Create the .privado folder if not present
@@ -144,7 +157,7 @@ object DefaultProcessor {
 
     val xtocpg = withNewEmptyCpg(cpgOutputPath, cpgconfig: JavaConfig) { (cpg, config) => {} }
 
-    val msg = processCPG(xtocpg, ruleCache, sourceRepoLocation)
+    val msg = processCPG(xtocpg, ruleCache, sourceRepoLocation, dataFlowCache)
     msg
   }
 }

--- a/src/main/scala/ai/privado/languageEngine/default/tagger/PrivadoTagger.scala
+++ b/src/main/scala/ai/privado/languageEngine/default/tagger/PrivadoTagger.scala
@@ -1,11 +1,11 @@
 package ai.privado.languageEngine.default.tagger
 
-import ai.privado.cache.{RuleCache, TaggerCache}
+import ai.privado.cache.{DataFlowCache, RuleCache, TaggerCache}
 import ai.privado.tagger.source.SqlQueryTagger
 import ai.privado.tagger.PrivadoBaseTagger
 import io.shiftleft.codepropertygraph.generated.Cpg
 import io.shiftleft.codepropertygraph.generated.nodes.Tag
-import io.shiftleft.semanticcpg.language._
+import io.shiftleft.semanticcpg.language.*
 import org.slf4j.LoggerFactory
 import overflowdb.traversal.Traversal
 

--- a/src/main/scala/ai/privado/languageEngine/java/processor/JavaProcessor.scala
+++ b/src/main/scala/ai/privado/languageEngine/java/processor/JavaProcessor.scala
@@ -64,7 +64,8 @@ object JavaProcessor {
   private def processCPG(
     xtocpg: Try[codepropertygraph.Cpg],
     ruleCache: RuleCache,
-    sourceRepoLocation: String
+    sourceRepoLocation: String,
+    dataFlowCache: DataFlowCache
   ): Either[String, Unit] = {
     xtocpg match {
       case Success(cpg) => {
@@ -97,14 +98,14 @@ object JavaProcessor {
           // Run tagger
           println(s"${Calendar.getInstance().getTime} - Tagging source code with rules...")
           val taggerCache = new TaggerCache
-          cpg.runTagger(ruleCache, taggerCache, ScanProcessor.config)
+          cpg.runTagger(ruleCache, taggerCache, ScanProcessor.config, dataFlowCache)
           println(
             s"${TimeMetric.getNewTime()} - Tagging source code is done in \t\t\t- ${TimeMetric.setNewTimeToLastAndGetTimeDiff()}"
           )
           println(s"${Calendar.getInstance().getTime} - Finding source to sink flow of data...")
-          val dataflowMap = cpg.dataflow(ScanProcessor.config, ruleCache)
+          val dataflowMap = cpg.dataflow(ScanProcessor.config, ruleCache, dataFlowCache)
           println(s"${TimeMetric.getNewTime()} - Finding source to sink flow is done in \t\t- ${TimeMetric
-              .setNewTimeToLastAndGetTimeDiff()} - Processed final flows - ${DataFlowCache.finalDataflow.size}")
+              .setNewTimeToLastAndGetTimeDiff()} - Processed final flows - ${dataFlowCache.finalDataflow.size}")
           println(
             s"\n\n${TimeMetric.getNewTime()} - Code scanning is done in \t\t\t- ${TimeMetric.getTheTotalTime()}\n\n"
           )
@@ -112,7 +113,15 @@ object JavaProcessor {
           MetricHandler.setScanStatus(true)
           val errorMsg = new ListBuffer[String]()
           // Exporting Results
-          JSONExporter.fileExport(cpg, outputFileName, sourceRepoLocation, dataflowMap, ruleCache, taggerCache) match {
+          JSONExporter.fileExport(
+            cpg,
+            outputFileName,
+            sourceRepoLocation,
+            dataflowMap,
+            ruleCache,
+            taggerCache,
+            dataFlowCache
+          ) match {
             case Left(err) =>
               MetricHandler.otherErrorsOrWarnings.addOne(err)
               errorMsg += err
@@ -151,7 +160,7 @@ object JavaProcessor {
             JSONExporter.UnresolvedFlowFileExport(
               outputUnresolvedFilename,
               sourceRepoLocation,
-              DataFlowCache.getJsonFormatDataFlow(AuditCache.unfilteredFlow)
+              dataFlowCache.getJsonFormatDataFlow(AuditCache.unfilteredFlow)
             ) match {
               case Left(err) =>
                 MetricHandler.otherErrorsOrWarnings.addOne(err)
@@ -168,7 +177,7 @@ object JavaProcessor {
             JSONExporter.IntermediateFileExport(
               outputIntermediateFileName,
               sourceRepoLocation,
-              DataFlowCache.getJsonFormatDataFlow(DataFlowCache.getIntermediateDataFlow())
+              dataFlowCache.getJsonFormatDataFlow(dataFlowCache.getIntermediateDataFlow())
             ) match {
               case Left(err) =>
                 MetricHandler.otherErrorsOrWarnings.addOne(err)
@@ -208,7 +217,12 @@ object JavaProcessor {
     * @param lang
     * @return
     */
-  def createJavaCpg(ruleCache: RuleCache, sourceRepoLocation: String, lang: String): Either[String, Unit] = {
+  def createJavaCpg(
+    ruleCache: RuleCache,
+    sourceRepoLocation: String,
+    lang: String,
+    dataFlowCache: DataFlowCache
+  ): Either[String, Unit] = {
     println(s"${Calendar.getInstance().getTime} - Processing source code using ${Languages.JAVASRC} engine")
     if (!config.skipDownloadDependencies)
       println(s"${Calendar.getInstance().getTime} - Downloading dependencies and Parsing source code...")
@@ -248,7 +262,7 @@ object JavaProcessor {
       cpg
     }
 
-    val msg = processCPG(xtocpg, ruleCache, sourceRepoLocation)
+    val msg = processCPG(xtocpg, ruleCache, sourceRepoLocation, dataFlowCache)
 
     // Delete the delomboked directory after scanning is completed
     if (AppCache.isLombokPresent) {

--- a/src/main/scala/ai/privado/languageEngine/java/tagger/PrivadoTagger.scala
+++ b/src/main/scala/ai/privado/languageEngine/java/tagger/PrivadoTagger.scala
@@ -23,7 +23,7 @@
 
 package ai.privado.languageEngine.java.tagger
 
-import ai.privado.cache.{RuleCache, TaggerCache}
+import ai.privado.cache.{DataFlowCache, RuleCache, TaggerCache}
 import ai.privado.entrypoint.{PrivadoInput, ScanProcessor}
 import ai.privado.languageEngine.java.feeder.StorageInheritRule
 import ai.privado.languageEngine.java.passes.read.{
@@ -52,7 +52,8 @@ class PrivadoTagger(cpg: Cpg) extends PrivadoBaseTagger {
   override def runTagger(
     ruleCache: RuleCache,
     taggerCache: TaggerCache,
-    privadoInputConfig: PrivadoInput
+    privadoInputConfig: PrivadoInput,
+    dataFlowCache: DataFlowCache
   ): Traversal[Tag] = {
 
     logger.info("Starting tagging")
@@ -76,13 +77,13 @@ class PrivadoTagger(cpg: Cpg) extends PrivadoBaseTagger {
       StorageInheritRule.rules.foreach(ruleCache.setRuleInfo)
       new InheritMethodTagger(cpg, ruleCache).createAndApply()
       new MessagingConsumerCustomTagger(cpg, ruleCache).createAndApply()
-      new MessagingConsumerReadPass(cpg, taggerCache).createAndApply()
+      new MessagingConsumerReadPass(cpg, taggerCache, dataFlowCache).createAndApply()
     }
 
     new DatabaseQueryReadPass(cpg, ruleCache, taggerCache, privadoInputConfig, EntityMapper.getClassTableMapping(cpg))
       .createAndApply()
 
-    new DatabaseRepositoryReadPass(cpg, taggerCache).createAndApply()
+    new DatabaseRepositoryReadPass(cpg, taggerCache, dataFlowCache).createAndApply()
 
     new CollectionTagger(cpg, ruleCache).createAndApply()
 

--- a/src/main/scala/ai/privado/languageEngine/java/threatEngine/CookieConsentMgmtModule.scala
+++ b/src/main/scala/ai/privado/languageEngine/java/threatEngine/CookieConsentMgmtModule.scala
@@ -1,13 +1,13 @@
 package ai.privado.languageEngine.java.threatEngine
 
-import ai.privado.cache.{AppCache, RuleCache}
+import ai.privado.cache.{AppCache, DataFlowCache, RuleCache}
 import ai.privado.languageEngine.java.threatEngine.ThreatUtility.hasDataElements
 import ai.privado.model.PolicyOrThreat
-import ai.privado.model.exporter.{ViolationProcessingModel}
+import ai.privado.model.exporter.ViolationProcessingModel
 import ai.privado.policyEngine.PolicyExecutor
 import io.joern.dataflowengineoss.language.Path
 import io.shiftleft.codepropertygraph.generated.Cpg
-import io.shiftleft.semanticcpg.language._
+import io.shiftleft.semanticcpg.language.*
 import org.slf4j.LoggerFactory
 
 import scala.util.Try
@@ -26,10 +26,11 @@ object CookieConsentMgmtModule {
     threat: PolicyOrThreat,
     cpg: Cpg,
     dataflows: Map[String, Path],
-    ruleCache: RuleCache
+    ruleCache: RuleCache,
+    dataFlowCache: DataFlowCache
   ): Try[(Boolean, List[ViolationProcessingModel])] = Try {
     if (hasDataElements(cpg)) {
-      val policyExecutor = new PolicyExecutor(cpg, dataflows, AppCache.repoName, ruleCache)
+      val policyExecutor = new PolicyExecutor(cpg, dataFlowCache, AppCache.repoName, ruleCache)
       val violatingFlows = policyExecutor.getViolatingOccurrencesForPolicy(threat)
 
       val consentMgmtModulePresent      = cpg.call.methodFullName(getCookieConsentMgmtModulePattern(threat.config))

--- a/src/main/scala/ai/privado/languageEngine/java/threatEngine/DataLeakageToLogs.scala
+++ b/src/main/scala/ai/privado/languageEngine/java/threatEngine/DataLeakageToLogs.scala
@@ -23,7 +23,7 @@
 
 package ai.privado.languageEngine.java.threatEngine
 
-import ai.privado.cache.{AppCache, RuleCache}
+import ai.privado.cache.{AppCache, DataFlowCache, RuleCache}
 import ai.privado.model.exporter.ViolationDataFlowModel
 import ai.privado.policyEngine.PolicyExecutor
 import io.shiftleft.codepropertygraph.generated.Cpg
@@ -49,13 +49,14 @@ object DataLeakageToLogs {
     threat: PolicyOrThreat,
     cpg: Cpg,
     dataflows: Map[String, Path],
-    ruleCache: RuleCache
+    ruleCache: RuleCache,
+    dataFlowCache: DataFlowCache
   ): Try[(Boolean, List[ViolationDataFlowModel])] = Try {
     // use policy executor to directly process existing flows
     // we already have this implementation as part of policy enforcement
     // threat being type of suggestive policy
     // might restructure this in future and have central utilities consumed by both
-    val policyExecutor = new PolicyExecutor(cpg, dataflows, AppCache.repoName, ruleCache)
+    val policyExecutor = new PolicyExecutor(cpg, dataFlowCache, AppCache.repoName, ruleCache)
     val violatingFlows = policyExecutor.getViolatingFlowsForPolicy(threat)
 
     // violation if empty

--- a/src/main/scala/ai/privado/languageEngine/java/threatEngine/DataLeakageToNotifications.scala
+++ b/src/main/scala/ai/privado/languageEngine/java/threatEngine/DataLeakageToNotifications.scala
@@ -23,7 +23,7 @@
 
 package ai.privado.languageEngine.java.threatEngine
 
-import ai.privado.cache.{AppCache, RuleCache}
+import ai.privado.cache.{AppCache, DataFlowCache, RuleCache}
 import ai.privado.model.exporter.ViolationDataFlowModel
 import ai.privado.model.PolicyOrThreat
 import ai.privado.policyEngine.PolicyExecutor
@@ -49,13 +49,14 @@ object DataLeakageToNotifications {
     threat: PolicyOrThreat,
     cpg: Cpg,
     dataflows: Map[String, Path],
-    ruleCache: RuleCache
+    ruleCache: RuleCache,
+    dataFlowCache: DataFlowCache
   ): Try[(Boolean, List[ViolationDataFlowModel])] = Try {
     // use policy executor to directly process existing flows (we have rule for notifications)
     // we already have this implementation as part of policy enforcement
     // threat being type of suggestive policy
     // might restructure this in future and have central utilities consumed by both
-    val policyExecutor = new PolicyExecutor(cpg, dataflows, AppCache.repoName, ruleCache)
+    val policyExecutor = new PolicyExecutor(cpg, dataFlowCache, AppCache.repoName, ruleCache)
     val violatingFlows = policyExecutor.getViolatingFlowsForPolicy(threat)
 
     // violation if empty

--- a/src/main/scala/ai/privado/languageEngine/java/threatEngine/ThreatEngineExecutor.scala
+++ b/src/main/scala/ai/privado/languageEngine/java/threatEngine/ThreatEngineExecutor.scala
@@ -23,11 +23,11 @@
 
 package ai.privado.languageEngine.java.threatEngine
 
-import ai.privado.cache.{RuleCache, TaggerCache}
+import ai.privado.cache.{DataFlowCache, RuleCache, TaggerCache}
 import ai.privado.exporter.ExporterUtility
 import ai.privado.model.exporter.ViolationModel
 import ai.privado.model.PolicyOrThreat
-import ai.privado.utility.Utilities._
+import ai.privado.utility.Utilities.*
 import io.joern.dataflowengineoss.language.Path
 import io.shiftleft.codepropertygraph.generated.Cpg
 import org.slf4j.LoggerFactory
@@ -39,7 +39,8 @@ class ThreatEngineExecutor(
   dataflows: Map[String, Path],
   repoPath: String,
   ruleCache: RuleCache,
-  taggerCache: TaggerCache
+  taggerCache: TaggerCache,
+  dataFlowCache: DataFlowCache
 ) {
 
   private val logger = LoggerFactory.getLogger(getClass)
@@ -127,7 +128,7 @@ class ThreatEngineExecutor(
         }
 
       case "PrivadoPolicy.CookieConsent.IsCookieConsentMgmtModuleImplemented" =>
-        CookieConsentMgmtModule.getViolations(threat, cpg, dataflows, ruleCache) match {
+        CookieConsentMgmtModule.getViolations(threat, cpg, dataflows, ruleCache, dataFlowCache) match {
           case Success(res) => Some(res)
           case Failure(e) => {
             logger.debug(s"Error for ${threatId}: ${e}")
@@ -220,7 +221,7 @@ class ThreatEngineExecutor(
 
     val violationResponse = threatId match {
       case "Threats.Sharing.isDataExposedToThirdPartiesViaNotification" if isAndroidRepo =>
-        DataLeakageToNotifications.getViolations(threat, cpg, dataflows, ruleCache) match {
+        DataLeakageToNotifications.getViolations(threat, cpg, dataflows, ruleCache, dataFlowCache) match {
           case Success(res) => Some(res)
           case Failure(e) => {
             logger.debug(s"Error for ${threatId}: ${e}")
@@ -228,7 +229,7 @@ class ThreatEngineExecutor(
           }
         }
       case "Threats.Leakage.isDataLeakingToLog" =>
-        DataLeakageToLogs.getViolations(threat, cpg, dataflows, ruleCache) match {
+        DataLeakageToLogs.getViolations(threat, cpg, dataflows, ruleCache, dataFlowCache) match {
           case Success(res) => Some(res)
           case Failure(e) => {
             logger.debug(s"Error for ${threatId}: ${e}")

--- a/src/main/scala/ai/privado/languageEngine/javascript/tagger/PrivadoTagger.scala
+++ b/src/main/scala/ai/privado/languageEngine/javascript/tagger/PrivadoTagger.scala
@@ -23,7 +23,7 @@
 
 package ai.privado.languageEngine.javascript.tagger
 
-import ai.privado.cache.{RuleCache, TaggerCache}
+import ai.privado.cache.{DataFlowCache, RuleCache, TaggerCache}
 import ai.privado.entrypoint.{PrivadoInput, TimeMetric}
 import ai.privado.languageEngine.javascript.config.JSDBConfigTagger
 import ai.privado.languageEngine.javascript.passes.read.GraphqlQueryParserPass
@@ -47,7 +47,8 @@ class PrivadoTagger(cpg: Cpg) extends PrivadoBaseTagger {
   override def runTagger(
     ruleCache: RuleCache,
     taggerCache: TaggerCache,
-    privadoInputConfig: PrivadoInput
+    privadoInputConfig: PrivadoInput,
+    dataFlowCache: DataFlowCache
   ): Traversal[Tag] = {
 
     logger.info("Starting tagging")

--- a/src/main/scala/ai/privado/languageEngine/python/processor/PythonProcessor.scala
+++ b/src/main/scala/ai/privado/languageEngine/python/processor/PythonProcessor.scala
@@ -40,7 +40,8 @@ object PythonProcessor {
     xtocpg: Try[codepropertygraph.Cpg],
     ruleCache: RuleCache,
     sourceRepoLocation: String,
-    dataFlowCache: DataFlowCache
+    dataFlowCache: DataFlowCache,
+    auditCache: AuditCache
   ): Either[String, Unit] = {
     xtocpg match {
       case Success(cpg) => {
@@ -99,7 +100,7 @@ object PythonProcessor {
           )
 
           println(s"${Calendar.getInstance().getTime} - Finding source to sink flow of data...")
-          val dataflowMap = cpg.dataflow(ScanProcessor.config, ruleCache, dataFlowCache)
+          val dataflowMap = cpg.dataflow(ScanProcessor.config, ruleCache, dataFlowCache, auditCache)
           println(s"\n${TimeMetric.getNewTime()} - Finding source to sink flow is done in \t\t- ${TimeMetric
               .setNewTimeToLastAndGetTimeDiff()} - Processed final flows - ${dataFlowCache.finalDataflow.size}")
           println(s"\n${TimeMetric.getNewTime()} - Code scanning is done in \t\t\t- ${TimeMetric.getTheTotalTime()}\n")
@@ -131,7 +132,7 @@ object PythonProcessor {
           if (ScanProcessor.config.generateAuditReport) {
             ExcelExporter.auditExport(
               outputAuditFileName,
-              AuditReportEntryPoint.getAuditWorkbookPy(),
+              AuditReportEntryPoint.getAuditWorkbookPy(auditCache),
               sourceRepoLocation
             ) match {
               case Left(err) =>
@@ -147,7 +148,7 @@ object PythonProcessor {
             JSONExporter.UnresolvedFlowFileExport(
               outputUnresolvedFilename,
               sourceRepoLocation,
-              dataFlowCache.getJsonFormatDataFlow(AuditCache.unfilteredFlow)
+              dataFlowCache.getJsonFormatDataFlow(auditCache.unfilteredFlow)
             ) match {
               case Left(err) =>
                 MetricHandler.otherErrorsOrWarnings.addOne(err)
@@ -209,7 +210,8 @@ object PythonProcessor {
     ruleCache: RuleCache,
     sourceRepoLocation: String,
     lang: String,
-    dataFlowCache: DataFlowCache
+    dataFlowCache: DataFlowCache,
+    auditCache: AuditCache
   ): Either[String, Unit] = {
 
     println(s"${Calendar.getInstance().getTime} - Processing source code using $lang engine")
@@ -232,7 +234,7 @@ object PythonProcessor {
       )
       cpg
     }
-    processCPG(xtocpg, ruleCache, sourceRepoLocation, dataFlowCache)
+    processCPG(xtocpg, ruleCache, sourceRepoLocation, dataFlowCache, auditCache)
   }
 
 }

--- a/src/main/scala/ai/privado/languageEngine/python/tagger/PrivadoTagger.scala
+++ b/src/main/scala/ai/privado/languageEngine/python/tagger/PrivadoTagger.scala
@@ -1,6 +1,6 @@
 package ai.privado.languageEngine.python.tagger
 
-import ai.privado.cache.{RuleCache, TaggerCache}
+import ai.privado.cache.{DataFlowCache, RuleCache, TaggerCache}
 import ai.privado.entrypoint.PrivadoInput
 import ai.privado.languageEngine.python.config.PythonDBConfigTagger
 import ai.privado.languageEngine.python.feeder.StorageInheritRule
@@ -24,7 +24,8 @@ class PrivadoTagger(cpg: Cpg) extends PrivadoBaseTagger {
   override def runTagger(
     ruleCache: RuleCache,
     taggerCache: TaggerCache,
-    privadoInputConfig: PrivadoInput
+    privadoInputConfig: PrivadoInput,
+    dataFlowCache: DataFlowCache
   ): Traversal[Tag] = {
 
     logger.info("Starting tagging")

--- a/src/main/scala/ai/privado/languageEngine/ruby/processor/RubyProcessor.scala
+++ b/src/main/scala/ai/privado/languageEngine/ruby/processor/RubyProcessor.scala
@@ -23,7 +23,7 @@
 
 package ai.privado.languageEngine.ruby.processor
 
-import ai.privado.cache.{AppCache, DataFlowCache, RuleCache, TaggerCache}
+import ai.privado.cache.{AppCache, AuditCache, DataFlowCache, RuleCache, TaggerCache}
 import ai.privado.entrypoint.ScanProcessor.config
 import ai.privado.entrypoint.{ScanProcessor, TimeMetric}
 import ai.privado.exporter.JSONExporter
@@ -84,7 +84,8 @@ object RubyProcessor {
     xtocpg: Try[codepropertygraph.Cpg],
     ruleCache: RuleCache,
     sourceRepoLocation: String,
-    dataFlowCache: DataFlowCache
+    dataFlowCache: DataFlowCache,
+    auditCache: AuditCache
   ): Either[String, Unit] = {
     xtocpg match {
       case Success(cpg) =>
@@ -172,7 +173,7 @@ object RubyProcessor {
           val taggerCache = new TaggerCache
           cpg.runTagger(ruleCache, taggerCache, privadoInputConfig = ScanProcessor.config.copy(), dataFlowCache)
           println(s"${Calendar.getInstance().getTime} - Finding source to sink flow of data...")
-          val dataflowMap = cpg.dataflow(ScanProcessor.config, ruleCache, dataFlowCache)
+          val dataflowMap = cpg.dataflow(ScanProcessor.config, ruleCache, dataFlowCache, auditCache)
           println(s"${Calendar.getInstance().getTime} - No of flows found -> ${dataflowMap.size}")
           println(
             s"\n\n${TimeMetric.getNewTime()} - Code scanning is done in \t\t\t- ${TimeMetric.getTheTotalTime()}\n\n"
@@ -301,7 +302,8 @@ object RubyProcessor {
     ruleCache: RuleCache,
     sourceRepoLocation: String,
     lang: String,
-    dataFlowCache: DataFlowCache
+    dataFlowCache: DataFlowCache,
+    auditCache: AuditCache
   ): Either[String, Unit] = {
     logger.warn("Warnings are getting printed")
     println(s"${Calendar.getInstance().getTime} - Processing source code using $lang engine")
@@ -339,7 +341,7 @@ object RubyProcessor {
     println(
       s"${TimeMetric.getNewTime()} - Parsing source code done in \t\t\t\t\t\t- ${TimeMetric.setNewTimeToLastAndGetTimeDiff()}"
     )
-    processCPG(xtocpg, ruleCache, sourceRepoLocation, dataFlowCache)
+    processCPG(xtocpg, ruleCache, sourceRepoLocation, dataFlowCache, auditCache)
 
   }
 

--- a/src/main/scala/ai/privado/languageEngine/ruby/processor/RubyProcessor.scala
+++ b/src/main/scala/ai/privado/languageEngine/ruby/processor/RubyProcessor.scala
@@ -23,7 +23,7 @@
 
 package ai.privado.languageEngine.ruby.processor
 
-import ai.privado.cache.{AppCache, RuleCache, TaggerCache}
+import ai.privado.cache.{AppCache, DataFlowCache, RuleCache, TaggerCache}
 import ai.privado.entrypoint.ScanProcessor.config
 import ai.privado.entrypoint.{ScanProcessor, TimeMetric}
 import ai.privado.exporter.JSONExporter
@@ -83,7 +83,8 @@ object RubyProcessor {
   private def processCPG(
     xtocpg: Try[codepropertygraph.Cpg],
     ruleCache: RuleCache,
-    sourceRepoLocation: String
+    sourceRepoLocation: String,
+    dataFlowCache: DataFlowCache
   ): Either[String, Unit] = {
     xtocpg match {
       case Success(cpg) =>
@@ -169,9 +170,9 @@ object RubyProcessor {
           // Run tagger
           println(s"${Calendar.getInstance().getTime} - Tagging source code with rules...")
           val taggerCache = new TaggerCache
-          cpg.runTagger(ruleCache, taggerCache, privadoInputConfig = ScanProcessor.config.copy())
+          cpg.runTagger(ruleCache, taggerCache, privadoInputConfig = ScanProcessor.config.copy(), dataFlowCache)
           println(s"${Calendar.getInstance().getTime} - Finding source to sink flow of data...")
-          val dataflowMap = cpg.dataflow(ScanProcessor.config, ruleCache)
+          val dataflowMap = cpg.dataflow(ScanProcessor.config, ruleCache, dataFlowCache)
           println(s"${Calendar.getInstance().getTime} - No of flows found -> ${dataflowMap.size}")
           println(
             s"\n\n${TimeMetric.getNewTime()} - Code scanning is done in \t\t\t- ${TimeMetric.getTheTotalTime()}\n\n"
@@ -179,7 +180,15 @@ object RubyProcessor {
           println(s"${Calendar.getInstance().getTime} - Brewing result...")
           MetricHandler.setScanStatus(true)
           // Exporting
-          JSONExporter.fileExport(cpg, outputFileName, sourceRepoLocation, dataflowMap, ruleCache) match {
+          JSONExporter.fileExport(
+            cpg,
+            outputFileName,
+            sourceRepoLocation,
+            dataflowMap,
+            ruleCache,
+            taggerCache,
+            dataFlowCache
+          ) match {
             case Left(err) =>
               MetricHandler.otherErrorsOrWarnings.addOne(err)
               Left(err)
@@ -288,7 +297,12 @@ object RubyProcessor {
     * @param lang
     * @return
     */
-  def createRubyCpg(ruleCache: RuleCache, sourceRepoLocation: String, lang: String): Either[String, Unit] = {
+  def createRubyCpg(
+    ruleCache: RuleCache,
+    sourceRepoLocation: String,
+    lang: String,
+    dataFlowCache: DataFlowCache
+  ): Either[String, Unit] = {
     logger.warn("Warnings are getting printed")
     println(s"${Calendar.getInstance().getTime} - Processing source code using $lang engine")
     println(s"${Calendar.getInstance().getTime} - Parsing source code...")
@@ -325,7 +339,7 @@ object RubyProcessor {
     println(
       s"${TimeMetric.getNewTime()} - Parsing source code done in \t\t\t\t\t\t- ${TimeMetric.setNewTimeToLastAndGetTimeDiff()}"
     )
-    processCPG(xtocpg, ruleCache, sourceRepoLocation)
+    processCPG(xtocpg, ruleCache, sourceRepoLocation, dataFlowCache)
 
   }
 

--- a/src/main/scala/ai/privado/languageEngine/ruby/tagger/PrivadoTagger.scala
+++ b/src/main/scala/ai/privado/languageEngine/ruby/tagger/PrivadoTagger.scala
@@ -23,7 +23,7 @@
 
 package ai.privado.languageEngine.ruby.tagger
 
-import ai.privado.cache.{RuleCache, TaggerCache}
+import ai.privado.cache.{DataFlowCache, RuleCache, TaggerCache}
 import ai.privado.entrypoint.{PrivadoInput, ScanProcessor, TimeMetric}
 import ai.privado.languageEngine.ruby.tagger.collection.CollectionTagger
 import ai.privado.languageEngine.ruby.config.RubyDBConfigTagger
@@ -46,7 +46,8 @@ class PrivadoTagger(cpg: Cpg) extends PrivadoBaseTagger {
   override def runTagger(
     ruleCache: RuleCache,
     taggerCache: TaggerCache,
-    privadoInputConfig: PrivadoInput
+    privadoInputConfig: PrivadoInput,
+    dataFlowCache: DataFlowCache
   ): Traversal[Tag] = {
     logger.info("Starting tagging")
     new LiteralTagger(cpg, ruleCache).createAndApply()

--- a/src/main/scala/ai/privado/policyEngine/PolicyExecutor.scala
+++ b/src/main/scala/ai/privado/policyEngine/PolicyExecutor.scala
@@ -31,14 +31,14 @@ import ai.privado.model.{Constants, PolicyAction, PolicyOrThreat}
 import io.joern.dataflowengineoss.language.Path
 import io.shiftleft.codepropertygraph.generated.Cpg
 import io.shiftleft.codepropertygraph.generated.nodes.{CfgNode, Tag}
-import io.shiftleft.semanticcpg.language._
+import io.shiftleft.semanticcpg.language.*
 import org.slf4j.LoggerFactory
 import overflowdb.traversal.Traversal
 
 import scala.collection.mutable
 import scala.util.{Failure, Success, Try}
 
-class PolicyExecutor(cpg: Cpg, dataflowMap: Map[String, Path], repoName: String, ruleCache: RuleCache) {
+class PolicyExecutor(cpg: Cpg, dataflowCache: DataFlowCache, repoName: String, ruleCache: RuleCache) {
 
   private val logger = LoggerFactory.getLogger(getClass)
 
@@ -152,11 +152,11 @@ class PolicyExecutor(cpg: Cpg, dataflowMap: Map[String, Path], repoName: String,
   }
 
   private def getDataflowBySourceIdMapping = {
-    DataFlowCache.getDataflow.groupBy(_.sourceId).map(entrySet => (entrySet._1, entrySet._2.map(_.pathId)))
+    dataflowCache.getDataflow.groupBy(_.sourceId).map(entrySet => (entrySet._1, entrySet._2.map(_.pathId)))
   }
 
   private def getDataflowBySinkIdMapping = {
-    DataFlowCache.getDataflow.groupBy(_.sinkId).map(entrySet => (entrySet._1, entrySet._2.map(_.pathId)))
+    dataflowCache.getDataflow.groupBy(_.sinkId).map(entrySet => (entrySet._1, entrySet._2.map(_.pathId)))
   }
 
   private def getSourcesMatchingRegex(policy: PolicyOrThreat): Set[String] = {

--- a/src/main/scala/ai/privado/policyEngine/PolicyExecutor.scala
+++ b/src/main/scala/ai/privado/policyEngine/PolicyExecutor.scala
@@ -38,7 +38,7 @@ import overflowdb.traversal.Traversal
 import scala.collection.mutable
 import scala.util.{Failure, Success, Try}
 
-class PolicyExecutor(cpg: Cpg, dataflowCache: DataFlowCache, repoName: String, ruleCache: RuleCache) {
+class PolicyExecutor(cpg: Cpg, dataFlowCache: DataFlowCache, repoName: String, ruleCache: RuleCache) {
 
   private val logger = LoggerFactory.getLogger(getClass)
 
@@ -152,11 +152,11 @@ class PolicyExecutor(cpg: Cpg, dataflowCache: DataFlowCache, repoName: String, r
   }
 
   private def getDataflowBySourceIdMapping = {
-    dataflowCache.getDataflow.groupBy(_.sourceId).map(entrySet => (entrySet._1, entrySet._2.map(_.pathId)))
+    dataFlowCache.getDataflow.groupBy(_.sourceId).map(entrySet => (entrySet._1, entrySet._2.map(_.pathId)))
   }
 
   private def getDataflowBySinkIdMapping = {
-    dataflowCache.getDataflow.groupBy(_.sinkId).map(entrySet => (entrySet._1, entrySet._2.map(_.pathId)))
+    dataFlowCache.getDataflow.groupBy(_.sinkId).map(entrySet => (entrySet._1, entrySet._2.map(_.pathId)))
   }
 
   private def getSourcesMatchingRegex(policy: PolicyOrThreat): Set[String] = {

--- a/src/main/scala/ai/privado/policyEngine/PolicyExecutor.scala
+++ b/src/main/scala/ai/privado/policyEngine/PolicyExecutor.scala
@@ -111,7 +111,7 @@ class PolicyExecutor(cpg: Cpg, dataflowMap: Map[String, Path], repoName: String,
     val sinksMatchingIds  = getSinksMatchingRegex(policy)
     sourceMatchingIds.foreach(sourceId => {
       sinksMatchingIds.foreach(sinkId => {
-        val intersectingPathIds = dataflowSourceIdMap(sourceId).intersect(dataflowSinkIdMap(sinkId))
+        val intersectingPathIds = dataflowSourceIdMap(sourceId).intersect(dataflowSinkIdMap(sinkId)).dedup.toList
         if (intersectingPathIds.nonEmpty) {
           violatingFlowList.add(ViolationDataFlowModel(sourceId, sinkId, intersectingPathIds))
         }

--- a/src/main/scala/ai/privado/tagger/PrivadoBaseTagger.scala
+++ b/src/main/scala/ai/privado/tagger/PrivadoBaseTagger.scala
@@ -1,14 +1,19 @@
 package ai.privado.tagger
 
-import ai.privado.cache.{RuleCache, TaggerCache}
+import ai.privado.cache.{DataFlowCache, RuleCache, TaggerCache}
 import ai.privado.entrypoint.PrivadoInput
 import io.shiftleft.codepropertygraph.generated.nodes.Tag
 import overflowdb.traversal.Traversal
 
 abstract class PrivadoBaseTagger {
 
-  def runTagger(rules: RuleCache): Traversal[Tag]                                                             = ???
-  def runTagger(rules: RuleCache, taggerCache: TaggerCache): Traversal[Tag]                                   = ???
-  def runTagger(rules: RuleCache, taggerCache: TaggerCache, privadoInputConfig: PrivadoInput): Traversal[Tag] = ???
+  def runTagger(rules: RuleCache): Traversal[Tag]                           = ???
+  def runTagger(rules: RuleCache, taggerCache: TaggerCache): Traversal[Tag] = ???
+  def runTagger(
+    rules: RuleCache,
+    taggerCache: TaggerCache,
+    privadoInputConfig: PrivadoInput,
+    dataFlowCache: DataFlowCache
+  ): Traversal[Tag] = ???
 
 }

--- a/src/test/scala/ai/privado/languageEngine/java/audit/DataFlowReportTest.scala
+++ b/src/test/scala/ai/privado/languageEngine/java/audit/DataFlowReportTest.scala
@@ -1,7 +1,7 @@
 package ai.privado.languageEngine.java.audit
 
 import ai.privado.audit.DataFlowReport
-import ai.privado.cache.AuditCache
+import ai.privado.cache.{AuditCache, DataFlowCache}
 import ai.privado.cache.AuditCache.SourcePathInfo
 import ai.privado.dataflow.Dataflow
 import ai.privado.entrypoint.PrivadoInput
@@ -31,7 +31,8 @@ class DataFlowReportTest extends DataFlowReportTestBase {
     new IdentifierTagger(cpg, ruleCache, taggerCache).createAndApply()
     new RegularSinkTagger(cpg, ruleCache).createAndApply()
     new InSensitiveCallTagger(cpg, ruleCache, taggerCache).createAndApply()
-    new Dataflow(cpg).dataflow(privadoInput, ruleCache)
+    val dataFlowCache = new DataFlowCache
+    new Dataflow(cpg).dataflow(privadoInput, ruleCache, dataFlowCache)
   }
 
   def getContent(): Map[String, String] = {

--- a/src/test/scala/ai/privado/languageEngine/java/audit/DataFlowReportTest.scala
+++ b/src/test/scala/ai/privado/languageEngine/java/audit/DataFlowReportTest.scala
@@ -2,7 +2,7 @@ package ai.privado.languageEngine.java.audit
 
 import ai.privado.audit.DataFlowReport
 import ai.privado.cache.{AuditCache, DataFlowCache}
-import ai.privado.cache.AuditCache.SourcePathInfo
+import ai.privado.cache.SourcePathInfo
 import ai.privado.dataflow.Dataflow
 import ai.privado.entrypoint.PrivadoInput
 import ai.privado.languageEngine.java.audit.TestData.AuditTestClassData
@@ -31,8 +31,7 @@ class DataFlowReportTest extends DataFlowReportTestBase {
     new IdentifierTagger(cpg, ruleCache, taggerCache).createAndApply()
     new RegularSinkTagger(cpg, ruleCache).createAndApply()
     new InSensitiveCallTagger(cpg, ruleCache, taggerCache).createAndApply()
-    val dataFlowCache = new DataFlowCache
-    new Dataflow(cpg).dataflow(privadoInput, ruleCache, dataFlowCache)
+    new Dataflow(cpg).dataflow(privadoInput, ruleCache, dataFlowCache, auditCache)
   }
 
   def getContent(): Map[String, String] = {
@@ -53,11 +52,11 @@ class DataFlowReportTest extends DataFlowReportTestBase {
       val firstDedupMap   = mutable.HashMap[String, String]()
       val secondDedupMap  = mutable.HashMap[String, String]()
 
-      AuditCache.addIntoBeforeSemantics(
+      auditCache.addIntoBeforeSemantics(
         SourcePathInfo("Data.Sensitive.FinancialData.PaymentMode", "ThirdParties.SDK.Stripe", "2880-2883-2882")
       )
 
-      val workflowResult = DataFlowReport.processDataFlowAudit()
+      val workflowResult = DataFlowReport.processDataFlowAudit(auditCache)
 
       workflowResult.foreach(row => {
         firstFilterMap.put(row.head, row(6))
@@ -75,7 +74,7 @@ class DataFlowReportTest extends DataFlowReportTestBase {
     }
 
     "test unfiltered flow Data size" in {
-      val unfilteredFlow = AuditCache.getFlowBeforeFirstFiltering
+      val unfilteredFlow = auditCache.getFlowBeforeFirstFiltering
 
       unfilteredFlow.size should not equal (0)
     }
@@ -89,7 +88,7 @@ class DataFlowReportTest extends DataFlowReportTestBase {
       val workflowfinalResult    = new mutable.HashMap[SourcePathInfo, String]()
 
       DataFlowReport
-        .processDataFlowAudit()
+        .processDataFlowAudit(auditCache)
         .foreach(row => {
           val sourcePathInfo = SourcePathInfo(row.head, row(1), row(3))
           workflowSemanticResult.put(sourcePathInfo, row(5))

--- a/src/test/scala/ai/privado/languageEngine/java/audit/DataFlowReportTestBase.scala
+++ b/src/test/scala/ai/privado/languageEngine/java/audit/DataFlowReportTestBase.scala
@@ -1,6 +1,6 @@
 package ai.privado.languageEngine.java.audit
 
-import ai.privado.cache.{AppCache, RuleCache, TaggerCache}
+import ai.privado.cache.{AppCache, AuditCache, DataFlowCache, RuleCache, TaggerCache}
 import ai.privado.model.{CatLevelOne, ConfigAndRules, Language, NodeType, RuleInfo}
 import better.files.File
 import io.joern.javasrc2cpg.{Config, JavaSrc2Cpg}
@@ -126,6 +126,7 @@ abstract class DataFlowReportTestBase extends AnyWordSpec with Matchers with Bef
   val rule: ConfigAndRules =
     ConfigAndRules(sourceRule, sinkRule, collectionRule, List(), List(), List(), List(), List(), List(), List())
 
-  val taggerCache = new TaggerCache()
-
+  val taggerCache   = new TaggerCache()
+  val auditCache    = new AuditCache
+  val dataFlowCache = new DataFlowCache(auditCache)
 }

--- a/src/test/scala/ai/privado/languageEngine/java/audit/UnresolvedFlowTest.scala
+++ b/src/test/scala/ai/privado/languageEngine/java/audit/UnresolvedFlowTest.scala
@@ -21,9 +21,12 @@ class UnresolvedFlowTest extends UnresolvedFlowTestBase {
 
   override def beforeAll(): Unit = {
     super.beforeAll()
-    val privadoInput = PrivadoInput(generateAuditReport = true)
-    val context      = new LayerCreatorContext(cpg)
-    val options      = new OssDataFlowOptions()
+    val privadoInput = PrivadoInput(generateAuditReport = true, enableAuditSemanticsFilter = true)
+
+    // TODO Instead of assigning config directly need to pass instance.
+    ScanProcessor.config = privadoInput
+    val context = new LayerCreatorContext(cpg)
+    val options = new OssDataFlowOptions()
     new OssDataFlow(options).run(context)
     new IdentifierTagger(cpg, ruleCache, taggerCache).createAndApply()
     val sources         = Dataflow.getSources(cpg)
@@ -33,7 +36,7 @@ class UnresolvedFlowTest extends UnresolvedFlowTestBase {
         Utilities.getEngineContext(4, config = privadoInput)(getSemantics(cpg, privadoInput, ruleCache))
       )
       .l
-    AuditCache.setUnfilteredFlow(Dataflow.getExpendedFlowInfo(unresolvedFlows))
+    auditCache.setUnfilteredFlow(Dataflow.getExpendedFlowInfo(unresolvedFlows))
   }
 
   def getContent(): Map[String, String] = {
@@ -48,7 +51,7 @@ class UnresolvedFlowTest extends UnresolvedFlowTestBase {
       val sinkSet     = mutable.HashSet[String]()
       val codeSnippet = mutable.HashSet[String]()
 
-      val workbookResult = UnresolvedFlowReport.processUnresolvedFlow()
+      val workbookResult = UnresolvedFlowReport.processUnresolvedFlow(auditCache)
 
       workbookResult.foreach(row => {
         sourceSet += row.head

--- a/src/test/scala/ai/privado/languageEngine/java/audit/UnresolvedFlowTestBase.scala
+++ b/src/test/scala/ai/privado/languageEngine/java/audit/UnresolvedFlowTestBase.scala
@@ -1,6 +1,6 @@
 package ai.privado.languageEngine.java.audit
 
-import ai.privado.cache.{RuleCache, TaggerCache}
+import ai.privado.cache.{AuditCache, RuleCache, TaggerCache}
 import ai.privado.model.{CatLevelOne, ConfigAndRules, Language, NodeType, RuleInfo}
 import better.files.File
 import io.joern.javasrc2cpg.{Config, JavaSrc2Cpg}
@@ -109,4 +109,5 @@ abstract class UnresolvedFlowTestBase extends AnyWordSpec with Matchers with Bef
     ConfigAndRules(sourceRule, sinkRule, List(), List(), List(), List(), List(), List(), List(), List())
 
   val taggerCache = new TaggerCache()
+  val auditCache  = new AuditCache
 }

--- a/src/test/scala/ai/privado/languageEngine/python/passes/config/PythonPropertiesFilePassTest.scala
+++ b/src/test/scala/ai/privado/languageEngine/python/passes/config/PythonPropertiesFilePassTest.scala
@@ -55,7 +55,6 @@ class GetEnvironmentTest extends PythonPropertiesFilePassTestBase(".env") {
       filename.endsWith("/test.env") shouldBe true
     }
     "connect property node to literal via `IS_USED_AT` edge" in {
-      println(cpg.property.usedAt.lineNumber.l)
       val lit = cpg.property.usedAt.l.head
       lit.code shouldBe "\"MONGO_URL\""
     }

--- a/src/test/scala/ai/privado/policyEngine/PolicyTests.scala
+++ b/src/test/scala/ai/privado/policyEngine/PolicyTests.scala
@@ -106,7 +106,7 @@ class PolicyTests extends AnyWordSpec with Matchers with BeforeAndAfterAll {
       violationDataflowModel.pathIds.size shouldBe 1
     }
     "have only unique path ids" ignore {
-      violationDataflowModel.pathIds.count(p => p == "9-16-11") shouldBe 1
+      violationDataflowModel.pathIds.size == violationDataflowModel.pathIds.toSet.size shouldBe true
     }
   }
 

--- a/src/test/scala/ai/privado/policyEngine/PolicyTests.scala
+++ b/src/test/scala/ai/privado/policyEngine/PolicyTests.scala
@@ -105,8 +105,7 @@ class PolicyTests extends AnyWordSpec with Matchers with BeforeAndAfterAll {
     "have non-empty pathIds" in {
       violationDataflowModel.pathIds.size shouldBe 1
     }
-    "have only unique path ids" in {
-      println(violationDataflowModel.pathIds)
+    "have only unique path ids" ignore {
       violationDataflowModel.pathIds.count(p => p == "9-16-11") shouldBe 1
     }
   }
@@ -114,9 +113,10 @@ class PolicyTests extends AnyWordSpec with Matchers with BeforeAndAfterAll {
   def code(code: String): PolicyExecutor = {
     val inputDir = File.newTemporaryDirectory()
     (inputDir / "sample.js").write(code)
-    val outputFile   = File.newTemporaryFile()
-    val config       = Config().withInputPath(inputDir.pathAsString).withOutputPath(outputFile.pathAsString)
-    val privadoInput = PrivadoInput(generateAuditReport = true, enableAuditSemanticsFilter = true)
+    val outputFile = File.newTemporaryFile()
+    val config     = Config().withInputPath(inputDir.pathAsString).withOutputPath(outputFile.pathAsString)
+    val privadoInput =
+      PrivadoInput(generateAuditReport = true, enableAuditSemanticsFilter = true)
     val configAndRules =
       ConfigAndRules(sourceRule, sinkRule, List(), List(), List(), List(), List(), List(), List(), List())
     ScanProcessor.config = privadoInput

--- a/src/test/scala/ai/privado/policyEngine/PolicyTests.scala
+++ b/src/test/scala/ai/privado/policyEngine/PolicyTests.scala
@@ -105,7 +105,7 @@ class PolicyTests extends AnyWordSpec with Matchers with BeforeAndAfterAll {
     "have non-empty pathIds" in {
       violationDataflowModel.pathIds.size shouldBe 1
     }
-    "have only unique path ids" ignore {
+    "have only unique path ids" in {
       violationDataflowModel.pathIds.size == violationDataflowModel.pathIds.toSet.size shouldBe true
     }
   }

--- a/src/test/scala/ai/privado/policyEngine/PolicyTests.scala
+++ b/src/test/scala/ai/privado/policyEngine/PolicyTests.scala
@@ -1,0 +1,138 @@
+package ai.privado.policyEngine
+
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import ai.privado.cache.{RuleCache, TaggerCache}
+import ai.privado.dataflow.Dataflow
+import ai.privado.entrypoint.{PrivadoInput, ScanProcessor}
+import ai.privado.languageEngine.java.tagger.source.InSensitiveCallTagger
+import ai.privado.languageEngine.javascript.tagger.sink.RegularSinkTagger
+import ai.privado.languageEngine.javascript.tagger.source.IdentifierTagger
+import ai.privado.model.{
+  CatLevelOne,
+  ConfigAndRules,
+  DataFlow,
+  Language,
+  NodeType,
+  PolicyAction,
+  PolicyOrThreat,
+  PolicyThreatType,
+  RuleInfo,
+  SourceFilter
+}
+import ai.privado.model.sql.SQLQueryType
+import better.files.File
+import io.joern.jssrc2cpg.{Config, JsSrc2Cpg}
+import io.joern.x2cpg.X2Cpg
+import io.shiftleft.codepropertygraph.generated.Cpg
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import ai.privado.semantic.Language.*
+import io.joern.dataflowengineoss.language.Path
+import io.joern.dataflowengineoss.layers.dataflows.{OssDataFlow, OssDataFlowOptions}
+import io.shiftleft.semanticcpg.language.*
+import io.shiftleft.semanticcpg.layers.LayerCreatorContext
+
+import scala.collection.mutable
+
+class PolicyTests extends AnyWordSpec with Matchers with BeforeAndAfterAll {
+  val sourceRule: List[RuleInfo] = List(
+    RuleInfo(
+      "Data.Sensitive.ContactData.EmailAddress",
+      "EmailAddress",
+      "",
+      Array(),
+      List("(?i).*email.*"),
+      true,
+      "",
+      Map(),
+      NodeType.REGULAR,
+      "",
+      CatLevelOne.SOURCES,
+      "",
+      Language.JAVASCRIPT,
+      Array()
+    )
+  )
+
+  val sinkRule: List[RuleInfo] = List(
+    RuleInfo(
+      "Leakages.Log.Error",
+      "Log Error",
+      "",
+      Array(),
+      List("(?i).*(error).*"),
+      true,
+      "",
+      Map(),
+      NodeType.REGULAR,
+      "",
+      CatLevelOne.SINKS,
+      "",
+      Language.JAVASCRIPT,
+      Array()
+    )
+  )
+
+  val policy = PolicyOrThreat(
+    "Policy.Deny.Sharing.LeakToConsole",
+    "Policy to restrict Contact Information being leaked to console",
+    "Example: Don't leak contact data",
+    "Talk to the Data Protection team: dataprotection@org.com",
+    PolicyThreatType.COMPLIANCE,
+    PolicyAction.DENY,
+    DataFlow(List("Data.Sensitive.ContactData.*"), SourceFilter(Option(true), ""), List("Leakages.Log.*")),
+    List(".*"),
+    Map[String, String](),
+    Map[String, String](),
+    "",
+    Array[String]()
+  )
+
+  "Policy Executor" should {
+    val policyExecutor = code("""
+        |let email = "abc@def.com";
+        |console.error(email);
+        |""".stripMargin)
+
+    val List(violationDataflowModel) = policyExecutor.getViolatingFlowsForPolicy(policy).toList
+    "have a sourceId and sinkId" in {
+      violationDataflowModel.sourceId shouldBe "Data.Sensitive.ContactData.EmailAddress"
+      violationDataflowModel.sinkId shouldBe "Leakages.Log.Error"
+    }
+    "have non-empty pathIds" in {
+      violationDataflowModel.pathIds.size shouldBe 1
+    }
+    "have only unique path ids" in {
+      violationDataflowModel.pathIds.count(p => p == "9-16-15-11") shouldBe 1
+    }
+  }
+
+  def code(code: String): PolicyExecutor = {
+    val inputDir = File.newTemporaryDirectory()
+    (inputDir / "sample.js").write(code)
+    val outputFile   = File.newTemporaryFile()
+    val config       = Config().withInputPath(inputDir.pathAsString).withOutputPath(outputFile.pathAsString)
+    val privadoInput = PrivadoInput(enableAuditSemanticsFilter = true)
+    val configAndRules =
+      ConfigAndRules(sourceRule, sinkRule, List(), List(), List(), List(), List(), List(), List(), List())
+    ScanProcessor.config = privadoInput
+    val ruleCache = new RuleCache()
+    ruleCache.setRule(configAndRules)
+    val cpg = new JsSrc2Cpg().createCpgWithAllOverlays(config).get
+
+    X2Cpg.applyDefaultOverlays(cpg)
+    val context = new LayerCreatorContext(cpg)
+    val options = new OssDataFlowOptions()
+    new OssDataFlow(options).run(context)
+    new IdentifierTagger(cpg, ruleCache, new TaggerCache()).createAndApply()
+    new RegularSinkTagger(cpg, ruleCache).createAndApply()
+    new InSensitiveCallTagger(cpg, ruleCache, new TaggerCache()).createAndApply()
+    val dataflowMap =
+      cpg.dataflow(privadoInput, ruleCache)
+    val policyExecutor = new PolicyExecutor(cpg, dataflowMap, config.inputPath, ruleCache)
+    policyExecutor
+  }
+}

--- a/src/test/scala/ai/privado/policyEngine/PolicyTests.scala
+++ b/src/test/scala/ai/privado/policyEngine/PolicyTests.scala
@@ -3,7 +3,7 @@ package ai.privado.policyEngine
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
-import ai.privado.cache.{RuleCache, TaggerCache}
+import ai.privado.cache.{DataFlowCache, RuleCache, TaggerCache}
 import ai.privado.dataflow.Dataflow
 import ai.privado.entrypoint.{PrivadoInput, ScanProcessor}
 import ai.privado.languageEngine.java.tagger.source.InSensitiveCallTagger
@@ -106,7 +106,8 @@ class PolicyTests extends AnyWordSpec with Matchers with BeforeAndAfterAll {
       violationDataflowModel.pathIds.size shouldBe 1
     }
     "have only unique path ids" in {
-      violationDataflowModel.pathIds.count(p => p == "9-16-15-11") shouldBe 1
+      println(violationDataflowModel.pathIds)
+      violationDataflowModel.pathIds.count(p => p == "9-16-11") shouldBe 1
     }
   }
 
@@ -130,9 +131,10 @@ class PolicyTests extends AnyWordSpec with Matchers with BeforeAndAfterAll {
     new IdentifierTagger(cpg, ruleCache, new TaggerCache()).createAndApply()
     new RegularSinkTagger(cpg, ruleCache).createAndApply()
     new InSensitiveCallTagger(cpg, ruleCache, new TaggerCache()).createAndApply()
+    val dataFlowCache = new DataFlowCache
     val dataflowMap =
-      cpg.dataflow(privadoInput, ruleCache)
-    val policyExecutor = new PolicyExecutor(cpg, dataflowMap, config.inputPath, ruleCache)
+      cpg.dataflow(privadoInput, ruleCache, dataFlowCache)
+    val policyExecutor = new PolicyExecutor(cpg, dataFlowCache, config.inputPath, ruleCache)
     policyExecutor
   }
 }


### PR DESCRIPTION
We were seeing identical `pathIds` in the dataflow section of the violations. Used `dedup` on the `pathIds` to include each pathId only once.