### PR TITLE
Add support to collect egress from code for js, python and java

### DIFF
--- a/src/test/scala/ai/privado/exporter/JavaLanguageEgressTest.scala
+++ b/src/test/scala/ai/privado/exporter/JavaLanguageEgressTest.scala
@@ -1,0 +1,91 @@
+/*
+ * This file is part of Privado OSS.
+ *
+ * Privado is an open source static code analysis tool to discover data flows in the code.
+ * Copyright (C) 2022 Privado, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * For more information, contact support@privado.ai
+ *
+ */
+
+package ai.privado.exporter
+
+import ai.privado.cache.S3DatabaseDetailsCache
+import ai.privado.entrypoint.PrivadoInput
+import ai.privado.exporter.HttpConnectionMetadataExporter
+import ai.privado.languageEngine.java.JavaTaggingTestBase
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import ai.privado.tagger.sink.RegularSinkTagger
+
+import scala.collection.mutable
+
+class JavaLanguageEgressTest extends JavaTaggingTestBase {
+
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+  }
+
+  override val javaFileContents: String =
+    """
+      |package com.twilio;
+      |
+      |import org.springframework.beans.factory.annotation.Autowired;
+      |import org.springframework.http.ResponseEntity;
+      |import org.springframework.stereotype.Service;
+      |import org.springframework.web.client.RestTemplate;
+      |
+      |@Service
+      |public class NasaApodService {
+      |
+      |    private final RestTemplate restTemplate;
+      |
+      |    @Autowired
+      |    public NasaApodService(RestTemplate restTemplate) {
+      |        this.restTemplate = restTemplate;
+      |    }
+      |
+      |    public NasaApodResponse getNasaApod(String apiKey) {
+      |        String login = "api/v1/login";
+      |        String userMetaPath = "api/v1/" + "user/meta";
+      |        String userId = "123";
+      |        String apiKey = "key";
+      |        String formatted = String.format("https://vineet%s/hellow", "api/hellow");
+      |        String apiUrl = "https://abc.com/planetary/apod?api_key=" + apiKey;
+      |        ResponseEntity<NasaApodResponse> responseEntity = restTemplate.getForEntity(apiUrl, NasaApodResponse.class);
+      |        ResponseEntity<NasaApodResponse> responseEntity = restTemplate.getForEntity(apiUrl, NasaApodResponse.class);
+      |        return responseEntity.getBody();
+      |    }
+      |}
+      |""".stripMargin
+
+  "Java code egresses" should {
+    "collect egress url for java code" in {
+      val propertyExporter          = new HttpConnectionMetadataExporter(cpg, ruleCache)
+      val egressesFromLanguageFiles = propertyExporter.getLiteralsFromLanguageFiles
+      egressesFromLanguageFiles.size shouldBe 5
+      egressesFromLanguageFiles shouldBe List(
+        "api/v1/login",
+        "api/v1/user/meta",
+        "https://vineet%s/hellow",
+        "api/hellow",
+        "https://abc.com/planetary/apod?api_key=apiKey"
+      )
+    }
+  }
+
+}

--- a/src/test/scala/ai/privado/exporter/JavaScriptLanguageEgressTest.scala
+++ b/src/test/scala/ai/privado/exporter/JavaScriptLanguageEgressTest.scala
@@ -1,0 +1,63 @@
+/*
+ * This file is part of Privado OSS.
+ *
+ * Privado is an open source static code analysis tool to discover data flows in the code.
+ * Copyright (C) 2022 Privado, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * For more information, contact support@privado.ai
+ *
+ */
+
+package ai.privado.exporter
+
+import ai.privado.entrypoint.PrivadoInput
+import ai.privado.exporter.HttpConnectionMetadataExporter
+import ai.privado.languageEngine.javascript.JavascriptTaggingTestBase
+import ai.privado.model.ConfigAndRules
+import ai.privado.tagger.sink.RegularSinkTagger
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+import scala.collection.mutable
+
+class JavaScriptLanguageEgressTest extends JavascriptTaggingTestBase {
+
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+  }
+  override val rule: ConfigAndRules            = ConfigAndRules()
+  override val packageJsonFileContents: String = ""
+
+  override val javascriptFileContents: String =
+    """
+      | import { requests } from "service/settings"
+      | const endpoint = { getUserDetails: (id) => `v1/api/user${id}`, getLogin: "v1/api/login" }
+      | const signup = "v1/api" + "/signup"
+      | const signup = requests("v1/api/users/meta")
+      |""".stripMargin
+
+  "Javascript code egresses" should {
+    "collect egress url for javascript code" in {
+      val propertyExporter          = new HttpConnectionMetadataExporter(cpg, ruleCache)
+      val egressesFromLanguageFiles = propertyExporter.getLiteralsFromLanguageFiles
+      print(egressesFromLanguageFiles)
+      egressesFromLanguageFiles.size shouldBe 4
+      egressesFromLanguageFiles shouldBe List("v1/api/userid", "v1/api/login", "v1/api/signup", "v1/api/users/meta")
+    }
+  }
+
+}

--- a/src/test/scala/ai/privado/exporter/JavaScriptLanguageEgressTest.scala
+++ b/src/test/scala/ai/privado/exporter/JavaScriptLanguageEgressTest.scala
@@ -47,6 +47,8 @@ class JavaScriptLanguageEgressTest extends JavascriptTaggingTestBase {
       | import { requests } from "service/settings"
       | const endpoint = { getUserDetails: (id) => `v1/api/user${id}`, getLogin: "v1/api/login" }
       | const signup = "v1/api" + "/signup"
+      | const tag = "<div>something else <h1>heelo</h1></div>"
+      | const newEndpoint = "api/v1/" + "user/meta" + "/profile"
       | const signup = requests("v1/api/users/meta")
       |""".stripMargin
 
@@ -54,9 +56,15 @@ class JavaScriptLanguageEgressTest extends JavascriptTaggingTestBase {
     "collect egress url for javascript code" in {
       val propertyExporter          = new HttpConnectionMetadataExporter(cpg, ruleCache)
       val egressesFromLanguageFiles = propertyExporter.getLiteralsFromLanguageFiles
-      print(egressesFromLanguageFiles)
-      egressesFromLanguageFiles.size shouldBe 4
-      egressesFromLanguageFiles shouldBe List("v1/api/userid", "v1/api/login", "v1/api/signup", "v1/api/users/meta")
+      egressesFromLanguageFiles.size shouldBe 6
+      egressesFromLanguageFiles shouldBe List(
+        "v1/api/userid",
+        "v1/api/login",
+        "v1/api/signup",
+        "api/v1/user/meta",
+        "api/v1/ + user/meta/profile",
+        "v1/api/users/meta"
+      )
     }
   }
 

--- a/src/test/scala/ai/privado/exporter/PythonLanguageEgressTest.scala
+++ b/src/test/scala/ai/privado/exporter/PythonLanguageEgressTest.scala
@@ -63,12 +63,14 @@ class PythonLanguageEgressTest extends PrivadoPySrc2CpgFixture {
       |        },
       |    }
       | }
+      | customerId = "234324-32rr23-42424-32"
+      | repoId = "234324-32rr23-42424-32"
       | API_HOST = ""
-      | API_1 =  API_HOST + "/ce/something/customers/{customerId}/init"
-      | API_2 =  API_HOST + "/ce/customers/{customerId}/repo/{repoId}/file"
-      | API_3 =      API_HOST + "/ce/customers/{customerId}/scan/{repoId}"
+      | API_1 =  API_HOST + f"/ce/something/customers/{customerId}/init"
+      | API_2 =  API_HOST + f"/ce/customers/{customerId}/repo/{repoId}/file"
+      | API_3 =      API_HOST + f"/ce/customers/{customerId}/scan/{repoId}/data"
       | BASE_HOST = "api/v1"
-      | API_4 =      BASE_HOST + "/ce/customers/{customerId}/scan/{repoId}"
+      | API_4 =      BASE_HOST + f"/ce/customers/{customerId}/scan/{repoId}/data"
       | API_5 =      "api/v2" + "/ce/customers"
       |""".stripMargin)
 
@@ -76,14 +78,12 @@ class PythonLanguageEgressTest extends PrivadoPySrc2CpgFixture {
     "collect egress url for python code" in {
       val propertyExporter          = new HttpConnectionMetadataExporter(cpg, ruleCache)
       val egressesFromLanguageFiles = propertyExporter.getLiteralsFromLanguageFiles
-      print(egressesFromLanguageFiles)
-      egressesFromLanguageFiles.size shouldBe 6
+      egressesFromLanguageFiles.size shouldBe 5
       egressesFromLanguageFiles shouldBe List(
-        "API_HOST/ce/something/customers/{customerId}/init",
-        "API_HOST/ce/customers/{customerId}/repo/{repoId}/file",
-        "API_HOST/ce/customers/{customerId}/scan/{repoId}",
+        "/ce/something/customers/{customerId}/init",
+        "/ce/customers/{customerId}/repo/{repoId}/file",
+        "/ce/customers/{customerId}/scan/{repoId}/data",
         "api/v1",
-        "BASE_HOST/ce/customers/{customerId}/scan/{repoId}",
         "api/v2/ce/customers"
       )
 

--- a/src/test/scala/ai/privado/exporter/PythonLanguageEgressTest.scala
+++ b/src/test/scala/ai/privado/exporter/PythonLanguageEgressTest.scala
@@ -1,0 +1,93 @@
+/*
+ * This file is part of Privado OSS.
+ *
+ * Privado is an open source static code analysis tool to discover data flows in the code.
+ * Copyright (C) 2022 Privado, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * For more information, contact support@privado.ai
+ *
+ */
+
+package ai.privado.exporter
+
+import ai.privado.cache.RuleCache
+import ai.privado.entrypoint.PrivadoInput
+import ai.privado.exporter.HttpConnectionMetadataExporter
+import ai.privado.languageEngine.javascript.JavascriptTaggingTestBase
+import ai.privado.languageEngine.python.{PrivadoPySrc2CpgFixture, PrivadoPySrcTestCpg}
+import ai.privado.model.ConfigAndRules
+import ai.privado.tagger.sink.RegularSinkTagger
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+import scala.collection.mutable
+
+class PythonLanguageEgressTest extends PrivadoPySrc2CpgFixture {
+  val ruleCache = new RuleCache()
+  val cpg: PrivadoPySrcTestCpg = code("""
+      | LOGGING = {
+      |    'version': 1,
+      |    'disable_existing_loggers': True,
+      |    'formatters': {
+      |        'standard': {
+      |            'format': "[%(asctime)s] %(levelname)s [%(name)s:%(lineno)s] %(message)s",
+      |            'datefmt': "%d/%b/%Y %H:%M:%S"
+      |        },
+      |    },
+      |    'handlers': {
+      |        'slack_admins': {
+      |            'level': 'ERROR',
+      |            'class': 'django_slack.log.SlackExceptionHandler',
+      |            'filters': ['slack_filter']
+      |        },
+      |    },
+      |    'loggers': {
+      |        'django': {
+      |            'handlers': ['slack_admins', 'console', 'mail_admins'],
+      |            'propagate': True,
+      |            'level': 'ERROR',
+      |        },
+      |    }
+      | }
+      | API_HOST = ""
+      | API_1 =  API_HOST + "/ce/something/customers/{customerId}/init"
+      | API_2 =  API_HOST + "/ce/customers/{customerId}/repo/{repoId}/file"
+      | API_3 =      API_HOST + "/ce/customers/{customerId}/scan/{repoId}"
+      | BASE_HOST = "api/v1"
+      | API_4 =      BASE_HOST + "/ce/customers/{customerId}/scan/{repoId}"
+      | API_5 =      "api/v2" + "/ce/customers"
+      |""".stripMargin)
+
+  "Python code egresses" should {
+    "collect egress url for python code" in {
+      val propertyExporter          = new HttpConnectionMetadataExporter(cpg, ruleCache)
+      val egressesFromLanguageFiles = propertyExporter.getLiteralsFromLanguageFiles
+      print(egressesFromLanguageFiles)
+      egressesFromLanguageFiles.size shouldBe 6
+      egressesFromLanguageFiles shouldBe List(
+        "API_HOST/ce/something/customers/{customerId}/init",
+        "API_HOST/ce/customers/{customerId}/repo/{repoId}/file",
+        "API_HOST/ce/customers/{customerId}/scan/{repoId}",
+        "api/v1",
+        "BASE_HOST/ce/customers/{customerId}/scan/{repoId}",
+        "api/v2/ce/customers"
+      )
+
+    }
+  }
+
+}


### PR DESCRIPTION
### Collect egresses from code for js, python and java
- Cases Handled
    -  String concatenation using addition operator 
    -  String formatter operator
    - Literal without any operation and getting assigned to a variable. 
- Implementation Details
   - Collecting all literals that has slash in it and allowing some specific character to also support string formatter
   - Filtering if only non alphanumeric symbols present
   - remove \\" from all the strings
   - go to call node(_we are not handling nested level concatination/formatting for now_) and collect strings based on the call node and their arguments
   
- The current logic is designed for Java, Python, and JavaScript, as I have tested it for these languages. I have not extended it to other languages yet, as literals can also appear in imports. In such cases, I will need to write additional logic to handle this scenario. This was done for javascript.