### PR TITLE
product level datamap: exclude false positive entries from egress

### DIFF
--- a/src/main/scala/ai/privado/exporter/HttpConnectionMetadataExporter.scala
+++ b/src/main/scala/ai/privado/exporter/HttpConnectionMetadataExporter.scala
@@ -89,15 +89,6 @@ class HttpConnectionMetadataExporter(cpg: Cpg, ruleCache: RuleCache) {
   def getEgressUrlsFromCodeFiles: List[String] = {
     var egressUrls = List[String]()
 
-    egressUrls = egressUrls.concat(
-      cpg.property
-        .filterNot(_.value.matches(FILE_SUFFIX_REGEX_PATTERN))
-        .filterNot(_.value.matches(COMMON_FALSE_POSITIVE_EGRESS_PATTERN))
-        .or(_.value(STRING_START_WITH_SLASH), _.value(STRING_CONTAINS_TWO_SLASH))
-        .value
-        .dedup
-        .l
-    )
     /* We have verified literals for these languages, so we need to analyze other languages before broadening the rule.
        It can happen that literals may come from imports as well, which was the case for JavaScript, and we handled it.
        Therefore, we might need to do a few things specific to each language. */
@@ -114,7 +105,13 @@ class HttpConnectionMetadataExporter(cpg: Cpg, ruleCache: RuleCache) {
     var egressUrls = List[String]()
 
     egressUrls = egressUrls.concat(
-      cpg.property.or(_.value(STRING_START_WITH_SLASH), _.value(STRING_CONTAINS_TWO_SLASH)).value.dedup.l
+      cpg.property
+        .filterNot(_.value.matches(FILE_SUFFIX_REGEX_PATTERN))
+        .filterNot(_.value.matches(COMMON_FALSE_POSITIVE_EGRESS_PATTERN))
+        .or(_.value(STRING_START_WITH_SLASH), _.value(STRING_CONTAINS_TWO_SLASH))
+        .value
+        .dedup
+        .l
     )
 
     egressUrls = egressUrls.concat(addUrlFromFeignClient())

--- a/src/test/scala/ai/privado/languageEngine/java/passes/config/PropertiesFilePassTest.scala
+++ b/src/test/scala/ai/privado/languageEngine/java/passes/config/PropertiesFilePassTest.scala
@@ -23,7 +23,7 @@
 
 package ai.privado.languageEngine.java.passes.config
 
-import ai.privado.cache.RuleCache
+import ai.privado.cache.{AppCache, RuleCache}
 import ai.privado.languageEngine.java.language.*
 import ai.privado.model.Language
 import ai.privado.utility.PropertyParserPass
@@ -194,6 +194,18 @@ class EgressPropertyTests extends PropertiesFilePassTestBase(".yaml") {
                                       |spring:
                                       |   application:
                                       |       name: basepath
+                                      |false-positive-entries:
+                                      |    urls:
+                                      |      - http:
+                                      |          path1: en-wrapper/0.5.6/maven-wrapper-0.5.6.jar
+                                      |          path2: che-maven/3.6.3/apache-maven-3.6.3-bin.zip
+                                      |          path3: dkr.ecr.us-west-2.amazonaws.com/infrastructure/ecr-pusher:latest
+                                      |          path4: mvn -U -P ${ENVIRONMENT} package -DskipTests --settings ${home}/.m2/settings.xml
+                                      |          path5: somename.jpg
+                                      |          path6: somename.png
+                                      |          path7: somename.gif
+                                      |          path8: string having html tags <p>hello</p> and <b>world</b>
+                                      |
                                       |mx-record-delete:
                                       |    events:
                                       |      - http:
@@ -216,7 +228,7 @@ class EgressPropertyTests extends PropertiesFilePassTestBase(".yaml") {
 
   override val propertyFileContents = ""
 
-  "Fetch egress urls from property files" ignore {
+  "Fetch egress urls from property files" should {
     "Check egress urls" in {
       val egressExporter   = HttpConnectionMetadataExporter(cpg, new RuleCache)
       val List(url1, url2) = egressExporter.getEgressUrls
@@ -337,6 +349,7 @@ abstract class PropertiesFilePassTestBase(fileExtension: String)
       .get
     new PropertyParserPass(cpg, inputDir.toString(), new RuleCache, Language.JAVA).createAndApply()
     new JavaPropertyLinkerPass(cpg).createAndApply()
+    AppCache.repoLanguage = Language.JAVA
 
     super.beforeAll()
   }

--- a/src/test/scala/ai/privado/languageEngine/java/passes/config/PropertiesFilePassTest.scala
+++ b/src/test/scala/ai/privado/languageEngine/java/passes/config/PropertiesFilePassTest.scala
@@ -205,6 +205,13 @@ class EgressPropertyTests extends PropertiesFilePassTestBase(".yaml") {
                                       |          path6: somename.png
                                       |          path7: somename.gif
                                       |          path8: string having html tags <p>hello</p> and <b>world</b>
+                                      |          path9: /a/b/c containing spaces
+                                      |          path10: github.com/a/b/c
+                                      |          pathe11: ../some/file/path
+                                      |          path12: #somecomment
+                                      |          path13: ///a/b/c
+                                      |          path14: ./some/file/path
+                                      |
                                       |
                                       |mx-record-delete:
                                       |    events:
@@ -220,6 +227,12 @@ class EgressPropertyTests extends PropertiesFilePassTestBase(".yaml") {
                                       |      - ssm:
                                       |          path: /
                                       |          method: PUT
+                                      |      - privado:
+                                      |          path: https://code.privado.ai/repositories
+                                      |          method: PUT
+                                      |      - privado-without-http:
+                                      |          path: code.privado.ai/repositories
+                                      |          method: PUT
                                       |""".stripMargin
   override val codeFileContents =
     """
@@ -230,10 +243,12 @@ class EgressPropertyTests extends PropertiesFilePassTestBase(".yaml") {
 
   "Fetch egress urls from property files" should {
     "Check egress urls" in {
-      val egressExporter   = HttpConnectionMetadataExporter(cpg, new RuleCache)
-      val List(url1, url2) = egressExporter.getEgressUrls
+      val egressExporter               = HttpConnectionMetadataExporter(cpg, new RuleCache)
+      val List(url1, url2, url3, url4) = egressExporter.getEgressUrls
       url1 shouldBe "/v1/student/{id}"
       url2 shouldBe "v1/student/{id}"
+      url3 shouldBe "https://code.privado.ai/repositories"
+      url4 shouldBe "code.privado.ai/repositories"
     }
 
     "Check egress urls with single char" in {


### PR DESCRIPTION
Changes: Eliminating egress urls such as filename, aws urls or html template which is matching existing pattern(string having slash)

After adding this elimination pattern around 90% entries are reduced.

Also enabled one of test case which is marked ignored last time.