### PR TITLE
Fix/test failure scan pross

### DIFF
--- a/src/main/scala/ai/privado/audit/DataFlowReport.scala
+++ b/src/main/scala/ai/privado/audit/DataFlowReport.scala
@@ -1,6 +1,6 @@
 package ai.privado.audit
 
-import ai.privado.cache.{AuditCache, DataFlowCache}
+import ai.privado.cache.AuditCache
 
 import scala.collection.mutable.ListBuffer
 

--- a/src/main/scala/ai/privado/cache/AuditCache.scala
+++ b/src/main/scala/ai/privado/cache/AuditCache.scala
@@ -138,9 +138,7 @@ class AuditCache {
     dataflowMapByPathId
   }
 
-  def addIntoBeforeFirstDedup(
-    dataFlow: mutable.HashMap[String, mutable.HashMap[String, ListBuffer[DataFlowPathModel]]]
-  ): Unit = {
+  def addIntoBeforeFirstDedup(dataFlow: Map[String, mutable.HashMap[String, ListBuffer[DataFlowPathModel]]]): Unit = {
     dataFlow.foreach(flow => {
       flow._2.foreach(fileInfo => {
         fileInfo._2.foreach(dataflowModel => {

--- a/src/main/scala/ai/privado/cache/DataFlowCache.scala
+++ b/src/main/scala/ai/privado/cache/DataFlowCache.scala
@@ -154,7 +154,7 @@ object DataFlowCache {
     }
 
     if (privadoInput.generateAuditReport) {
-      auditCache.addIntoBeforeFirstDedup(dataflowAfterDedup)
+      auditCache.addIntoBeforeFirstDedup(dataflow)
     }
 
     val filteredSourceIdMap = dataflow.map(entrySet => {
@@ -168,7 +168,7 @@ object DataFlowCache {
       })
       (sourceId, filteredFileLineNumberMap)
     })
-    val flowsWithAppyDedupFalse = dataflow.flatMap(_._2.values.flatMap(_.filterNot(_.applyDedup).toList)).toList
+    val flowsWithApplyDedupFalse = dataflow.flatMap(_._2.values.flatMap(_.filterNot(_.applyDedup).toList)).toList
 
     if (privadoInput.generateAuditReport) {
       auditCache.addIntoBeforeSecondDedup(filteredSourceIdMap)
@@ -179,6 +179,6 @@ object DataFlowCache {
         fileLineNoEntry._2.foreach(dfpm => addToMap(dfpm))
       })
     })
-    dataflowAfterDedup.flatMap(_._2.values.flatMap(_.toList)).toList ::: flowsWithAppyDedupFalse
+    dataflowAfterDedup.flatMap(_._2.values.flatMap(_.toList)).toList ::: flowsWithApplyDedupFalse
   }
 }

--- a/src/main/scala/ai/privado/exporter/ExporterUtility.scala
+++ b/src/main/scala/ai/privado/exporter/ExporterUtility.scala
@@ -326,7 +326,7 @@ object ExporterUtility {
   ) = {
     logger.info("Initiated exporter engine")
     val sourceExporter             = new SourceExporter(cpg, ruleCache, privadoInput, repoItemTagName = repoItemTagName)
-    val sinkExporter               = new SinkExporter(cpg, ruleCache, repoItemTagName = repoItemTagName)
+    val sinkExporter               = new SinkExporter(cpg, ruleCache, privadoInput, repoItemTagName = repoItemTagName)
     val dataflowExporter           = new DataflowExporter(dataflows, taggerCache)
     val collectionExporter         = new CollectionExporter(cpg, ruleCache, repoItemTagName = repoItemTagName)
     val androidPermissionsExporter = new AndroidPermissionsExporter(cpg, ruleCache, repoItemTagName = repoItemTagName)

--- a/src/main/scala/ai/privado/exporter/SinkExporter.scala
+++ b/src/main/scala/ai/privado/exporter/SinkExporter.scala
@@ -24,9 +24,9 @@
 package ai.privado.exporter
 
 import ai.privado.cache.{DatabaseDetailsCache, RuleCache}
-import ai.privado.entrypoint.ScanProcessor
+import ai.privado.entrypoint.{PrivadoInput, ScanProcessor}
 import ai.privado.model.exporter.{SinkModel, SinkProcessingModel}
-import ai.privado.model.exporter.DataFlowEncoderDecoder._
+import ai.privado.model.exporter.DataFlowEncoderDecoder.*
 import ai.privado.semantic.Language.*
 import ai.privado.model.{CatLevelOne, Constants, DatabaseDetails, InternalTag, NodeType}
 import ai.privado.utility.Utilities
@@ -38,7 +38,7 @@ import org.slf4j.LoggerFactory
 
 import scala.collection.mutable
 
-class SinkExporter(cpg: Cpg, ruleCache: RuleCache, repoItemTagName: Option[String] = None) {
+class SinkExporter(cpg: Cpg, ruleCache: RuleCache, privadoInput: PrivadoInput, repoItemTagName: Option[String] = None) {
 
   lazy val sinkList: List[AstNode]      = getSinkList
   lazy val sinkTagList: List[List[Tag]] = sinkList.map(_.tag.l)
@@ -76,7 +76,7 @@ class SinkExporter(cpg: Cpg, ruleCache: RuleCache, repoItemTagName: Option[Strin
           entrySet._1,
           ExporterUtility
             .convertPathElements({
-              if (ScanProcessor.config.disableDeDuplication)
+              if (privadoInput.disableDeDuplication)
                 entrySet._2.toList
               else
                 entrySet._2.toList

--- a/src/main/scala/ai/privado/languageEngine/java/tagger/sink/FeignAPI.scala
+++ b/src/main/scala/ai/privado/languageEngine/java/tagger/sink/FeignAPI.scala
@@ -154,7 +154,7 @@ class FeignAPI(cpg: Cpg, ruleCache: RuleCache) {
             Utilities.getEngineContext(privadoInputConfig, 4)(JavaSemanticGenerator.getDefaultSemantics)
           )
           .l
-        if (ScanProcessor.config.disableDeDuplication)
+        if (privadoInputConfig.disableDeDuplication)
           flows
         else
           DuplicateFlowProcessor.getUniquePathsAfterDedup(flows)

--- a/src/main/scala/ai/privado/languageEngine/ruby/tagger/PrivadoTagger.scala
+++ b/src/main/scala/ai/privado/languageEngine/ruby/tagger/PrivadoTagger.scala
@@ -59,7 +59,7 @@ class PrivadoTagger(cpg: Cpg) extends PrivadoBaseTagger {
     new APITagger(cpg, ruleCache, privadoInput = privadoInputConfig).createAndApply()
     new CollectionTagger(cpg, ruleCache).createAndApply()
     new RubyDBConfigTagger(cpg).createAndApply()
-    if (!ScanProcessor.config.ignoreInternalRules) {
+    if (!privadoInputConfig.ignoreInternalRules) {
       StorageInheritRule.rules.foreach(ruleCache.setRuleInfo)
       new InheritMethodTagger(cpg, ruleCache).createAndApply()
 

--- a/src/test/scala/ai/privado/languageEngine/go/GoTestBase.scala
+++ b/src/test/scala/ai/privado/languageEngine/go/GoTestBase.scala
@@ -319,7 +319,6 @@ abstract class GoTestBase extends AnyWordSpec with Matchers with BeforeAndAfterA
       .withOutputPath(outputFile.pathAsString)
       .withFetchDependencies(downloadDependency)
 
-    ScanProcessor.config = privadoInput
     ruleCache.setRule(configAndRules)
     val cpg = new GoSrc2Cpg().createCpg(config).get
     AppCache.repoLanguage = Language.GO

--- a/src/test/scala/ai/privado/languageEngine/java/audit/DataFlowReportTest.scala
+++ b/src/test/scala/ai/privado/languageEngine/java/audit/DataFlowReportTest.scala
@@ -20,10 +20,6 @@ class DataFlowReportTest extends DataFlowReportTestBase {
 
   override def beforeAll(): Unit = {
     super.beforeAll()
-    val privadoInput = PrivadoInput(generateAuditReport = true, enableAuditSemanticsFilter = true)
-
-    // TODO Instead of assigning config directly need to pass instance.
-    ScanProcessor.config = privadoInput
 
     val context = new LayerCreatorContext(cpg)
     val options = new OssDataFlowOptions()

--- a/src/test/scala/ai/privado/languageEngine/java/audit/UnresolvedFlowTest.scala
+++ b/src/test/scala/ai/privado/languageEngine/java/audit/UnresolvedFlowTest.scala
@@ -21,10 +21,7 @@ class UnresolvedFlowTest extends UnresolvedFlowTestBase {
 
   override def beforeAll(): Unit = {
     super.beforeAll()
-    val privadoInput = PrivadoInput(generateAuditReport = true, enableAuditSemanticsFilter = true)
 
-    // TODO Instead of assigning config directly need to pass instance.
-    ScanProcessor.config = privadoInput
     val context = new LayerCreatorContext(cpg)
     val options = new OssDataFlowOptions()
     new OssDataFlow(options).run(context)

--- a/src/test/scala/ai/privado/languageEngine/java/audit/UnresolvedFlowTestBase.scala
+++ b/src/test/scala/ai/privado/languageEngine/java/audit/UnresolvedFlowTestBase.scala
@@ -1,6 +1,7 @@
 package ai.privado.languageEngine.java.audit
 
 import ai.privado.cache.{AuditCache, RuleCache, TaggerCache}
+import ai.privado.entrypoint.PrivadoInput
 import ai.privado.model.{CatLevelOne, ConfigAndRules, Language, NodeType, RuleInfo}
 import better.files.File
 import io.joern.javasrc2cpg.{Config, JavaSrc2Cpg}
@@ -108,6 +109,7 @@ abstract class UnresolvedFlowTestBase extends AnyWordSpec with Matchers with Bef
   val rule: ConfigAndRules =
     ConfigAndRules(sourceRule, sinkRule, List(), List(), List(), List(), List(), List(), List(), List())
 
-  val taggerCache = new TaggerCache()
-  val auditCache  = new AuditCache
+  val taggerCache  = new TaggerCache()
+  val auditCache   = new AuditCache
+  val privadoInput = PrivadoInput(generateAuditReport = true, enableAuditSemanticsFilter = true)
 }

--- a/src/test/scala/ai/privado/policyEngine/PolicyTests.scala
+++ b/src/test/scala/ai/privado/policyEngine/PolicyTests.scala
@@ -651,7 +651,6 @@ class PolicyTests extends AnyWordSpec with Matchers with BeforeAndAfterAll {
       PrivadoInput(generateAuditReport = true, enableAuditSemanticsFilter = true)
     val configAndRules =
       ConfigAndRules(sourceRule, sinkRule, collectionRule, List(), List(), List(), List(), List(), systemConfig, List())
-    ScanProcessor.config = privadoInput
     val ruleCache = new RuleCache()
     ruleCache.setRule(configAndRules)
     val cpg           = new JsSrc2Cpg().createCpgWithAllOverlays(config).get


### PR DESCRIPTION
Fixes the failing test case on dataflowAuditReport.
- Have removed the usage of `ScanProcessor.config`
- Have kept the base branch as `rubymonolith` otherwise there will be conflicts on the `rubymonolith` branch