### PR TITLE
Support allow filters in sources & sinks in Policies

### DIFF
--- a/src/main/resources/ai/privado/rulevalidator/schema/policies.json
+++ b/src/main/resources/ai/privado/rulevalidator/schema/policies.json
@@ -115,6 +115,31 @@
                     "title": "isSensitive",
                     "type": "boolean",
                     "default": false
+                  },
+                  "allowedSourceFilters": {
+                    "$id": "#root/policies/items/dataFlow/sourceFilters/allowedSourceFilters",
+                    "title": "AllowedSourceFilters",
+                    "type": "object",
+                    "default": null,
+                    "properties": {
+                      "sources": {
+                        "$id": "#root/policies/items/dataFlow/sourceFilters/allowedSourceFilters/sources",
+                        "title": "Sources",
+                        "type": "array",
+                        "default": [],
+                        "items":{
+                          "$id": "#root/policies/items/dataFlow/sourceFilters/allowedSourceFilters/sources/items",
+                          "title": "Items",
+                          "type": "string",
+                          "format": "regex",
+                          "default": "",
+                          "examples": [
+                            "Data.Sensitive.ContactData.*"
+                          ],
+                          "pattern": "^.*$"
+                        }
+                      }
+                    }
                   }
                 }
               },
@@ -168,6 +193,31 @@
                         "slack.com"
                       ],
                       "pattern": "^.*$"
+                    }
+                  },
+                  "allowedSinkFilters": {
+                    "$id": "#root/policies/items/dataFlow/sinkFilters/allowedSinkFilters",
+                    "title": "AllowedSinkFilters",
+                    "type": "object",
+                    "default": null,
+                    "properties": {
+                      "domains": {
+                        "$id": "#root/policies/items/dataFlow/sinkFilters/allowedSinkFilters/domains",
+                        "title": "Domains",
+                        "type": "array",
+                        "default": [],
+                        "items":{
+                          "$id": "#root/policies/items/dataFlow/sinkFilters/allowedSinkFilters/domains/items",
+                          "title": "Items",
+                          "type": "string",
+                          "format": "regex",
+                          "default": "",
+                          "examples": [
+                            "slack.com"
+                          ],
+                          "pattern": "^.*$"
+                        }
+                      }
                     }
                   }
                 }

--- a/src/main/resources/ai/privado/rulevalidator/schema/threats.json
+++ b/src/main/resources/ai/privado/rulevalidator/schema/threats.json
@@ -106,6 +106,31 @@
                     "title": "isSensitive",
                     "type": "boolean",
                     "default": false
+                  },
+                  "allowedSourceFilters": {
+                    "$id": "#root/policies/items/dataFlow/sourceFilters/allowedSourceFilters",
+                    "title": "AllowedSourceFilters",
+                    "type": "object",
+                    "default": null,
+                    "properties": {
+                      "sources": {
+                        "$id": "#root/policies/items/dataFlow/sourceFilters/allowedSourceFilters/sources",
+                        "title": "Sources",
+                        "type": "array",
+                        "default": [],
+                        "items":{
+                          "$id": "#root/policies/items/dataFlow/sourceFilters/allowedSourceFilters/sources/items",
+                          "title": "Items",
+                          "type": "string",
+                          "format": "regex",
+                          "default": "",
+                          "examples": [
+                            "Data.Sensitive.ContactData.*"
+                          ],
+                          "pattern": "^.*$"
+                        }
+                      }
+                    }
                   }
                 }
               },
@@ -159,6 +184,31 @@
                         "slack.com"
                       ],
                       "pattern": "^.*$"
+                    }
+                  },
+                  "allowedSinkFilters": {
+                    "$id": "#root/policies/items/dataFlow/sinkFilters/allowedSinkFilters",
+                    "title": "AllowedSinkFilters",
+                    "type": "object",
+                    "default": null,
+                    "properties": {
+                      "domains": {
+                        "$id": "#root/policies/items/dataFlow/sinkFilters/allowedSinkFilters/domains",
+                        "title": "Domains",
+                        "type": "array",
+                        "default": [],
+                        "items":{
+                          "$id": "#root/policies/items/dataFlow/sinkFilters/allowedSinkFilters/domains/items",
+                          "title": "Items",
+                          "type": "string",
+                          "format": "regex",
+                          "default": "",
+                          "examples": [
+                            "slack.com"
+                          ],
+                          "pattern": "^.*$"
+                        }
+                      }
                     }
                   }
                 }

--- a/src/main/scala/ai/privado/model/Constants.scala
+++ b/src/main/scala/ai/privado/model/Constants.scala
@@ -97,6 +97,8 @@ object Constants {
   val sources                      = "sources"
   val sourceFilters                = "sourceFilters"
   val sinkFilters                  = "sinkFilters"
+  val allowedSourceFilters         = "allowedSourceFilters"
+  val allowedSinkFilters           = "allowedSinkFilters"
   val sinkType                     = "sinkType"
   val collectionFilters            = "collectionFilters"
   val collectionType               = "collectionType"

--- a/src/main/scala/ai/privado/policyEngine/PolicyExecutor.scala
+++ b/src/main/scala/ai/privado/policyEngine/PolicyExecutor.scala
@@ -264,6 +264,20 @@ class PolicyExecutor(
         val ruleInfo = ruleCache.getRuleInfo(sinkId)
         namePattern.exists(pattern => ruleInfo.exists(info => pattern.findFirstIn(info.name).nonEmpty))
       }
+    println(matchingSourceIds)
+    println("Allowed Sources: ")
+    println(sourceFilters.allowedSourceFilters.sources)
+    if (sourceFilters.allowedSourceFilters.sources.nonEmpty) {
+      matchingSourceIds = matchingSourceIds.filter { sourceId =>
+        sourceFilters.allowedSourceFilters.sources
+          .filter(d => {
+            val sourcePattern: Regex = d.r
+            sourcePattern.findFirstIn(sourceId).nonEmpty
+          })
+          .isEmpty
+      }
+    }
+    println(matchingSourceIds)
 
     matchingSourceIds
   }
@@ -311,6 +325,33 @@ class PolicyExecutor(
         }
       }
     }
+
+    println(matchingSinkIds)
+    if (sinkFilters.allowedSinkFilters.domains.nonEmpty) {
+      matchingSinkIds = matchingSinkIds.filter { sinkId =>
+        val ruleInfo = ruleCache.getRuleInfo(sinkId)
+        // ----------------Covering Cases:
+        // Sinks.ThirdParties.API.mediaconvert.awsRegion.amazonaws.com
+        // Sinks.ThirdParties.API.axios.com
+        // ThirdParties.SDK.Sendgrid
+        // ----------------Not covered:
+        // Sinks.API.InternalAPI
+        // Sinks.ThirdParties.API
+        if (sinkId.contains(f"${Constants.thirdPartiesAPIRuleId}.")) {
+          sinkFilters.allowedSinkFilters.domains
+            .filter(d => {
+              val domainPattern: Regex = d.r
+              domainPattern.findFirstIn(sinkId).nonEmpty
+            })
+            .isEmpty
+        } else {
+          ruleInfo.exists(info => info.domains.intersect(sinkFilters.allowedSinkFilters.domains).isEmpty)
+        }
+      }
+    }
+    println("Allowed Sinks: ")
+    println(sinkFilters.allowedSinkFilters.domains)
+    println(matchingSinkIds)
 
     if (sinkFilters.name.nonEmpty)
       val namePattern: Option[Regex] = Some(sinkFilters.name.r)

--- a/src/main/scala/ai/privado/policyEngine/PolicyExecutor.scala
+++ b/src/main/scala/ai/privado/policyEngine/PolicyExecutor.scala
@@ -264,9 +264,6 @@ class PolicyExecutor(
         val ruleInfo = ruleCache.getRuleInfo(sinkId)
         namePattern.exists(pattern => ruleInfo.exists(info => pattern.findFirstIn(info.name).nonEmpty))
       }
-    println(matchingSourceIds)
-    println("Allowed Sources: ")
-    println(sourceFilters.allowedSourceFilters.sources)
     if (sourceFilters.allowedSourceFilters.sources.nonEmpty) {
       matchingSourceIds = matchingSourceIds.filter { sourceId =>
         sourceFilters.allowedSourceFilters.sources
@@ -277,7 +274,6 @@ class PolicyExecutor(
           .isEmpty
       }
     }
-    println(matchingSourceIds)
 
     matchingSourceIds
   }
@@ -326,7 +322,6 @@ class PolicyExecutor(
       }
     }
 
-    println(matchingSinkIds)
     if (sinkFilters.allowedSinkFilters.domains.nonEmpty) {
       matchingSinkIds = matchingSinkIds.filter { sinkId =>
         val ruleInfo = ruleCache.getRuleInfo(sinkId)
@@ -349,9 +344,6 @@ class PolicyExecutor(
         }
       }
     }
-    println("Allowed Sinks: ")
-    println(sinkFilters.allowedSinkFilters.domains)
-    println(matchingSinkIds)
 
     if (sinkFilters.name.nonEmpty)
       val namePattern: Option[Regex] = Some(sinkFilters.name.r)

--- a/src/test/scala/ai/privado/policyEngine/PolicyTests.scala
+++ b/src/test/scala/ai/privado/policyEngine/PolicyTests.scala
@@ -59,7 +59,7 @@ class PolicyTests extends AnyWordSpec with Matchers with BeforeAndAfterAll {
       "",
       Array(),
       List("(?i).*(user[^\\s/(;)#|,=!>]{0,5}name)"),
-      false,
+      true,
       "",
       Map(),
       NodeType.REGULAR,
@@ -211,9 +211,9 @@ class PolicyTests extends AnyWordSpec with Matchers with BeforeAndAfterAll {
       PolicyAction.DENY,
       DataFlow(
         List("Data.Sensitive.ContactData.*"),
-        SourceFilter(Option(true), "", ""),
+        SourceFilter(Option(true), "", "", AllowedSourceFilters(List[String]())),
         List("Leakages.Log.*"),
-        SinkFilter(List[String](), "", ""),
+        SinkFilter(List[String](), "", "", AllowedSinkFilters(List[String]())),
         CollectionFilter("", "")
       ),
       List(".*"),
@@ -250,9 +250,9 @@ class PolicyTests extends AnyWordSpec with Matchers with BeforeAndAfterAll {
       PolicyAction.DENY,
       DataFlow(
         List("Data.Sensitive.ContactData.*"),
-        SourceFilter(Option(true), "", ""),
+        SourceFilter(Option(true), "", "", AllowedSourceFilters(List[String]())),
         List(".*"),
-        SinkFilter(List[String](), "ThirdParties.API", ""),
+        SinkFilter(List[String](), "ThirdParties.API", "", AllowedSinkFilters(List[String]())),
         CollectionFilter("", "")
       ),
       List(".*"),
@@ -298,9 +298,9 @@ class PolicyTests extends AnyWordSpec with Matchers with BeforeAndAfterAll {
       PolicyAction.DENY,
       DataFlow(
         List(".*"),
-        SourceFilter(Option(true), "", "(?i).*email.*"),
+        SourceFilter(Option(true), "", "(?i).*email.*", AllowedSourceFilters(List[String]())),
         List(".*"),
-        SinkFilter(List[String]("drive.google.com"), "", ""),
+        SinkFilter(List[String]("drive.google.com"), "", "", AllowedSinkFilters(List[String]())),
         CollectionFilter("", "")
       ),
       List(".*"),
@@ -336,6 +336,61 @@ class PolicyTests extends AnyWordSpec with Matchers with BeforeAndAfterAll {
     }
   }
 
+  "Policy Executor: Applying the allowedSourceFilters & allowedSinkFilters" should {
+    val policySinkFilter = PolicyOrThreat(
+      "Policy.Deny.Sharing.ThirdParties.SDK.Google.Drive",
+      "Policy to restrict Contact Information being send to thirdparty sdk",
+      "Example: Don't send contact data to thirdparty sdk",
+      "Talk to the Data Protection team: dataprotection@org.com",
+      PolicyThreatType.COMPLIANCE,
+      PolicyAction.DENY,
+      DataFlow(
+        List(".*"),
+        SourceFilter(Option(true), "", "", AllowedSourceFilters(List[String]("Data.Sensitive.ContactData"))),
+        List(".*"),
+        SinkFilter(List[String](), "", "", AllowedSinkFilters(List[String]("drive.google.com"))),
+        CollectionFilter("", "")
+      ),
+      List(".*"),
+      Map[String, String](),
+      Map[String, String](),
+      "",
+      Array[String]()
+    )
+
+    val policyExecutor = code("""
+        |const google = require('googleapis');
+        |const axios = require('axios');
+        |
+        |const username =  "XWXX-2324-KJHH";
+        |
+        |const accountDetails = {
+        |    "ccN": emailAddress
+        |};
+        |
+        |const emailAddress = "jhgjbk@gfdghch";
+        |const apiUrl = `https://123.axios.com/todos/${username}`;
+        |
+        |// Make an API request using Fetch
+        |axios.get(apiUrl).then((response) => { return response.json(); })
+        |
+        |// Create a new instance of the Drive API
+        |export const driveObj = google.drive([accountDetails], {version: 'v3', auth });
+        |""".stripMargin)
+
+    val List(violationDataflowModel) = policyExecutor.getViolatingFlowsForPolicy(policySinkFilter).toList
+    "have a sourceId and sinkId" in {
+      violationDataflowModel.sourceId shouldBe "Data.Sensitive.AccountName"
+      violationDataflowModel.sinkId shouldBe "Sinks.ThirdParties.API.123.axios.com"
+    }
+    "have non-empty pathIds" in {
+      violationDataflowModel.pathIds.size shouldBe 1
+    }
+    "have only unique path ids" in {
+      violationDataflowModel.pathIds.size == violationDataflowModel.pathIds.toSet.size shouldBe true
+    }
+  }
+
   "Policy Executor: SinkFilters by domains with regex" should {
     val policySinkFilter = PolicyOrThreat(
       "Policy.Deny.Sharing.ThirdParties.SDK.Google.Drive",
@@ -346,9 +401,9 @@ class PolicyTests extends AnyWordSpec with Matchers with BeforeAndAfterAll {
       PolicyAction.DENY,
       DataFlow(
         List(".*"),
-        SourceFilter(Option(true), "", ""),
+        SourceFilter(Option(true), "", "", AllowedSourceFilters(List[String]())),
         List(".*"),
-        SinkFilter(List[String]("axios.com"), "", ""),
+        SinkFilter(List[String]("axios.com"), "", "", AllowedSinkFilters(List[String]())),
         CollectionFilter("", "")
       ),
       List(".*"),
@@ -390,9 +445,9 @@ class PolicyTests extends AnyWordSpec with Matchers with BeforeAndAfterAll {
       PolicyAction.DENY,
       DataFlow(
         List(".*"),
-        SourceFilter(Option(false), "", ""),
+        SourceFilter(Option(false), "", "", AllowedSourceFilters(List[String]())),
         List(".*"),
-        SinkFilter(List[String](), "", ""),
+        SinkFilter(List[String](), "", "", AllowedSinkFilters(List[String]())),
         CollectionFilter("api", "/v1/auth0/user/reset-pass")
       ),
       List(".*"),
@@ -458,9 +513,9 @@ class PolicyTests extends AnyWordSpec with Matchers with BeforeAndAfterAll {
       PolicyAction.DENY,
       DataFlow(
         List("**"),
-        SourceFilter(Option(false), "", ""),
+        SourceFilter(Option(false), "", "", AllowedSourceFilters(List[String]())),
         List(),
-        SinkFilter(List[String](), "", ""),
+        SinkFilter(List[String](), "", "", AllowedSinkFilters(List[String]())),
         CollectionFilter("", "")
       ),
       List(".*"),
@@ -502,9 +557,9 @@ class PolicyTests extends AnyWordSpec with Matchers with BeforeAndAfterAll {
       PolicyAction.DENY,
       DataFlow(
         List("**"),
-        SourceFilter(Option(false), "", ""),
+        SourceFilter(Option(false), "", "", AllowedSourceFilters(List[String]())),
         List(".*"),
-        SinkFilter(List[String](), "", ""),
+        SinkFilter(List[String](), "", "", AllowedSinkFilters(List[String]())),
         CollectionFilter("form", "")
       ),
       List(".*"),
@@ -592,9 +647,9 @@ class PolicyTests extends AnyWordSpec with Matchers with BeforeAndAfterAll {
       PolicyAction.DENY,
       DataFlow(
         List("Data.Sensitive.Password"),
-        SourceFilter(Option(false), "", ""),
+        SourceFilter(Option(false), "", "", AllowedSourceFilters(List[String]())),
         List(),
-        SinkFilter(List[String](), "", ""),
+        SinkFilter(List[String](), "", "", AllowedSinkFilters(List[String]())),
         CollectionFilter("api", "")
       ),
       List(".*"),

--- a/src/test/scala/ai/privado/threatEngine/GoThreatTests.scala
+++ b/src/test/scala/ai/privado/threatEngine/GoThreatTests.scala
@@ -22,9 +22,9 @@ class GoThreatTests extends GoTestBase {
       PolicyAction.DENY,
       DataFlow(
         List(),
-        SourceFilter(Option(true), "", ""),
+        SourceFilter(Option(true), "", "", AllowedSourceFilters(List[String]())),
         List[String](),
-        SinkFilter(List[String](), "", ""),
+        SinkFilter(List[String](), "", "", AllowedSinkFilters(List[String]())),
         CollectionFilter("", "")
       ),
       List("**"),
@@ -197,9 +197,9 @@ class GoThreatTests extends GoTestBase {
       PolicyAction.DENY,
       DataFlow(
         List(),
-        SourceFilter(Option(true), "", ""),
+        SourceFilter(Option(true), "", "", AllowedSourceFilters(List[String]())),
         List[String](),
-        SinkFilter(List[String](), "", ""),
+        SinkFilter(List[String](), "", "", AllowedSinkFilters(List[String]())),
         CollectionFilter("", "")
       ),
       List("**"),
@@ -372,9 +372,9 @@ class GoThreatTests extends GoTestBase {
       PolicyAction.DENY,
       DataFlow(
         List(),
-        SourceFilter(Option(true), "", ""),
+        SourceFilter(Option(true), "", "", AllowedSourceFilters(List[String]())),
         List[String](),
-        SinkFilter(List[String](), "", ""),
+        SinkFilter(List[String](), "", "", AllowedSinkFilters(List[String]())),
         CollectionFilter("", "")
       ),
       List("**"),


### PR DESCRIPTION
Trying to add below support 

```dataFlow:
      sources:
        - **          
      sinks:
        - **
      sourceFilters:
        allowedSourceFilters:
          sources:
            - "(?i)PhoneNumber"
      sinkFilters:
        allowedSinkFilters:
          domains:
            - "aws.amazon.com"```

