### PR TITLE
use updated version of goastgen to ignore the indirect dependencies

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -16,7 +16,7 @@ val upickle           = "3.1.2"
 val circeVersion    = "0.14.2"
 val jacksonVersion  = "2.15.2"
 val mockitoVersion  = "1.17.14"
-val goAstGenVersion = "0.11.0"
+val goAstGenVersion = "0.12.0"
 
 lazy val schema         = Projects.schema
 lazy val domainClasses  = Projects.domainClasses


### PR DESCRIPTION
use the updated version of goastgen to ignore the indirect dependencies

We made changes in `goastgen` utility to add metadata to go.mod.josn to filter out indirect dependencies. We updated the `goastgen` version inside main language engine build.sbt. However it wasn't updated inside `privado-core` hence it was downloading all the dependencies including the indirect one. With this change it will only download direct dependencies.