### PR TITLE
Check in taggers for PHP

### DIFF
--- a/src/main/scala/ai/privado/languageEngine/php/tagger/PrivadoTagger.scala
+++ b/src/main/scala/ai/privado/languageEngine/php/tagger/PrivadoTagger.scala
@@ -25,10 +25,9 @@ package ai.privado.languageEngine.php.tagger
 
 import ai.privado.cache.{DataFlowCache, RuleCache, TaggerCache}
 import ai.privado.entrypoint.PrivadoInput
-import ai.privado.languageEngine.java.tagger.source.IdentifierTagger
 import ai.privado.tagger.PrivadoBaseTagger
 import ai.privado.tagger.sink.RegularSinkTagger
-import ai.privado.tagger.source.LiteralTagger
+import ai.privado.tagger.source.{IdentifierTagger, LiteralTagger}
 import io.shiftleft.codepropertygraph.generated.Cpg
 import io.shiftleft.codepropertygraph.generated.nodes.Tag
 import io.shiftleft.semanticcpg.language.*
@@ -48,7 +47,7 @@ class PrivadoTagger(cpg: Cpg) extends PrivadoBaseTagger {
 
     new LiteralTagger(cpg, rules).createAndApply()
     new RegularSinkTagger(cpg, rules).createAndApply()
-    new IdentifierTagger(cpg, rules, taggerCache).createAndApply()
+    new IdentifierTagger(cpg, rules).createAndApply()
 
     logger.info("Finished tagging")
     cpg.tag

--- a/src/main/scala/ai/privado/languageEngine/php/tagger/PrivadoTagger.scala
+++ b/src/main/scala/ai/privado/languageEngine/php/tagger/PrivadoTagger.scala
@@ -1,0 +1,56 @@
+/*
+ * This file is part of Privado OSS.
+ *
+ * Privado is an open source static code analysis tool to discover data flows in the code.
+ * Copyright (C) 2022 Privado, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * For more information, contact support@privado.ai
+ *
+ */
+
+package ai.privado.languageEngine.php.tagger
+
+import ai.privado.cache.{DataFlowCache, RuleCache, TaggerCache}
+import ai.privado.entrypoint.PrivadoInput
+import ai.privado.languageEngine.java.tagger.source.IdentifierTagger
+import ai.privado.tagger.PrivadoBaseTagger
+import ai.privado.tagger.sink.RegularSinkTagger
+import ai.privado.tagger.source.LiteralTagger
+import io.shiftleft.codepropertygraph.generated.Cpg
+import io.shiftleft.codepropertygraph.generated.nodes.Tag
+import io.shiftleft.semanticcpg.language.*
+import org.slf4j.LoggerFactory
+import overflowdb.traversal.Traversal
+
+class PrivadoTagger(cpg: Cpg) extends PrivadoBaseTagger {
+  private val logger = LoggerFactory.getLogger(this.getClass)
+
+  override def runTagger(
+    rules: RuleCache,
+    taggerCache: TaggerCache,
+    privadoInputConfig: PrivadoInput,
+    dataFlowCache: DataFlowCache
+  ): Traversal[Tag] = {
+    logger.info("Beginning tagging")
+
+    new LiteralTagger(cpg, rules).createAndApply()
+    new RegularSinkTagger(cpg, rules).createAndApply()
+    new IdentifierTagger(cpg, rules, taggerCache).createAndApply()
+
+    logger.info("Finished tagging")
+    cpg.tag
+  }
+}

--- a/src/main/scala/ai/privado/languageEngine/ruby/tagger/PrivadoTagger.scala
+++ b/src/main/scala/ai/privado/languageEngine/ruby/tagger/PrivadoTagger.scala
@@ -27,12 +27,12 @@ import ai.privado.cache.{DataFlowCache, RuleCache, TaggerCache}
 import ai.privado.entrypoint.{PrivadoInput, ScanProcessor, TimeMetric}
 import ai.privado.languageEngine.ruby.tagger.collection.CollectionTagger
 import ai.privado.languageEngine.ruby.config.RubyDBConfigTagger
-import ai.privado.languageEngine.ruby.tagger.source.{IdentifierDerivedTagger, IdentifierTagger}
+import ai.privado.languageEngine.ruby.tagger.source.IdentifierDerivedTagger
 import ai.privado.languageEngine.ruby.feeder.{LeakageRule, StorageInheritRule}
 import ai.privado.languageEngine.ruby.tagger.monolith.MonolithTagger
 import ai.privado.languageEngine.ruby.tagger.sink.{APITagger, InheritMethodTagger, LeakageTagger, RegularSinkTagger}
 import ai.privado.tagger.PrivadoBaseTagger
-import ai.privado.tagger.source.{LiteralTagger, SqlQueryTagger}
+import ai.privado.tagger.source.{IdentifierTagger, LiteralTagger, SqlQueryTagger}
 import io.shiftleft.codepropertygraph.generated.Cpg
 import io.shiftleft.codepropertygraph.generated.nodes.Tag
 import io.shiftleft.semanticcpg.language.*

--- a/src/main/scala/ai/privado/tagger/source/IdentifierTagger.scala
+++ b/src/main/scala/ai/privado/tagger/source/IdentifierTagger.scala
@@ -21,7 +21,7 @@
  *
  */
 
-package ai.privado.languageEngine.ruby.tagger.source
+package ai.privado.tagger.source
 
 import ai.privado.cache.RuleCache
 import ai.privado.model.{InternalTag, RuleInfo}


### PR DESCRIPTION
This PR checks in the taggers required for supporting PHP. In addition to that, based on my discussions with Khemraj, I've moved the `IdentifierTagger` from `ruby` package to the common package for its reuse.