### PR TITLE
Fix Extraction of URL from Request Mapping Annotations

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,10 @@ IDE Setup.
 - import the code with "BSP" option inside intelliJ
 - run "stage" command inside sbt shell earlier executed. This will generate the required executable binaries
 
+
+Run the application locally
+- ./privado-core -Dlog4j.configurationFile=log4j2.xml
+
 ```
 
 
@@ -52,6 +56,15 @@ sbt stage
 ```
 If facing issues related to imports not working try
 - File -> invalidate caches - Invalidate and restart
+```
+
+```
+Run test cases
+- sbt test
+```
+```
+Format the code
+- sbt scalafmt Test/scalafmt
 ```
 
 ### IntelliJ IDEA Caveats

--- a/README.md
+++ b/README.md
@@ -42,10 +42,6 @@ IDE Setup.
 - import the code with "BSP" option inside intelliJ
 - run "stage" command inside sbt shell earlier executed. This will generate the required executable binaries
 
-
-Run the application locally
-- ./privado-core -Dlog4j.configurationFile=log4j2.xml
-
 ```
 
 

--- a/src/main/scala/ai/privado/languageEngine/java/tagger/collection/CollectionUtility.scala
+++ b/src/main/scala/ai/privado/languageEngine/java/tagger/collection/CollectionUtility.scala
@@ -160,7 +160,7 @@ object CollectionUtility {
     * @return
     */
   def getUrlFromAnnotation(annotation: Annotation): String = {
-    annotation.parameterAssign.order(1).astChildren.order(2).l.headOption match {
+    annotation.parameterAssign.where(_.parameter.code("value")).value.l.headOption match {
       case Some(url) => url.code
       case None =>
         annotation.parameterAssign.order(1).headOption match {

--- a/src/test/scala/ai/privado/languageEngine/java/tagger/collection/CollectionUtilityTest.scala
+++ b/src/test/scala/ai/privado/languageEngine/java/tagger/collection/CollectionUtilityTest.scala
@@ -58,6 +58,9 @@ class CollectionUtilityTest extends JavaTaggingTestBase {
       |	public Token login(@RequestBody String somestring) {
       | }
       |
+      | @RequestMapping(method = RequestMethod.GET, value = "/products", produces = "application/json")
+      | public List<Product> getProducts() {
+      |    }
       |}
       |
       |
@@ -75,6 +78,12 @@ class CollectionUtilityTest extends JavaTaggingTestBase {
     }
   }
 
+  "Get Url for annotation where first parameter is other than 'value'" should {
+    "give url for getProducts" in {
+      CollectionUtility.getUrlFromAnnotation(cpg.method("getProducts").annotation.head) shouldBe "/products"
+    }
+  }
+
   "Get Url for annotation" should {
     "give url for sample3" in {
       CollectionUtility.getUrlFromAnnotation(cpg.method("sample3").annotation.head) shouldBe "sample3"
@@ -87,7 +96,7 @@ class CollectionUtilityTest extends JavaTaggingTestBase {
       collectionTagger.createAndApply()
       ingressUrls = collectionTagger.getIngressUrls()
 
-      ingressUrls.size shouldBe 4
+      ingressUrls.size shouldBe 5
       true shouldBe ingressUrls.contains("/api/public/user/login")
     }
   }


### PR DESCRIPTION
**Description:**
This pull request addresses a critical issue where the actual URL of a collection is not correctly extracted under specific conditions. The bug manifests when the first parameter of annotations such as  @RequestMapping ,  @GetMapping ,  @PostMapping , etc., is something other than the intended URL. Previously, our logic incorrectly assumed that the first parameter always represented the URL. 

**Key Changes:** 
 
1. **Issue Identification:** Identified a breaking case where the extraction logic fails if the first parameter of the mapping annotation does not directly represent the URL. 
 
2. **Existing Logic Revision:** The existing extraction logic was limited to evaluating only the first parameter of the annotation, which led to inaccuracies in URL retrieval. 
 
3. **Focused Extraction:** Revised the logic to prioritize the extraction of the  value  parameter specifically, as it directly corresponds to the intended URL. In cases where the  value  parameter is not explicitly named, the logic defaults to extracting the direct URL string provided. 
 
4. **CPG Query Update:** Modified the code property graph (CPG) query to accurately extract the value associated with the  value  parameter, or to proceed without a parameter when a direct URL string is provided. 
 
5. **Testing and Verification:** Conducted thorough testing to ensure the accuracy of URL extraction across all scenarios. This included verifying all existing test cases related to collection URLs and introducing tests for the identified breaking case to prevent future regressions. 