### PR TITLE
Use android collection rules for tagging

### DIFF
--- a/src/main/scala/ai/privado/languageEngine/kotlin/tagger/collection/AndroidCollectionTagger.scala
+++ b/src/main/scala/ai/privado/languageEngine/kotlin/tagger/collection/AndroidCollectionTagger.scala
@@ -21,9 +21,9 @@ class AndroidCollectionTagger(cpg: Cpg, projectRoot: String, ruleCache: RuleCach
   private val logger = LoggerFactory.getLogger(this.getClass)
 
   override def generateParts(): Array[RuleInfo] =
-    ruleCache.getRule.sources.toArray
+    ruleCache.getRule.collections.filter(_.catLevelTwo == Constants.android).toArray
 
-  override def runOnPart(builder: DiffGraphBuilder, sourceRuleInfo: RuleInfo): Unit = {
+  override def runOnPart(builder: DiffGraphBuilder, collectionRuleInfo: RuleInfo): Unit = {
     /* We have all the XML layout nodes in cpg.androidXmlLayoutNodes containing
      * parsed id (eg. `emailEditText`), node type (`<ExitText>`), line and col number. We now
      * find all points in code where the id is used and tag those nodes as collection points.
@@ -45,7 +45,7 @@ class AndroidCollectionTagger(cpg: Cpg, projectRoot: String, ruleCache: RuleCach
 
     // For case (1), we want to tag the `fieldIdentifiers` here (`binding.emailEditText`).
     val fieldIdentifiers = cpg.androidXmlLayoutNode
-      .name(sourceRuleInfo.combinedRulePattern)
+      .name(collectionRuleInfo.combinedRulePattern)
       .flatMap { elem =>
         cpg.fieldAccess.astChildren.isFieldIdentifier.where(_.canonicalName(elem.name)).l
       }
@@ -53,7 +53,7 @@ class AndroidCollectionTagger(cpg: Cpg, projectRoot: String, ruleCache: RuleCach
     if (fieldIdentifiers.nonEmpty) {
       fieldIdentifiers.foreach(node => {
         storeForTag(builder, node, ruleCache)(Constants.collectionSource, node.canonicalName)
-        addRuleTags(builder, node, sourceRuleInfo, ruleCache)
+        addRuleTags(builder, node, collectionRuleInfo, ruleCache)
       })
     }
     // TODO: for case (2), fieldIdentifier approach works for now, but we should ideally tag findViewById

--- a/src/main/scala/ai/privado/model/Constants.scala
+++ b/src/main/scala/ai/privado/model/Constants.scala
@@ -38,6 +38,7 @@ object Constants {
   val underScore       = "_"
   val apiUrl           = "apiUrl"
   val collectionSource = "collectionSource"
+  val android          = "android"
 
   // semantic
   val signature = "signature"

--- a/src/test/scala/ai/privado/passes/AndroidXmlPassTest.scala
+++ b/src/test/scala/ai/privado/passes/AndroidXmlPassTest.scala
@@ -64,10 +64,13 @@ class AndroidXmlPassTest extends AnyWordSpec with Matchers with BeforeAndAfterAl
       "",
       Language.JAVA,
       Array()
-    ),
+    )
+  )
+
+  private val collections = List(
     RuleInfo(
-      "Data.Sensitive.Email",
-      "Email",
+      "Collections.Android.Form.Email",
+      "Android app email input",
       "",
       Array(),
       List("(?i).*email.*"),
@@ -76,8 +79,8 @@ class AndroidXmlPassTest extends AnyWordSpec with Matchers with BeforeAndAfterAl
       Map(),
       NodeType.REGULAR,
       "",
-      CatLevelOne.SOURCES,
-      "",
+      CatLevelOne.COLLECTIONS,
+      "android",
       Language.KOTLIN,
       Array()
     )
@@ -189,7 +192,7 @@ class AndroidXmlPassTest extends AnyWordSpec with Matchers with BeforeAndAfterAl
         .l
 
       taggedNodes.tag.where(_.nameExact(Constants.collectionSource)).value.headOption shouldBe Some("emailEditText")
-      taggedNodes.tag.where(_.nameExact(Constants.id)).value.headOption shouldBe Some("Data.Sensitive.Email")
+      taggedNodes.tag.where(_.nameExact(Constants.id)).value.headOption shouldBe Some("Collections.Android.Form.Email")
     }
   }
 
@@ -204,7 +207,7 @@ class AndroidXmlPassTest extends AnyWordSpec with Matchers with BeforeAndAfterAl
     val outputFile = File.newTemporaryFile()
     outPutFiles.addOne(outputFile)
     val rule: ConfigAndRules =
-      ConfigAndRules(sources, List(), List(), List(), List(), List(), List(), List(), List(), List())
+      ConfigAndRules(sources, List(), collections, List(), List(), List(), List(), List(), List(), List())
     ruleCache.setRule(rule)
     val config = Config().withInputPath(inputDir.toString()).withOutputPath(outputFile.toString())
     val cpg    = new Kotlin2Cpg().createCpgWithOverlays(config).get


### PR DESCRIPTION
With this approach, we won't use source rules and directly use special collection rules for android forms. This improves tagging coverage since source rules were missing multiple androidXmlTagging node names which are usually very consistent (`emailEditText`, `email_edit_text` etc). This also allows us to add new rules fast and get them added as collections

This has a dependency on android collection rules PR: https://github.com/Privado-Inc/privado/pull/356
