### PR TITLE
Changed JS API tagger

### DIFF
--- a/src/main/scala/ai/privado/languageEngine/javascript/tagger/sink/JSAPITagger.scala
+++ b/src/main/scala/ai/privado/languageEngine/javascript/tagger/sink/JSAPITagger.scala
@@ -52,6 +52,12 @@ import overflowdb.BatchedUpdate
 class JSAPITagger(cpg: Cpg, ruleCache: RuleCache, privadoInput: PrivadoInput)
     extends APITagger(cpg, ruleCache, privadoInput) {
 
+  override val apis = cacheCall
+    .name(APISINKS_REGEX)
+    .methodFullNameNot(COMMON_IGNORED_SINKS_REGEX)
+    .code(commonHttpPackages)
+    .l
+
   override def runOnPart(builder: DiffGraphBuilder, ruleInfo: RuleInfo): Unit = {
     super.runOnPart(builder, ruleInfo)
 

--- a/src/main/scala/ai/privado/tagger/sink/APITagger.scala
+++ b/src/main/scala/ai/privado/tagger/sink/APITagger.scala
@@ -45,6 +45,7 @@ class APITagger(cpg: Cpg, ruleCache: RuleCache, privadoInput: PrivadoInput)
   lazy val APISINKS_REGEX        = ruleCache.getSystemConfigByKey(Constants.apiSinks)
   val commonHttpPackages: String = ruleCache.getSystemConfigByKey(Constants.apiHttpLibraries)
 
+  // NOTE : JSAPITagger is overriding it to run the query on cpg.code instead of methodFullName
   val apis = cacheCall
     .name(APISINKS_REGEX)
     .methodFullNameNot(COMMON_IGNORED_SINKS_REGEX)


### PR DESCRIPTION
Changed JS API tagger to run the queries on `cpg.code` instead of methodFullName