### PR TITLE
fix - performance issue due to callIn

### DIFF
--- a/src/main/scala/ai/privado/languageEngine/java/passes/read/DatabaseReadUtility.scala
+++ b/src/main/scala/ai/privado/languageEngine/java/passes/read/DatabaseReadUtility.scala
@@ -75,6 +75,7 @@ object DatabaseReadUtility {
           cpg.method
             .fullName("org[.]hibernate[.].*create[a-zA-Z]{0,10}Query:.*")
             .callIn
+            .dedup
             .where(_.argument.code("(\"){0,1}" + nameOfNamedQuery + "(\"){0,1}"))
             .l
         } else

--- a/src/main/scala/ai/privado/languageEngine/java/tagger/Utility/SOAPTaggerUtility.scala
+++ b/src/main/scala/ai/privado/languageEngine/java/tagger/Utility/SOAPTaggerUtility.scala
@@ -35,7 +35,7 @@ object SOAPTaggerUtility {
 
   def getAPICallNodes(cpg: Cpg): List[Call] = {
     implicit val resolver: ICallResolver = NoResolve
-    getAPIMethods(cpg).callIn.l
+    getAPIMethods(cpg).callIn.dedup.l
   }
 
 }

--- a/src/main/scala/ai/privado/languageEngine/java/tagger/sink/FeignAPI.scala
+++ b/src/main/scala/ai/privado/languageEngine/java/tagger/sink/FeignAPI.scala
@@ -80,6 +80,7 @@ class FeignAPI(cpg: Cpg, ruleCache: RuleCache) {
       .filterNot(item => feignClientTypeDeclWithUrl.contains(item.fullName))
       .method
       .callIn
+      .dedup
       .l
     feignAPISinks
   }
@@ -186,7 +187,7 @@ class FeignAPI(cpg: Cpg, ruleCache: RuleCache) {
       if (typeDecls.nonEmpty) {
         val typeDecl   = typeDecls.head
         var apiLiteral = entrySet._2.stripPrefix("\"").stripSuffix("\"")
-        val apiCalls   = typeDecl.method.callIn.l
+        val apiCalls   = typeDecl.method.callIn.dedup.l
         if (ruleInfo.id.equals(Constants.internalAPIRuleId)) {
           if (apiLiteral.matches(ruleInfo.combinedRulePattern)) {
             apiCalls.foreach(apiNode => {

--- a/src/main/scala/ai/privado/languageEngine/java/tagger/source/IdentifierTagger.scala
+++ b/src/main/scala/ai/privado/languageEngine/java/tagger/source/IdentifierTagger.scala
@@ -26,8 +26,8 @@ package ai.privado.languageEngine.java.tagger.source
 import ai.privado.cache.{RuleCache, TaggerCache}
 import ai.privado.model.{CatLevelOne, Constants, InternalTag, RuleInfo}
 import ai.privado.utility.Utilities.*
-import io.shiftleft.codepropertygraph.generated.nodes.TypeDecl
-import io.shiftleft.codepropertygraph.generated.Cpg
+import io.shiftleft.codepropertygraph.generated.nodes.{Identifier, MethodParameterIn, TypeDecl}
+import io.shiftleft.codepropertygraph.generated.{Cpg, Operators}
 import io.shiftleft.semanticcpg.language.*
 import overflowdb.BatchedUpdate
 import ai.privado.languageEngine.java.tagger.source.Utility.*
@@ -40,39 +40,46 @@ import scala.collection.mutable
 class IdentifierTagger(cpg: Cpg, ruleCache: RuleCache, taggerCache: TaggerCache)
     extends PrivadoParallelCpgPass[RuleInfo](cpg) {
 
-  implicit val resolver: ICallResolver                              = NoResolve
-  lazy val RANDOM_ID_OBJECT_OF_TYPE_DECL_HAVING_MEMBER_NAME: String = UUID.randomUUID.toString
-  lazy val RANDOM_ID_OBJECT_OF_TYPE_DECL_HAVING_MEMBER_TYPE: String = UUID.randomUUID.toString
-  lazy val RANDOM_ID_OBJECT_OF_TYPE_DECL_EXTENDING_TYPE: String     = UUID.randomUUID.toString
+  implicit val resolver: ICallResolver                                 = NoResolve
+  private val RANDOM_ID_OBJECT_OF_TYPE_DECL_HAVING_MEMBER_NAME: String = UUID.randomUUID.toString
+  private val RANDOM_ID_OBJECT_OF_TYPE_DECL_HAVING_MEMBER_TYPE: String = UUID.randomUUID.toString
+  private val RANDOM_ID_OBJECT_OF_TYPE_DECL_EXTENDING_TYPE: String     = UUID.randomUUID.toString
+
+  private val cachedIdentifier: List[Identifier] = cpg.identifier
+    .filterNot(item => item.name.equals(item.name.toUpperCase))
+    .filterNot(_.code.equals(Constants.thisConstant))
+    .l
+  private val cachedParameter: List[MethodParameterIn] = cpg.parameter
+    .filterNot(item => item.name.equals(item.name.toUpperCase))
+    .filterNot(_.code.equals(Constants.thisConstant))
+    .l
+  private val cachedMember = cpg.member.filterNot(item => item.name.equals(item.name.toUpperCase)).l
+  private val cachedFieldAccess = cpg.method
+    .fullNameExact(Operators.fieldAccess, Operators.indirectFieldAccess)
+    .callIn
+    .dedup
+    .l
 
   override def generateParts(): Array[RuleInfo] = ruleCache.getRule.sources.toArray
 
   override def runOnPart(builder: DiffGraphBuilder, ruleInfo: RuleInfo): Unit = {
 
     // Step 1.1
-    val rulePattern = ruleInfo.combinedRulePattern
-    val regexMatchingIdentifiers =
-      cpg.identifier(rulePattern).filterNot(item => item.name.equals(item.name.toUpperCase))
+    val rulePattern              = ruleInfo.combinedRulePattern
+    val regexMatchingIdentifiers = cachedIdentifier.name(rulePattern)
     regexMatchingIdentifiers.foreach(identifier => {
       storeForTag(builder, identifier, ruleCache)(InternalTag.VARIABLE_REGEX_IDENTIFIER.toString)
       addRuleTags(builder, identifier, ruleInfo, ruleCache)
     })
 
-    val regexMatchingMembers = cpg.member.name(rulePattern).l
+    val regexMatchingMembers = cachedMember.name(rulePattern).l
     regexMatchingMembers.foreach(member => {
       storeForTag(builder, member, ruleCache)(InternalTag.VARIABLE_REGEX_MEMBER.toString)
       addRuleTags(builder, member, ruleInfo, ruleCache)
     })
 
     val regexMatchingFieldIdentifiersIdentifiers =
-      cpg.fieldAccess
-        .where(
-          _.fieldIdentifier
-            .canonicalName(rulePattern)
-            .filterNot(item => item.canonicalName.equals(item.canonicalName.toUpperCase))
-        )
-        .isCall
-        .l
+      cachedFieldAccess.where(_.argument(2).code(rulePattern)).l
     regexMatchingFieldIdentifiersIdentifiers.foreach(identifier => {
       storeForTag(builder, identifier, ruleCache)(InternalTag.VARIABLE_REGEX_IDENTIFIER.toString)
       addRuleTags(builder, identifier, ruleInfo, ruleCache)
@@ -90,59 +97,55 @@ class IdentifierTagger(cpg: Cpg, ruleCache: RuleCache, taggerCache: TaggerCache)
     memberNameRegex: String,
     ruleInfo: RuleInfo
   ): Unit = {
-    val typeDeclWithMemberNameHavingMemberName = cpg.typeDecl
-      .where(_.member.name(memberNameRegex).filterNot(item => item.name.equals(item.name.toUpperCase)))
-      .map(typeDeclNode => (typeDeclNode, typeDeclNode.member.name(memberNameRegex).l))
+    val typeDeclWithMemberNameHavingMemberName = cachedMember
+      .name(memberNameRegex)
+      .map(memberNode => (memberNode.typeDecl, memberNode))
       .l
     typeDeclWithMemberNameHavingMemberName
-      .distinctBy(_._1.fullName)
       .foreach(typeDeclValEntry => {
-        typeDeclValEntry._2.foreach(typeDeclMember => {
-          val typeDeclVal = typeDeclValEntry._1.fullName
-          // updating cache
-          taggerCache.addItemToTypeDeclMemberCache(typeDeclVal, ruleInfo.id, typeDeclMember)
-          val typeDeclMemberName = typeDeclMember.name
-          // Have started tagging Parameters as well, as in collection points sometimes there is no referencing Identifier present for a local
-          val impactedObjects =
-            cpg.identifier.where(_.typeFullName(typeDeclVal)).l ::: cpg.parameter.where(_.typeFullName(typeDeclVal)).l
-          impactedObjects
-            .whereNot(_.code("this"))
-            .foreach(impactedObject => {
-              if (impactedObject.tag.nameExact(Constants.id).l.isEmpty) {
-                storeForTag(builder, impactedObject, ruleCache)(
-                  InternalTag.OBJECT_OF_SENSITIVE_CLASS_BY_MEMBER_NAME.toString,
-                  ruleInfo.id
-                )
-                storeForTag(builder, impactedObject, ruleCache)(
-                  Constants.id,
-                  Constants.privadoDerived + Constants.underScore + RANDOM_ID_OBJECT_OF_TYPE_DECL_HAVING_MEMBER_NAME
-                )
-                storeForTag(builder, impactedObject, ruleCache)(Constants.catLevelOne, CatLevelOne.DERIVED_SOURCES.name)
-              }
+        val typeDeclMember = typeDeclValEntry._2
+        val typeDeclVal    = typeDeclValEntry._1.fullName
+        // updating cache
+        taggerCache.addItemToTypeDeclMemberCache(typeDeclVal, ruleInfo.id, typeDeclMember)
+        val typeDeclMemberName = typeDeclMember.name
+        // Have started tagging Parameters as well, as in collection points sometimes there is no referencing Identifier present for a local
+
+        (cachedIdentifier.where(_.typeFullName(typeDeclVal)).l ::: cachedParameter.where(_.typeFullName(typeDeclVal)).l)
+          .foreach(impactedObject => {
+            if (impactedObject.tag.nameExact(Constants.id).l.isEmpty) {
               storeForTag(builder, impactedObject, ruleCache)(
-                Constants.privadoDerived + Constants.underScore + RANDOM_ID_OBJECT_OF_TYPE_DECL_HAVING_MEMBER_NAME,
+                InternalTag.OBJECT_OF_SENSITIVE_CLASS_BY_MEMBER_NAME.toString,
                 ruleInfo.id
               )
-              // Tag for storing memberName in derived Objects -> user --> (email, password)
               storeForTag(builder, impactedObject, ruleCache)(
-                ruleInfo.id + Constants.underScore + Constants.privadoDerived + Constants.underScore + RANDOM_ID_OBJECT_OF_TYPE_DECL_HAVING_MEMBER_NAME,
-                typeDeclMemberName
+                Constants.id,
+                Constants.privadoDerived + Constants.underScore + RANDOM_ID_OBJECT_OF_TYPE_DECL_HAVING_MEMBER_NAME
               )
-            })
+              storeForTag(builder, impactedObject, ruleCache)(Constants.catLevelOne, CatLevelOne.DERIVED_SOURCES.name)
+            }
+            storeForTag(builder, impactedObject, ruleCache)(
+              Constants.privadoDerived + Constants.underScore + RANDOM_ID_OBJECT_OF_TYPE_DECL_HAVING_MEMBER_NAME,
+              ruleInfo.id
+            )
+            // Tag for storing memberName in derived Objects -> user --> (email, password)
+            storeForTag(builder, impactedObject, ruleCache)(
+              ruleInfo.id + Constants.underScore + Constants.privadoDerived + Constants.underScore + RANDOM_ID_OBJECT_OF_TYPE_DECL_HAVING_MEMBER_NAME,
+              typeDeclMemberName
+            )
+          })
 
-          // To Mark all field Access and getters
-          tagAllFieldAccessAndGetters(builder, typeDeclVal, ruleInfo, typeDeclMemberName, true)
-        })
+        // To Mark all field Access and getters
+        tagAllFieldAccessAndGetters(builder, typeDeclVal, ruleInfo, typeDeclMemberName, true)
       })
 
     typeDeclWithMemberNameHavingMemberName
       .distinctBy(_._1.fullName)
       .foreach(typeDeclValEntry => {
-        val typeDeclName = typeDeclValEntry._1.fullName
+        val typeDeclNode = typeDeclValEntry._1
         // Step 2.2
-        tagObjectOfTypeDeclHavingMemberType(builder, typeDeclName, ruleInfo)
+        tagObjectOfTypeDeclHavingMemberType(builder, typeDeclNode.fullName, ruleInfo)
         // Step 2.3
-        tagObjectOfTypeDeclExtendingType(builder, typeDeclName, ruleInfo)
+        tagObjectOfTypeDeclExtendingType(builder, typeDeclNode, ruleInfo)
       })
   }
 
@@ -155,17 +158,15 @@ class IdentifierTagger(cpg: Cpg, ruleCache: RuleCache, taggerCache: TaggerCache)
   ): Unit = {
     // stores tuple(Member, TypeDeclFullName)
     val typeDeclHavingMemberTypeTuple =
-      cpg.typeDecl.member.typeFullName(memberType).map(member => (member, member.typeDecl.fullName)).dedup.l
+      cachedMember.typeFullName(memberType).map(member => (member, member.typeDecl.fullName)).dedup.l
     typeDeclHavingMemberTypeTuple.foreach(typeDeclTuple => {
       val typeDeclVal    = typeDeclTuple._2
       val typeDeclMember = typeDeclTuple._1
       taggerCache.addItemToTypeDeclMemberCache(typeDeclVal, ruleInfo.id, typeDeclMember)
-      val impactedObjects =
-        cpg.identifier.where(_.typeFullName(typeDeclVal)).whereNot(_.code("this")).l ::: cpg.parameter
-          .where(_.typeFullName(typeDeclVal))
-          .whereNot(_.code("this"))
-          .l
-      impactedObjects.foreach(impactedObject => {
+
+      (cachedIdentifier.where(_.typeFullName(typeDeclVal)).l ::: cachedParameter
+        .where(_.typeFullName(typeDeclVal))
+        .l).foreach(impactedObject => {
         if (impactedObject.tag.nameExact(Constants.id).l.isEmpty) {
           storeForTag(builder, impactedObject, ruleCache)(InternalTag.OBJECT_OF_SENSITIVE_CLASS_BY_MEMBER_TYPE.toString)
           storeForTag(builder, impactedObject, ruleCache)(
@@ -190,16 +191,17 @@ class IdentifierTagger(cpg: Cpg, ruleCache: RuleCache, taggerCache: TaggerCache)
     */
   private def tagObjectOfTypeDeclExtendingType(
     builder: BatchedUpdate.DiffGraphBuilder,
-    typeDeclName: String,
+    typeDeclNode: TypeDecl,
     ruleInfo: RuleInfo
   ): Unit = {
-    val typeDeclsExtendingTypeName = cpg.typeDecl.filter(_.inheritsFromTypeFullName.contains(typeDeclName)).dedup.l
+    val typeDeclsExtendingTypeName =
+      cpg.typeDecl.filter(_.inheritsFromTypeFullName.contains(typeDeclNode.fullName)).dedup.l
 
     typeDeclsExtendingTypeName.foreach(typeDecl => {
       taggerCache.typeDeclDerivedByExtendsCache.put(typeDecl.fullName, typeDecl)
 
       taggerCache
-        .typeDeclMemberCache(typeDeclName)
+        .typeDeclMemberCache(typeDeclNode.fullName)
         .filter(_._1.equals(ruleInfo.id))
         .foreach(entrySet => {
           val sourceRuleId = entrySet._1
@@ -220,14 +222,11 @@ class IdentifierTagger(cpg: Cpg, ruleCache: RuleCache, taggerCache: TaggerCache)
         taggerCache.typeDeclExtendingTypeDeclCache.put(typeDeclVal, TrieMap[String, TypeDecl]())
       taggerCache
         .getTypeDeclExtendingTypeDeclCacheItem(typeDeclVal)
-        .put(ruleInfo.id, cpg.typeDecl.where(_.fullNameExact(typeDeclName)).head)
+        .put(ruleInfo.id, typeDeclNode)
 
-      val impactedObjects =
-        cpg.identifier.where(_.typeFullName(typeDeclVal)).whereNot(_.code("this")).l ::: cpg.parameter
-          .where(_.typeFullName(typeDeclVal))
-          .whereNot(_.code("this"))
-          .l
-      impactedObjects.foreach(impactedObject => {
+      (cachedIdentifier.where(_.typeFullName(typeDeclVal)).l ::: cachedParameter
+        .where(_.typeFullName(typeDeclVal))
+        .l).foreach(impactedObject => {
         if (impactedObject.tag.nameExact(Constants.id).l.isEmpty) {
           storeForTag(builder, impactedObject, ruleCache)(InternalTag.OBJECT_OF_SENSITIVE_CLASS_BY_INHERITANCE.toString)
           storeForTag(builder, impactedObject, ruleCache)(
@@ -275,10 +274,8 @@ class IdentifierTagger(cpg: Cpg, ruleCache: RuleCache, taggerCache: TaggerCache)
     typeDeclMemberName: String,
     isDerived: Boolean = false
   ): Unit = {
-    val impactedGetters = getFieldAccessCallsMatchingRegex(cpg, typeDeclVal, s"($typeDeclMemberName)")
-      .filterNot(item => item.code.equals(item.code.toUpperCase))
 
-    impactedGetters.foreach(impactedGetter => {
+    getFieldAccessCallsMatchingRegex(cpg, typeDeclVal, s"($typeDeclMemberName)").foreach(impactedGetter => {
       storeForTag(builder, impactedGetter, ruleCache)(InternalTag.SENSITIVE_FIELD_ACCESS.toString)
       addRuleTags(builder, impactedGetter, ruleInfo, ruleCache)
       if (isDerived)

--- a/src/main/scala/ai/privado/languageEngine/java/tagger/source/Utility.scala
+++ b/src/main/scala/ai/privado/languageEngine/java/tagger/source/Utility.scala
@@ -50,6 +50,7 @@ object Utility {
       .code(s"return (?i)(this.)?$regexString(;)?")
       .method
       .callIn
+      .dedup
       .l ++ cpg.identifier
       .typeFullName(typeDeclFullName)
       .astParent
@@ -79,6 +80,7 @@ object Utility {
       .where(_.fullName(typeDeclFullName))
       .method
       .callIn
+      .dedup
       .typeFullName(returnType)
       .name(setterRegex)
       .l ++ cpg.identifier
@@ -103,6 +105,7 @@ object Utility {
     cpg.method
       .fullNameExact(Operators.fieldAccess, Operators.indirectFieldAccess)
       .callIn
+      .dedup
       .where(_.argument(1).isIdentifier.typeFullName(typeDeclFullName))
       .where(_.argument(2).code(s"(?i)$regexString"))
       .l

--- a/src/main/scala/ai/privado/model/Constants.scala
+++ b/src/main/scala/ai/privado/model/Constants.scala
@@ -168,6 +168,7 @@ object Constants {
   val annotations       = "annotations"
   val default           = "default"
   val semanticDelimeter = "_A_"
+  val thisConstant      = "this"
 
   // Ruby defaults
   val defaultExpansionLimit = 100

--- a/src/main/scala/ai/privado/threatEngine/BackgroundScreenshot.scala
+++ b/src/main/scala/ai/privado/threatEngine/BackgroundScreenshot.scala
@@ -49,6 +49,7 @@ object BackgroundScreenshot {
       val safeFlagCalls = cpg.method
         .fullName(SET_FLAG_METHOD_PATTERN)
         .callIn
+        .dedup
         .where(_.argument.code(s".*$SAFE_FLAG.*"))
 
       // violation if empty


### PR DESCRIPTION
PR contains fix for performance issues faced in Kotlin Identifier tagger.

Reason was `callIn` returns duplicate nodes, so need to use `dedup` on top on `callIn` (The root cause can be incorrect AST structure for Kotlin frontend)

On top of it, have cached some queries in Identifier tagger, which helps in optimising the queries further