### PR TITLE
Bump up Scala version to `3.3.1`

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ import sbt.Credentials
 
 name                     := "privado-core"
 ThisBuild / organization := "ai.privado"
-ThisBuild / scalaVersion := "3.3.0"
+ThisBuild / scalaVersion := "3.3.1"
 ThisBuild / version      := sys.env.getOrElse("BUILD_VERSION", "dev-SNAPSHOT")
 // parsed by project/Versions.scala, updated by updateDependencies.sh
 


### PR DESCRIPTION
Bumping up the patch version allows us to utilise a newer JDK version based on earlier discussions. `stage` and `tests` work fine and I haven't noticed any issues.