### PR TITLE
Log4j: Changed console logs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -175,7 +175,7 @@ fabric.properties
 *.class
 
 # Log file
-*.log
+*.logs
 
 # BlueJ files
 *.ctxt

--- a/log4j2.xml
+++ b/log4j2.xml
@@ -1,16 +1,29 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Configuration status="WARN">
     <Appenders>
+        <!-- File Appender for Console Logs -->
         <Console name="Console" target="SYSTEM_ERR">
             <PatternLayout pattern="%d{yyy-MM-dd HH:mm:ss.SSS} %p %logger{36} %F:%L: %msg%n"/>
         </Console>
+        <!-- File Appender for Debug Logs -->
+        <File name="File" fileName="${sys:logFilePath:-logs/app.log}">
+            <PatternLayout pattern="%d{yyy-MM-dd HH:mm:ss.SSS} %p %logger{36} %F:%L: %msg%n"/>
+        </File>
     </Appenders>
+
+    <Loggers>
+        <Root level="ERROR">
+            <AppenderRef ref="Console"/>
+        </Root>
+    </Loggers>
+
     <Loggers>
         <logger name="com.networknt.schema" level="ERROR" />
         <logger name="io.shiftleft" level="WARN" />
         <logger name="io.joern" level="WARN" />
         <Root level="DEBUG">
-            <AppenderRef ref="Console" />
+            <AppenderRef ref="File"/>
         </Root>
     </Loggers>
+
 </Configuration>

--- a/log4j2.xml
+++ b/log4j2.xml
@@ -6,7 +6,7 @@
             <PatternLayout pattern="%d{yyy-MM-dd HH:mm:ss.SSS} %p %logger{36} %F:%L: %msg%n"/>
         </Console>
         <!-- File Appender for Debug Logs -->
-        <File name="File" fileName="${sys:logFilePath:-logs/app.log}">
+        <File name="File" fileName="${sys:logFilePath:-.logs/app.log}">
             <PatternLayout pattern="%d{yyy-MM-dd HH:mm:ss.SSS} %p %logger{36} %F:%L: %msg%n"/>
         </File>
     </Appenders>


### PR DESCRIPTION
**Context**:
Currently we are populating print statement and error log on console.

**Requirements**:
Logs getting printed on console should work as is and additional to that we need WARN logs from privado-core plus additional few libraries collected in a single file for debugging purpose.

**Changes**:
Console Logs: Addition to print statement we have added ERROR statement will be printed over console: https://github.com/Privado-Inc/privado-core/pull/884/files#diff-618cc4f8ed2a13c1d6cc9405f35994ddf20869ca42eec1438626d5ad9baf06d0R14

Logs collected in file: privado-core's DEBUG level and some other library's WARN level logs are collected: https://github.com/Privado-Inc/privado-core/pull/884/files#diff-618cc4f8ed2a13c1d6cc9405f35994ddf20869ca42eec1438626d5ad9baf06d0R20