### PR TITLE
changed log handling and exit handling

### DIFF
--- a/src/main/scala/ai/privado/entrypoint/ScanProcessor.scala
+++ b/src/main/scala/ai/privado/entrypoint/ScanProcessor.scala
@@ -192,12 +192,12 @@ object ScanProcessor extends CommandProcessor {
                     )
                   case Left(error) =>
                     logger.error("Error while parsing this file -> '" + fullPath)
-                    logger.error("ERROR : " + error)
+                    logger.error("ERROR : ", error)
                     getEmptyConfigAndRule
                 }
               case Left(error) =>
                 logger.error("Error while parsing this file -> '" + fullPath)
-                logger.error("ERROR : " + error)
+                logger.error("ERROR : ", error)
                 getEmptyConfigAndRule
             }
           })
@@ -235,9 +235,6 @@ object ScanProcessor extends CommandProcessor {
   def processRules(lang: Set[Language], ruleCache: RuleCache): ConfigAndRules = {
     var internalConfigAndRules = getEmptyConfigAndRule
     if (!config.ignoreInternalRules) {
-      internalConfigAndRules = parseRules(config.internalConfigPath.head, lang)
-      ruleCache.setInternalRules(internalConfigAndRules)
-
       try {
         AppCache.privadoVersionMain = File((s"${config.internalConfigPath.head}/version.txt")).contentAsString
       } catch {
@@ -245,6 +242,8 @@ object ScanProcessor extends CommandProcessor {
           AppCache.privadoVersionMain = Constants.notDetected
       }
       println(s"Privado Main Version: ${AppCache.privadoVersionMain}")
+      internalConfigAndRules = parseRules(config.internalConfigPath.head, lang)
+      ruleCache.setInternalRules(internalConfigAndRules)
     }
     var externalConfigAndRules = getEmptyConfigAndRule
     if (config.externalConfigPath.nonEmpty) {

--- a/src/main/scala/ai/privado/rulevalidator/YamlFileValidator.scala
+++ b/src/main/scala/ai/privado/rulevalidator/YamlFileValidator.scala
@@ -66,7 +66,7 @@ object YamlFileValidator {
     */
   def validateDirectory(dir: File): Iterator[ValidationFailure] = {
 
-    logger.debug(s"Validating directory : ${dir.pathAsString}")
+    logger.trace(s"Validating directory : ${dir.pathAsString}")
     val validationErrors: Iterator[ValidationFailure] = dir.listRecursively
       .filter(subDir =>
         subDir
@@ -170,7 +170,7 @@ object YamlFileValidator {
 
     val catLevelOneKey =
       if (ruleJsonTree.fieldNames().hasNext) ruleJsonTree.fieldNames().next() else CatLevelOne.UNKNOWN.name
-    logger.debug(s"Found CatLevelOne key '$catLevelOneKey' in file : ${ruleFile.pathAsString}")
+    logger.trace(s"Found CatLevelOne key '$catLevelOneKey' in file : ${ruleFile.pathAsString}")
     CatLevelOne
       .withNameWithDefault(catLevelOneKey) match {
       case CatLevelOne.SOURCES     => Right(CatLevelOne.SOURCES.name, SOURCES)


### PR DESCRIPTION
1. Made changes in few log statments to log the complete stack trace.
2. Made changes to convert debug to trace logs for rule valiation.
3. Added exit(1) in main error handling situation, to indicate outer process that the scan failed. Made respective change in matric collection method calls as `finally` block will not be invoked after `exit(1)` call.