### PR TITLE
add asset discovery flag

### DIFF
--- a/src/main/scala/ai/privado/entrypoint/CommandParser.scala
+++ b/src/main/scala/ai/privado/entrypoint/CommandParser.scala
@@ -55,7 +55,8 @@ case class PrivadoInput(
   limitArgExpansionDataflows: Int = -1,
   offlineMode: Boolean = false,
   isMonolith: Boolean = false,
-  enableIngressAndEgressUrls: Boolean = false
+  enableIngressAndEgressUrls: Boolean = false,
+  assetDiscovery: Boolean = false
 )
 
 object CommandConstants {
@@ -107,6 +108,7 @@ object CommandConstants {
   val OFFLINE_MODE_ABBR                            = "om"
   val IS_MONOLITH                                  = "monolith"
   val ENABLE_INGRESS_AND_EGRESS_URLS               = "enableIngressAndEgressUrls"
+  val ASSEST_DISCOVERY                             = "asset-discovery"
 }
 
 object CommandParser {
@@ -185,6 +187,10 @@ object CommandParser {
               .optional()
               .action((_, c) => c.copy(enableIngressAndEgressUrls = true))
               .text("Add ingress and egress url in result json"),
+            opt[Unit](CommandConstants.ASSEST_DISCOVERY)
+              .optional()
+              .action((_, c) => c.copy(assetDiscovery = true))
+              .text("Add asset discovery details in result json"),
             opt[Unit](CommandConstants.DISABLE_2ND_LEVEL_CLOSURE)
               .abbr(CommandConstants.DISABLE_2ND_LEVEL_CLOSURE_ABBR)
               .optional()

--- a/src/main/scala/ai/privado/passes/PropertyParserPass.scala
+++ b/src/main/scala/ai/privado/passes/PropertyParserPass.scala
@@ -400,7 +400,7 @@ class PropertyParserPass(cpg: Cpg, projectRoot: String, ruleCache: RuleCache, la
     }
 
     SourceFiles
-      .determine(Set(projectRoot), extensions)(VisitOptions.default)
+      .determine(Set(projectRoot), extensions, ignoredFilesRegex = Some(".*[.]privado.*"))(VisitOptions.default)
       .concat(
         getListOfFiles(projectRoot)
           .map(f => {

--- a/src/main/scala/ai/privado/passes/PropertyParserPass.scala
+++ b/src/main/scala/ai/privado/passes/PropertyParserPass.scala
@@ -400,7 +400,7 @@ class PropertyParserPass(cpg: Cpg, projectRoot: String, ruleCache: RuleCache, la
     }
 
     SourceFiles
-      .determine(Set(projectRoot), extensions, ignoredFilesRegex = Some(".*[.]privado.*"))(VisitOptions.default)
+      .determine(projectRoot, extensions, ignoredFilesRegex = Some(".*[.]privado.*".r))(VisitOptions.default)
       .concat(
         getListOfFiles(projectRoot)
           .map(f => {


### PR DESCRIPTION
- add new flag `asset-discovery`
- skip reading `.privado` folder when running Property Pass