### PR TITLE
Fix: External script processing to work with scala 3

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,6 @@ ThisBuild / scalaVersion := "3.3.0"
 ThisBuild / version      := sys.env.getOrElse("BUILD_VERSION", "dev-SNAPSHOT")
 // parsed by project/Versions.scala, updated by updateDependencies.sh
 
-
 val cpgVersion        = "1.4.24"
 val joernVersion      = "2.0.117"
 val overflowdbVersion = "1.181"
@@ -14,9 +13,9 @@ val requests          = "0.8.0"
 val upickle           = "3.1.2"
 
 //External dependency versions
-val circeVersion   = "0.14.2"
-val jacksonVersion = "2.15.2"
-val mockitoVersion = "1.17.14"
+val circeVersion    = "0.14.2"
+val jacksonVersion  = "2.15.2"
+val mockitoVersion  = "1.17.14"
 val goAstGenVersion = "0.11.0"
 
 lazy val schema         = Projects.schema
@@ -31,7 +30,7 @@ libraryDependencies ++= Seq(
   "io.joern"             %% "javasrc2cpg"   % Versions.joern,
   "io.joern"             %% "pysrc2cpg"     % Versions.joern,
   "io.joern"             %% "rubysrc2cpg"   % Versions.joern,
-  "io.joern"             %% "gosrc2cpg"   % Versions.joern,
+  "io.joern"             %% "gosrc2cpg"     % Versions.joern,
   "io.joern"             %% "joern-cli"     % Versions.joern,
   "io.joern"             %% "semanticcpg"   % Versions.joern,
   "io.joern"             %% "semanticcpg"   % Versions.joern % Test classifier "tests",
@@ -62,7 +61,8 @@ libraryDependencies ++= Seq(
   "org.jruby"                        % "jruby-base"              % "9.4.3.0",
   "org.zeromq"                       % "jeromq"                  % "0.5.4",
   "org.sangria-graphql"             %% "sangria"                 % "4.0.0",
-  "com.michaelpollmeier"             % "versionsort"             % "1.0.11"
+  "com.michaelpollmeier"             % "versionsort"             % "1.0.11",
+  scalaOrganization.value           %% "scala3-compiler"         % scalaVersion.value
 )
 
 ThisBuild / Compile / scalacOptions ++= Seq("-feature", "-deprecation", "-language:implicitConversions")
@@ -117,8 +117,7 @@ lazy val goAstGenDlUrl = settingKey[String]("goastgen download url")
 goAstGenDlUrl := s"https://github.com/Privado-Inc/goastgen/releases/download/v${goAstGenVersion}/"
 
 lazy val goAstGenBinaryNames = taskKey[Seq[String]]("goastgen binary names")
-goAstGenBinaryNames := {Seq(GoAstgenWin, GoAstgenLinux, GoAstgenLinuxArm, GoAstgenMac, GoAstgenMacArm)
-}
+goAstGenBinaryNames := { Seq(GoAstgenWin, GoAstgenLinux, GoAstgenLinuxArm, GoAstgenMac, GoAstgenMacArm) }
 
 lazy val goAstGenDlTask = taskKey[Unit](s"Download goastgen binaries")
 goAstGenDlTask := {

--- a/build.sbt
+++ b/build.sbt
@@ -72,6 +72,7 @@ enablePlugins(JavaAppPackaging)
 ThisBuild / licenses := List("Apache-2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0"))
 
 Global / onChangedBuildSource := ReloadOnSourceChanges
+fork                          := true
 
 ThisBuild / resolvers ++= Seq(
   Resolver.mavenLocal,

--- a/src/main/scala/ai/privado/script/ExternalScalaScriptRunner.scala
+++ b/src/main/scala/ai/privado/script/ExternalScalaScriptRunner.scala
@@ -37,7 +37,7 @@ import scala.tools.reflect.{FastTrack, ToolBox}
 import scala.util.Using
 
 abstract class ExternalScript {
-  def process(cpg: Cpg, output: mutable.LinkedHashMap[String, Json]): Unit
+  def process(cpg: Cpg, output: mutable.LinkedHashMap[String, Json]): Any
 }
 
 case class LoadExternalScript(filePath: String) {

--- a/src/main/scala/ai/privado/script/ExternalScalaScriptRunner.scala
+++ b/src/main/scala/ai/privado/script/ExternalScalaScriptRunner.scala
@@ -41,8 +41,9 @@ abstract class ExternalScript {
 }
 
 case class LoadExternalScript(filePath: String) {
-  private val sourceCode               = Using(Source.fromFile(filePath)) { source => source.mkString }.getOrElse("")
-  def getFileReference: ExternalScript = ScriptEngine().eval(sourceCode).asInstanceOf[ExternalScript]
+  private val sourceCode = Using(Source.fromFile(filePath)) { source => source.mkString }.getOrElse("")
+  def getFileReference: ExternalScript =
+    ScriptEngine().eval(s"import ai.privado.script.*\n$sourceCode").asInstanceOf[ExternalScript]
 }
 
 object ExternalScalaScriptRunner {

--- a/src/main/scala/ai/privado/script/ExternalScalaScriptRunner.scala
+++ b/src/main/scala/ai/privado/script/ExternalScalaScriptRunner.scala
@@ -25,6 +25,7 @@ package ai.privado.script
 
 import ai.privado.cache.RuleCache
 import ai.privado.model.Constants
+import dotty.tools.repl.ScriptEngine
 import io.circe.Json
 import io.shiftleft.codepropertygraph.Cpg
 
@@ -33,23 +34,15 @@ import scala.collection.mutable
 import scala.io.{BufferedSource, Source}
 import scala.reflect.runtime.{currentMirror, universe}
 import scala.tools.reflect.{FastTrack, ToolBox}
+import scala.util.Using
 
 abstract class ExternalScript {
   def process(cpg: Cpg, output: mutable.LinkedHashMap[String, Json]): Unit
 }
 
 case class LoadExternalScript(filePath: String) {
-  val toolbox: ToolBox[universe.type] = universe.runtimeMirror(getClass.getClassLoader).mkToolBox()
-  val sourceFile: BufferedSource      = Source.fromFile(filePath)
-  private val fileContents =
-    try sourceFile.getLines().mkString("\n")
-    finally sourceFile.close()
-
-  // The below package import should be similar to the pacakage where ExternalScript abstract case is present
-  private val tree         = toolbox.parse(s"import ai.privado.script.*;\n$fileContents")
-  private val compiledCode = toolbox.compile(tree)
-
-  def getFileReference: ExternalScript = compiledCode().asInstanceOf[ExternalScript]
+  private val sourceCode               = Using(Source.fromFile(filePath)) { source => source.mkString }.getOrElse("")
+  def getFileReference: ExternalScript = ScriptEngine().eval(sourceCode).asInstanceOf[ExternalScript]
 }
 
 object ExternalScalaScriptRunner {

--- a/src/test/scala/ai/privado/script/ExternalScalaScriptTest.scala
+++ b/src/test/scala/ai/privado/script/ExternalScalaScriptTest.scala
@@ -1,0 +1,41 @@
+package ai.privado.script
+
+import ai.privado.cache.RuleCache
+import ai.privado.model.Constants
+import ai.privado.passes.SQLParser
+import better.files.File
+import io.circe.Json
+import io.joern.javasrc2cpg.Config
+import io.joern.x2cpg.X2Cpg
+import io.shiftleft.codepropertygraph.generated.Cpg
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+import scala.collection.mutable
+class ExternalScalaScriptTest extends AnyWordSpec with Matchers with BeforeAndAfterAll {
+  "External Scala script runner" should {
+    "test sample external scala script" in {
+      val scriptInstance = externalScript("""
+                             |import io.shiftleft.codepropertygraph.Cpg
+                             |import scala.collection.mutable.LinkedHashMap
+                             |import io.circe.*
+                             |
+                             |new ExternalScript {
+                             |  override def process(cpg: Cpg, output: LinkedHashMap[String, Json]): Int = {
+                             |    println("External Script Finished.")
+                             |    return 1;
+                             | }}""".stripMargin)
+
+      scriptInstance.process(new Cpg, mutable.LinkedHashMap[String, Json]()) shouldBe 1;
+    }
+  }
+  def externalScript(code: String): ExternalScript = {
+    val inputDir   = File.newTemporaryDirectory()
+    val sampleFile = (inputDir / "ExternalScript.scala").write(code)
+    val outputFile = File.newTemporaryFile()
+    val config     = Config().withInputPath(inputDir.pathAsString).withOutputPath(outputFile.pathAsString)
+    LoadExternalScript(sampleFile.pathAsString).getFileReference
+  }
+
+}


### PR DESCRIPTION
Using dotty `ScriptEngine` instead of scala reflection to run the external script. 
@khemrajrathore , please review.