### PR TITLE
Default collection url: when url is not defined on immediate annotation

### DIFF
--- a/src/main/scala/ai/privado/languageEngine/java/tagger/collection/CollectionUtility.scala
+++ b/src/main/scala/ai/privado/languageEngine/java/tagger/collection/CollectionUtility.scala
@@ -162,19 +162,7 @@ object CollectionUtility {
   def getUrlFromAnnotation(annotation: Annotation): String = {
     annotation.parameterAssign.where(_.parameter.code("value")).value.l.headOption match {
       case Some(url) => url.code
-      case None =>
-        annotation.parameterAssign.order(1).headOption match {
-          case Some(url) => url.code
-          case None =>
-            annotation.typeDecl.headOption match {
-              case Some(typeDeclNode) => typeDeclNode.name
-              case None =>
-                annotation.method.headOption match {
-                  case Some(methodNode) => methodNode.name
-                  case None             => ""
-                }
-            }
-        }
+      case None      => ""
     }
   }
 }

--- a/src/test/scala/ai/privado/languageEngine/java/tagger/collection/CollectionUtilityTest.scala
+++ b/src/test/scala/ai/privado/languageEngine/java/tagger/collection/CollectionUtilityTest.scala
@@ -61,8 +61,12 @@ class CollectionUtilityTest extends JavaTaggingTestBase {
       | @RequestMapping(method = RequestMethod.GET, value = "/products", produces = "application/json")
       | public List<Product> getProducts() {
       |    }
-      |}
       |
+      | @PostMapping(produces = "application/json")
+      | public List<Product> createProducts() {
+      |    }
+      |
+      |}
       |
       |""".stripMargin
 
@@ -84,9 +88,15 @@ class CollectionUtilityTest extends JavaTaggingTestBase {
     }
   }
 
+  "Get Url for annotation where value parameter or direct url is not defined" should {
+    "give url for createProducts" in {
+      CollectionUtility.getUrlFromAnnotation(cpg.method("createProducts").annotation.head) shouldBe ""
+    }
+  }
+
   "Get Url for annotation" should {
     "give url for sample3" in {
-      CollectionUtility.getUrlFromAnnotation(cpg.method("sample3").annotation.head) shouldBe "sample3"
+      CollectionUtility.getUrlFromAnnotation(cpg.method("sample3").annotation.head) shouldBe ""
     }
   }
 
@@ -96,7 +106,7 @@ class CollectionUtilityTest extends JavaTaggingTestBase {
       collectionTagger.createAndApply()
       ingressUrls = collectionTagger.getIngressUrls()
 
-      ingressUrls.size shouldBe 5
+      ingressUrls.size shouldBe 6
       true shouldBe ingressUrls.contains("/api/public/user/login")
     }
   }


### PR DESCRIPTION
##### Example Scenario:

```
package com.example.demo;

import org.springframework.web.bind.annotation.GetMapping;
import org.springframework.web.bind.annotation.RequestMapping;
import org.springframework.web.bind.annotation.RestController;

@RestController
@RequestMapping("/api") // Base URL for all methods in this controller
public class DemoController {

    // This method inherits the URL from the class annotation
    @GetMapping
    public String getBase() {
        return "This is the base API endpoint.";
    }

    // This method specifies its own URL
    @GetMapping("/hello")
    public String getHello() {
        return "Hello from /api/hello!";
    }
}
```

##### Explanation 
 - **Class-Level  @RequestMapping**: The  @RequestMapping("/api")  annotation at the class level specifies that every method in this controller will be accessible under the  /api  base path unless the method specifies otherwise. 
 
- **Method-Level Mapping Without a Path**: The  @GetMapping  annotation on the  getBase  method does not specify a path. Therefore, it inherits the path from the class-level  @RequestMapping . As a result, this method responds to GET requests to  /api . 
 
- **Method-Level Mapping With a Path**: The  @GetMapping("/hello")  annotation on the  getHello  method specifies its own path. This path is relative to the base path defined at the class level, making the full path to this method  /api/hello . 

- **Access the two endpoints**: 
 
   GET **/api**  will return "This is the base API endpoint." 
   GET **/api/hello**  will return "Hello from /api/hello!"

**Code Changes**:
In existing code base the url formed on getBase is **/api/getBase** instead of **/api**
