### PR TITLE
added base path for feign client

### DIFF
--- a/src/main/scala/ai/privado/exporter/HttpConnectionMetadataExporter.scala
+++ b/src/main/scala/ai/privado/exporter/HttpConnectionMetadataExporter.scala
@@ -93,7 +93,8 @@ class HttpConnectionMetadataExporter(cpg: Cpg, ruleCache: RuleCache) {
         val classLevelAnnotation = matchedAnnotation.method.typeDecl.annotation.name(FEIGN_CLIENT).headOption
         if (classLevelAnnotation.isDefined) {
           egressUrls = egressUrls :+ CollectionUtility
-            .getUrlFromAnnotation(classLevelAnnotation.get)
+//            In case Feign client name of service is denoted by parameter "name"
+            .getUrlFromAnnotation(classLevelAnnotation.get, "name")
             .stripSuffix("/") + SLASH_SYMBOL + CollectionUtility
             .getUrlFromAnnotation(matchedAnnotation)
             .strip()

--- a/src/main/scala/ai/privado/languageEngine/java/tagger/collection/CollectionUtility.scala
+++ b/src/main/scala/ai/privado/languageEngine/java/tagger/collection/CollectionUtility.scala
@@ -160,7 +160,7 @@ object CollectionUtility {
     * @return
     */
   def getUrlFromAnnotation(annotation: Annotation): String = {
-    annotation.parameterAssign.where(_.parameter.code("value")).value.l.headOption match {
+    annotation.parameterAssign.where(_.parameter.code("value|name")).value.l.headOption match {
       case Some(url) => url.code
       case None      => ""
     }

--- a/src/main/scala/ai/privado/languageEngine/java/tagger/collection/CollectionUtility.scala
+++ b/src/main/scala/ai/privado/languageEngine/java/tagger/collection/CollectionUtility.scala
@@ -159,8 +159,8 @@ object CollectionUtility {
     * @param parameterIn
     * @return
     */
-  def getUrlFromAnnotation(annotation: Annotation): String = {
-    annotation.parameterAssign.where(_.parameter.code("value|name")).value.l.headOption match {
+  def getUrlFromAnnotation(annotation: Annotation, parameterProperty: String = "value"): String = {
+    annotation.parameterAssign.where(_.parameter.code(parameterProperty)).value.l.headOption match {
       case Some(url) => url.code
       case None      => ""
     }

--- a/src/test/scala/ai/privado/exporter/FeignEgressExportTest.scala
+++ b/src/test/scala/ai/privado/exporter/FeignEgressExportTest.scala
@@ -62,7 +62,7 @@ class FeignEgressExportTest extends JavaTaggingTestBase {
       val propertyExporter = new HttpConnectionMetadataExporter(cpg, ruleCache)
       val egresses         = propertyExporter.getEgressUrls
       egresses.size shouldBe 1
-      egresses.head shouldBe "/address/{id}"
+      egresses.head shouldBe "address-service/address/{id}"
     }
   }
 


### PR DESCRIPTION
##### Example:
```
@FeignClient(name = "address-service", url = "http://localhost:8081", path = "/address-service")
public interface AddressClient {

	@GetMapping(value = "/address/{id}")
	public ResponseEntity<AddressResponse> getAddressByEmployeeId(@PathVariable("id") int id);

}
```
Requirement:
* Add base path as part of url.
      - url generating before: **/address/{id}**
      - url generating after change: **address-service/address/{id}**

Updated and verified existing test cases.