### PR TITLE
HTTP Audit Report

### DIFF
--- a/src/main/scala/ai/privado/audit/AuditReportConstants.scala
+++ b/src/main/scala/ai/privado/audit/AuditReportConstants.scala
@@ -14,6 +14,8 @@ object AuditReportConstants {
 
   val AUDIT_API_SHEET_NAME = "API Audit"
 
+  val AUDIT_HTTP_SHEET_NAME = "Http Audit"
+
   val AUDIT_EMPTY_CELL_VALUE = "--"
 
   val AUDIT_CHECKED_VALUE = "YES"
@@ -125,11 +127,15 @@ object AuditReportConstants {
   val JS_ELEMENTS_TO_BE_EXCLUDED =
     "^(?i)(modules?|loggers?|val|console|require|_|get|key|value|data|page|url|Set|filter|<init>|err|errors|axios|express|router|component|Instance|utils?|app|undefined|context|process|...props?|async|await|const|let|var|this)$"
 
-  val URLREGEX = ".*(/).*"
+  val URL_REGEX = ".*(/).*"
 
   val URL_AUDIT_URL_NAME = "URL"
+
+  val HTTP_AUDIT_HTTP_NAME = "http"
 
   val AUDIT_LINE_NO = "Line No."
 
   val API_AUDIT_API_NAME = "API Call"
+
+  val HTTP_REGEX = ".*http.*"
 }

--- a/src/main/scala/ai/privado/audit/AuditReportEntryPoint.scala
+++ b/src/main/scala/ai/privado/audit/AuditReportEntryPoint.scala
@@ -100,7 +100,9 @@ object AuditReportEntryPoint {
       UnresolvedFlowReport.processUnresolvedFlow(auditCache)
     )
 
-    createSheet(workbook, AuditReportConstants.AUDIT_URL_SHEET_NAME, URLReport.processURLAudit(xtocpg))
+    createSheet(workbook, AuditReportConstants.AUDIT_URL_SHEET_NAME, LiteralReport.processURLAudit(xtocpg))
+
+    createSheet(workbook, AuditReportConstants.AUDIT_HTTP_SHEET_NAME, LiteralReport.processHTTPAudit(xtocpg))
 
     createSheet(workbook, AuditReportConstants.AUDIT_API_SHEET_NAME, APIReport.processAPIAudit(xtocpg, ruleCache))
 
@@ -115,7 +117,9 @@ object AuditReportEntryPoint {
       DataFlowReport.processDataFlowAudit(auditCache)
     )
 
-    createSheet(workbook, AuditReportConstants.AUDIT_URL_SHEET_NAME, URLReport.processURLAudit(xtocpg))
+    createSheet(workbook, AuditReportConstants.AUDIT_URL_SHEET_NAME, LiteralReport.processURLAudit(xtocpg))
+
+    createSheet(workbook, AuditReportConstants.AUDIT_HTTP_SHEET_NAME, LiteralReport.processHTTPAudit(xtocpg))
 
     createSheet(workbook, AuditReportConstants.AUDIT_API_SHEET_NAME, APIReport.processAPIAudit(xtocpg, ruleCache))
 
@@ -149,7 +153,9 @@ object AuditReportEntryPoint {
       UnresolvedFlowReport.processUnresolvedFlow(auditCache)
     )
 
-    createSheet(workbook, AuditReportConstants.AUDIT_URL_SHEET_NAME, URLReport.processURLAudit(xtocpg))
+    createSheet(workbook, AuditReportConstants.AUDIT_URL_SHEET_NAME, LiteralReport.processURLAudit(xtocpg))
+
+    createSheet(workbook, AuditReportConstants.AUDIT_HTTP_SHEET_NAME, LiteralReport.processHTTPAudit(xtocpg))
 
     createSheet(workbook, AuditReportConstants.AUDIT_API_SHEET_NAME, APIReport.processAPIAudit(xtocpg, ruleCache))
 

--- a/src/main/scala/ai/privado/audit/LiteralReport.scala
+++ b/src/main/scala/ai/privado/audit/LiteralReport.scala
@@ -9,16 +9,28 @@ import org.slf4j.LoggerFactory
 
 import scala.util.{Success, Try}
 
-object URLReport {
+object LiteralReport {
 
   private val logger = LoggerFactory.getLogger(getClass)
 
   def processURLAudit(xtocpg: Try[Cpg]): List[List[String]] = {
+    processRegexAuditResult(xtocpg, AuditReportConstants.URL_REGEX, AuditReportConstants.URL_AUDIT_URL_NAME)
+  }
+
+  def processHTTPAudit(xtocpg: Try[Cpg]): List[List[String]] = {
+    processRegexAuditResult(xtocpg, AuditReportConstants.HTTP_REGEX, AuditReportConstants.HTTP_AUDIT_HTTP_NAME)
+  }
+
+  private def processRegexAuditResult(
+    xtocpg: Try[Cpg],
+    regexPattern: String,
+    propertyName: String
+  ): List[List[String]] = {
     val workFlowResult = new ListBuffer[List[String]]()
     xtocpg match {
       case Success(cpg) => {
-        val codeURLList       = cpg.literal.code(AuditReportConstants.URLREGEX).l
-        val propertiesURLList = cpg.property.l.filter(pair => pair.value.matches(AuditReportConstants.URLREGEX))
+        val codeURLList       = cpg.literal.code(regexPattern).l
+        val propertiesURLList = cpg.property.l.filter(pair => pair.value.matches(regexPattern))
         codeURLList.foreach(literal => {
           workFlowResult += List(literal.code, literal.file.head.name, literal.lineNumber.getOrElse(0).toString)
         })
@@ -27,16 +39,9 @@ object URLReport {
         })
 
         List(
-          List(
-            AuditReportConstants.URL_AUDIT_URL_NAME,
-            AuditReportConstants.FILE_PATH_NAME,
-            AuditReportConstants.AUDIT_LINE_NO
-          )
+          List(propertyName, AuditReportConstants.FILE_PATH_NAME, AuditReportConstants.AUDIT_LINE_NO)
         ) ++ workFlowResult.toList
       }
     }
   }
-
-  val workbookResult = new ListBuffer[List[String]]()
-
 }

--- a/src/test/scala/ai/privado/languageEngine/java/audit/LiteralReportTest.scala
+++ b/src/test/scala/ai/privado/languageEngine/java/audit/LiteralReportTest.scala
@@ -1,13 +1,13 @@
 package ai.privado.languageEngine.java.audit
 
 import scala.collection.mutable
-import ai.privado.audit.URLReport
+import ai.privado.audit.LiteralReport
 import ai.privado.languageEngine.java.tagger.source.IdentifierTagger
 import io.shiftleft.semanticcpg.language.*
 
 import scala.util.Try
 
-class URLReportTest extends URLReportTestBase {
+class LiteralReportTest extends LiteralReportTestBase {
   override val javaFileContentMap: Map[String, String] = getContent()
 
   override def beforeAll(): Unit = {
@@ -34,7 +34,7 @@ class URLReportTest extends URLReportTestBase {
 
   "Test URL sheet" should {
     "should return correct urls" in {
-      val workflowResult = URLReport.processURLAudit(Try(cpg))
+      val workflowResult = LiteralReport.processURLAudit(Try(cpg))
 
       val urlSet  = mutable.HashSet[String]()
       val lineSet = mutable.HashSet[String]()

--- a/src/test/scala/ai/privado/languageEngine/java/audit/LiteralReportTestBase.scala
+++ b/src/test/scala/ai/privado/languageEngine/java/audit/LiteralReportTestBase.scala
@@ -1,0 +1,52 @@
+package ai.privado.languageEngine.java.audit
+
+import ai.privado.cache.{RuleCache, TaggerCache}
+import ai.privado.model.ConfigAndRules
+import better.files.File
+import io.joern.javasrc2cpg.{Config, JavaSrc2Cpg}
+import io.joern.x2cpg.X2Cpg.applyDefaultOverlays
+import io.shiftleft.codepropertygraph.generated.Cpg
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+abstract class LiteralReportTestBase extends AnyWordSpec with Matchers with BeforeAndAfterAll {
+
+  var cpg: Cpg = _
+  val javaFileContentMap: Map[String, String]
+  var inputDir: File  = _
+  var outputDir: File = _
+  val ruleCache       = new RuleCache()
+
+  override def beforeAll(): Unit = {
+    inputDir = File.newTemporaryDirectory()
+    for ((key, content) <- javaFileContentMap) {
+      (inputDir / key).write(content)
+    }
+
+    outputDir = File.newTemporaryDirectory()
+
+    val config  = Config().withInputPath(inputDir.pathAsString).withOutputPath(outputDir.pathAsString)
+    val javaSrc = new JavaSrc2Cpg()
+    val xtocpg = javaSrc.createCpg(config).map { cpg =>
+      applyDefaultOverlays(cpg)
+      cpg
+    }
+
+    cpg = xtocpg.get
+
+    ruleCache.setRule(rule)
+    super.beforeAll()
+  }
+
+  override def afterAll(): Unit = {
+    inputDir.delete()
+    cpg.close()
+    outputDir.delete()
+    super.afterAll()
+  }
+
+  val taggerCache = new TaggerCache()
+  val rule: ConfigAndRules =
+    ConfigAndRules(List(), List(), List(), List(), List(), List(), List(), List(), List(), List())
+}

--- a/src/test/scala/ai/privado/languageEngine/javascript/audit/HTTPReportTest.scala
+++ b/src/test/scala/ai/privado/languageEngine/javascript/audit/HTTPReportTest.scala
@@ -1,0 +1,56 @@
+package ai.privado.languageEngine.javascript.audit
+
+import ai.privado.audit.APIReport
+import ai.privado.entrypoint.PrivadoInput
+import ai.privado.audit.LiteralReport
+import ai.privado.languageEngine.javascript.tagger.sink.JSAPITagger
+import ai.privado.languageEngine.javascript.tagger.source.IdentifierTagger
+
+import scala.collection.mutable
+import scala.util.Try
+
+class HTTPReportTest extends HTTPReportTestBase {
+
+  override val javascriptFileContentMap: Map[String, String] = getContent()
+
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+    new IdentifierTagger(cpg, ruleCache, taggerCache).createAndApply()
+    new JSAPITagger(cpg, ruleCache, PrivadoInput())
+  }
+
+  def getContent(): Map[String, String] = {
+    val testJavaScriptFileMap = mutable.HashMap[String, String]()
+    testJavaScriptFileMap.put(
+      "main.js",
+      """
+        |function main() {
+        |    const randomVar = "https://www.example.com";
+        |}
+        |""".stripMargin
+    )
+
+    testJavaScriptFileMap.toMap
+  }
+
+  "Test HTTP sheet" should {
+    "should return correct http literal" in {
+      val workflowResult = LiteralReport.processHTTPAudit(Try(cpg))
+
+      val codeSet = mutable.HashSet[String]()
+      val lineSet = mutable.HashSet[String]()
+      val fileSet = mutable.HashSet[String]()
+
+      workflowResult.foreach(row => {
+        codeSet += row.head
+        fileSet += row(1)
+        lineSet += row(2)
+      })
+
+      workflowResult.size shouldBe 2
+      codeSet should contain("\"https://www.example.com\"")
+      fileSet should contain("main.js")
+      lineSet should contain("3")
+    }
+  }
+}

--- a/src/test/scala/ai/privado/languageEngine/javascript/audit/HTTPReportTestBase.scala
+++ b/src/test/scala/ai/privado/languageEngine/javascript/audit/HTTPReportTestBase.scala
@@ -1,38 +1,32 @@
-package ai.privado.languageEngine.java.audit
+package ai.privado.languageEngine.javascript.audit
 
 import ai.privado.cache.{RuleCache, TaggerCache}
-import ai.privado.model.ConfigAndRules
+import ai.privado.model.{ConfigAndRules, Language, SystemConfig}
 import better.files.File
-import io.joern.javasrc2cpg.{Config, JavaSrc2Cpg}
-import io.joern.x2cpg.X2Cpg.applyDefaultOverlays
+import io.joern.jssrc2cpg.{Config, JsSrc2Cpg}
 import io.shiftleft.codepropertygraph.generated.Cpg
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
-abstract class URLReportTestBase extends AnyWordSpec with Matchers with BeforeAndAfterAll {
+abstract class HTTPReportTestBase extends AnyWordSpec with Matchers with BeforeAndAfterAll {
 
   var cpg: Cpg = _
-  val javaFileContentMap: Map[String, String]
+  val javascriptFileContentMap: Map[String, String]
   var inputDir: File  = _
   var outputDir: File = _
   val ruleCache       = new RuleCache()
 
   override def beforeAll(): Unit = {
     inputDir = File.newTemporaryDirectory()
-    for ((key, content) <- javaFileContentMap) {
+    for ((key, content) <- javascriptFileContentMap) {
       (inputDir / key).write(content)
     }
 
     outputDir = File.newTemporaryDirectory()
 
-    val config  = Config().withInputPath(inputDir.pathAsString).withOutputPath(outputDir.pathAsString)
-    val javaSrc = new JavaSrc2Cpg()
-    val xtocpg = javaSrc.createCpg(config).map { cpg =>
-      applyDefaultOverlays(cpg)
-      cpg
-    }
-
+    val config = Config().withInputPath(inputDir.pathAsString).withOutputPath(outputDir.pathAsString)
+    val xtocpg = new JsSrc2Cpg().createCpgWithAllOverlays(config)
     cpg = xtocpg.get
 
     ruleCache.setRule(rule)


### PR DESCRIPTION
- Added new sheet for `http` matched literal in audit report. 
- Done some refactoring, as some of the logic is common in the `URL` (having `\` matched literal ) and `HTTP` audit reports. 
