### PR TITLE
go: sql nodes for gorm framework

### DIFF
--- a/src/main/scala/ai/privado/languageEngine/go/passes/orm/GormParser.scala
+++ b/src/main/scala/ai/privado/languageEngine/go/passes/orm/GormParser.scala
@@ -1,0 +1,75 @@
+package ai.privado.languageEngine.go.passes.orm
+
+import ai.privado.cache.RuleCache
+import ai.privado.model.Constants
+import ai.privado.model.sql.{SQLColumn, SQLQuery, SQLQueryType, SQLTable}
+import ai.privado.tagger.PrivadoParallelCpgPass
+import ai.privado.utility.SQLNodeBuilder
+import ai.privado.utility.SQLParser.createSQLTableItem
+import better.files.*
+import io.joern.x2cpg.SourceFiles
+import io.shiftleft.codepropertygraph.generated.nodes.*
+import io.shiftleft.codepropertygraph.generated.{Cpg, EdgeTypes}
+import io.shiftleft.semanticcpg.language.*
+import org.slf4j.LoggerFactory
+import overflowdb.{BatchedUpdate, NodeOrDetachedNode}
+
+import scala.collection.mutable
+import scala.util.{Failure, Success, Try}
+
+class GormParser(cpg: Cpg) extends PrivadoParallelCpgPass[TypeDecl](cpg) {
+  val GORM_PARAMETER_TYPE_RULE = ".*github.com/jinzhu/gorm.*"
+  val logger                   = LoggerFactory.getLogger(getClass)
+
+  override def generateParts(): Array[_ <: AnyRef] = {
+    cpg.method.where(_.parameter.typeFullName(GORM_PARAMETER_TYPE_RULE)).typeDecl.dedup.toArray
+  }
+
+  override def runOnPart(builder: DiffGraphBuilder, model: TypeDecl): Unit = {
+    Try(model.file.head) match {
+      case Success(fileNode) =>
+        buildAndAddSqlQueryNodes(builder, model, fileNode)
+      case Failure(_) =>
+        val fileNode = NewFile().name(Constants.Unknown)
+        buildAndAddSqlQueryNodes(builder, model, fileNode)
+    }
+  }
+
+  private def buildAndAddSqlQueryNodes(
+    builder: DiffGraphBuilder,
+    model: TypeDecl,
+    fileNode: NodeOrDetachedNode
+  ): Unit = {
+    Try {
+      try {
+        val sqlTable: SQLTable = SQLTable(
+          model.code.stripPrefix("\"").stripSuffix("\""),
+          model.lineNumber.getOrElse(Integer.valueOf(-1)),
+          model.columnNumber.getOrElse(Integer.valueOf(-1))
+        )
+        val sqlColumns: List[SQLColumn] = model.member.l.map(x =>
+          SQLColumn(
+            x.code.stripPrefix("\"").stripSuffix("\""),
+            x.lineNumber.getOrElse(Integer.valueOf(-1)),
+            x.columnNumber.getOrElse(Integer.valueOf(-1))
+          )
+        )
+        val queryModel = SQLQuery(SQLQueryType.CREATE, sqlTable, sqlColumns)
+        SQLNodeBuilder.buildAndReturnIndividualQueryNode(
+          builder,
+          fileNode,
+          queryModel,
+          model.code,
+          model.lineNumber.getOrElse(Integer.valueOf(-1)),
+          0
+        )
+
+      } catch {
+        case ex: Exception =>
+          ex.printStackTrace()
+          println(s"Error while building sql nodes for GORM framework: ${ex.getMessage}")
+          None
+      }
+    }
+  }
+}

--- a/src/main/scala/ai/privado/languageEngine/go/passes/orm/GormParser.scala
+++ b/src/main/scala/ai/privado/languageEngine/go/passes/orm/GormParser.scala
@@ -62,31 +62,29 @@ class GormParser(cpg: Cpg) extends PrivadoParallelCpgPass[TypeDecl](cpg) {
     model: TypeDecl,
     fileNode: NodeOrDetachedNode
   ): Unit = {
-    Try {
-      try {
-        val sqlTable: SQLTable = SQLTable(
-          model.code,
-          model.lineNumber.getOrElse(Integer.valueOf(-1)),
-          model.columnNumber.getOrElse(Integer.valueOf(-1))
-        )
-        val sqlColumns: List[SQLColumn] = model.member.l.map(x =>
-          SQLColumn(x.code, x.lineNumber.getOrElse(Integer.valueOf(-1)), x.columnNumber.getOrElse(Integer.valueOf(-1)))
-        )
-        val queryModel = SQLQuery(SQLQueryType.CREATE, sqlTable, sqlColumns)
-        SQLNodeBuilder.buildAndReturnIndividualQueryNode(
-          builder,
-          fileNode,
-          queryModel,
-          model.code,
-          model.lineNumber.getOrElse(Integer.valueOf(-1)),
-          0
-        )
+    try {
+      val sqlTable: SQLTable = SQLTable(
+        model.code,
+        model.lineNumber.getOrElse(Integer.valueOf(-1)),
+        model.columnNumber.getOrElse(Integer.valueOf(-1))
+      )
+      val sqlColumns: List[SQLColumn] = model.member.l.map(x =>
+        SQLColumn(x.code, x.lineNumber.getOrElse(Integer.valueOf(-1)), x.columnNumber.getOrElse(Integer.valueOf(-1)))
+      )
+      val queryModel = SQLQuery(SQLQueryType.CREATE, sqlTable, sqlColumns)
+      SQLNodeBuilder.buildAndReturnIndividualQueryNode(
+        builder,
+        fileNode,
+        queryModel,
+        model.code,
+        model.lineNumber.getOrElse(Integer.valueOf(-1)),
+        0
+      )
 
-      } catch {
-        case ex: Exception =>
-          ex.printStackTrace()
-          println(s"Error while building sql nodes for GORM framework: ${ex.getMessage}")
-      }
+    } catch {
+      case ex: Exception =>
+        ex.printStackTrace()
+        println(s"Error while building sql nodes for GORM framework: ${ex.getMessage}")
     }
   }
 }

--- a/src/main/scala/ai/privado/languageEngine/go/passes/orm/GormParser.scala
+++ b/src/main/scala/ai/privado/languageEngine/go/passes/orm/GormParser.scala
@@ -1,3 +1,25 @@
+/*
+ * This file is part of Privado OSS.
+ *
+ * Privado is an open source static code analysis tool to discover data flows in the code.
+ * Copyright (C) 2022 Privado, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * For more information, contact support@privado.ai
+ *
+ */
 package ai.privado.languageEngine.go.passes.orm
 
 import ai.privado.cache.RuleCache
@@ -43,13 +65,13 @@ class GormParser(cpg: Cpg) extends PrivadoParallelCpgPass[TypeDecl](cpg) {
     Try {
       try {
         val sqlTable: SQLTable = SQLTable(
-          model.code.stripPrefix("\"").stripSuffix("\""),
+          model.code,
           model.lineNumber.getOrElse(Integer.valueOf(-1)),
           model.columnNumber.getOrElse(Integer.valueOf(-1))
         )
         val sqlColumns: List[SQLColumn] = model.member.l.map(x =>
           SQLColumn(
-            x.code.stripPrefix("\"").stripSuffix("\""),
+            x.code,
             x.lineNumber.getOrElse(Integer.valueOf(-1)),
             x.columnNumber.getOrElse(Integer.valueOf(-1))
           )

--- a/src/main/scala/ai/privado/languageEngine/go/passes/orm/GormParser.scala
+++ b/src/main/scala/ai/privado/languageEngine/go/passes/orm/GormParser.scala
@@ -44,7 +44,7 @@ class GormParser(cpg: Cpg) extends PrivadoParallelCpgPass[TypeDecl](cpg) {
   val logger                   = LoggerFactory.getLogger(getClass)
 
   override def generateParts(): Array[_ <: AnyRef] = {
-    cpg.method.where(_.parameter.typeFullName(GORM_PARAMETER_TYPE_RULE)).typeDecl.dedup.toArray
+    cpg.typeDecl.where(_.method.parameter.typeFullName(GORM_PARAMETER_TYPE_RULE)).dedup.toArray
   }
 
   override def runOnPart(builder: DiffGraphBuilder, model: TypeDecl): Unit = {
@@ -86,7 +86,6 @@ class GormParser(cpg: Cpg) extends PrivadoParallelCpgPass[TypeDecl](cpg) {
         case ex: Exception =>
           ex.printStackTrace()
           println(s"Error while building sql nodes for GORM framework: ${ex.getMessage}")
-          None
       }
     }
   }

--- a/src/main/scala/ai/privado/languageEngine/go/passes/orm/GormParser.scala
+++ b/src/main/scala/ai/privado/languageEngine/go/passes/orm/GormParser.scala
@@ -70,11 +70,7 @@ class GormParser(cpg: Cpg) extends PrivadoParallelCpgPass[TypeDecl](cpg) {
           model.columnNumber.getOrElse(Integer.valueOf(-1))
         )
         val sqlColumns: List[SQLColumn] = model.member.l.map(x =>
-          SQLColumn(
-            x.code,
-            x.lineNumber.getOrElse(Integer.valueOf(-1)),
-            x.columnNumber.getOrElse(Integer.valueOf(-1))
-          )
+          SQLColumn(x.code, x.lineNumber.getOrElse(Integer.valueOf(-1)), x.columnNumber.getOrElse(Integer.valueOf(-1)))
         )
         val queryModel = SQLQuery(SQLQueryType.CREATE, sqlTable, sqlColumns)
         SQLNodeBuilder.buildAndReturnIndividualQueryNode(

--- a/src/main/scala/ai/privado/languageEngine/go/processor/GoProcessor.scala
+++ b/src/main/scala/ai/privado/languageEngine/go/processor/GoProcessor.scala
@@ -23,6 +23,7 @@ import io.shiftleft.codepropertygraph
 import io.shiftleft.semanticcpg.language.*
 import io.shiftleft.semanticcpg.layers.LayerCreatorContext
 import org.slf4j.LoggerFactory
+import ai.privado.languageEngine.go.passes.orm.GormParser
 
 import java.nio.file.Paths
 import java.util.Calendar
@@ -62,6 +63,7 @@ object GoProcessor {
             val path = s"${config.sourceLocation.head}/${Constants.outputDirectoryName}"
             UnresolvedReportUtility.reportUnresolvedMethods(xtocpg, path, Language.GO)
           }
+          new GormParser(cpg).createAndApply()
 
           // Run tagger
           println(s"${Calendar.getInstance().getTime} - Tagging source code with rules...")

--- a/src/main/scala/ai/privado/utility/SQLParser.scala
+++ b/src/main/scala/ai/privado/utility/SQLParser.scala
@@ -21,6 +21,7 @@ import overflowdb.BatchedUpdate.DiffGraphBuilder
 import scala.jdk.CollectionConverters.*
 import scala.util.Try
 import scala.util.control.Breaks.{break, breakable}
+import overflowdb.{BatchedUpdate, NodeOrDetachedNode}
 
 object SqlCleaner {
   def clean(sql: String): String = {
@@ -184,7 +185,7 @@ object SQLNodeBuilder {
 
   def buildAndReturnIndividualQueryNode(
     builder: DiffGraphBuilder,
-    fileNode: NewFile,
+    fileNode: NodeOrDetachedNode,
     queryModel: SQLQuery,
     query: String,
     queryLineNumber: Int,

--- a/src/test/scala/ai/privado/languageEngine/go/passes/orm/GormParserTest.scala
+++ b/src/test/scala/ai/privado/languageEngine/go/passes/orm/GormParserTest.scala
@@ -1,0 +1,106 @@
+/*
+ * This file is part of Privado OSS.
+ *
+ * Privado is an open source static code analysis tool to discover data flows in the code.
+ * Copyright (C) 2022 Privado, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * For more information, contact support@privado.ai
+ *
+ */
+package ai.privado.languageEngine.go.passes.orm
+
+import ai.privado.languageEngine.go.tagger.GoTaggingTestBase
+import ai.privado.model.*
+import ai.privado.semantic.Language.*
+import io.joern.x2cpg.X2Cpg
+import io.shiftleft.semanticcpg.language.*
+import io.shiftleft.semanticcpg.layers.LayerCreatorContext
+import io.joern.dataflowengineoss.layers.dataflows.{OssDataFlow, OssDataFlowOptions}
+
+class GormParserTest extends GoTaggingTestBase {
+
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+    X2Cpg.applyDefaultOverlays(cpg)
+
+    val context = new LayerCreatorContext(cpg)
+    val options = new OssDataFlowOptions()
+    new OssDataFlow(options).run(context)
+    new GormParser(cpg).createAndApply()
+  }
+
+  override val goFileContents =
+    """
+      package models
+      |
+      |import (
+      |	"github.com/jinzhu/gorm"
+      |)
+      |
+      |// User Model
+      |type User struct {
+      |	// we need to use our own custom model because the id is different of the "gorm.Model"
+      |	ID      string `gorm:"PRIMARY KEY; UNIQUE" json:"id"`
+      |	Name    string `gorm:"type:varchar(255); NOT NULL" json:"name" validate:"required"`
+      |	Email   string `gorm:"type:varchar(255)" json:"email"`
+      |	Phone   string `gorm:"type:varchar(100); NOT NULL; UNIQUE; UNIQUE_INDEX" json:"phone" validate:"required"`
+      |	Address string `gorm:"type:text" json:"address"`
+      |	MyModel
+      |}
+      |
+      |// Check if Users Model implements/match Model interface
+      |var _ Model = &User{}
+      |
+      |// Save saves a User inside the database
+      |func (u *User) Save(db *gorm.DB) error {
+      |	uuidResult, err := uuid.NewRandom()
+      |	if err != nil {
+      |		log.Fatal(err)
+      |	}
+      |
+      |	u.ID = uuidResult.String()
+      |	u.CreatedAt = time.Now().String()
+      |	u.UpdatedAt = time.Now().String()
+      |
+      |	err = db.Save(&u).Error
+      |	if err != nil {
+      |		return err
+      |	}
+      |	return nil
+      |}
+      |""".stripMargin
+
+  "Adding sql nodes for GORM framework" should {
+    "check table nodes" in {
+      val tableNodes = cpg.sqlTable.l
+      tableNodes.size shouldBe 1
+    }
+
+    "check column nodes" in {
+      val columnNodes = cpg.sqlColumn.l
+      columnNodes.size shouldBe 5
+
+      val List(id, name, email, phone, address) = cpg.sqlColumn.l
+      id.code shouldBe "ID"
+      name.code shouldBe "Name"
+      email.code shouldBe "Email"
+      phone.code shouldBe "Phone"
+      address.code shouldBe "Address"
+    }
+
+  }
+
+}


### PR DESCRIPTION
Description

We are building graph for SQL nodes. In Gorm framework a module defined is act as table in sql and its member as column. So we are capturing TypeDecl nodes on whom gorm related functions are written.
Ex.

      import (
		"github.com/jinzhu/gorm"
	)

	type User struct {
		// we need to use our own custom model because the id is different of the "gorm.Model"
		ID      string `gorm:"PRIMARY KEY; UNIQUE" json:"id"`
		Name    string `gorm:"type:varchar(255); NOT NULL" json:"name" validate:"required"`
		Email   string `gorm:"type:varchar(255)" json:"email"`
		Phone   string `gorm:"type:varchar(100); NOT NULL; UNIQUE; UNIQUE_INDEX" json:"phone" validate:"required"`
		Address string `gorm:"type:text" json:"address"`
		MyModel
	}

	// Save saves a User inside the database
	func (u *User) Save(db *gorm.DB) error {
		uuidResult, err := uuid.NewRandom()
		if err != nil {
			log.Fatal(err)
		}

		u.ID = uuidResult.String()
		u.CreatedAt = time.Now().String()
		u.UpdatedAt = time.Now().String()

		err = db.Save(&u).Error
		if err != nil {
			return err
		}
		return nil


In above code snippet we are capturing method node having parameter `gorm.DB` and processing its corresponding `TypeDecl` node to create sql related nodes.