### PR TITLE
API YamlLinkerPass support

### DIFF
--- a/src/main/scala/ai/privado/languageEngine/go/passes/config/GoYamlLinkerPass.scala
+++ b/src/main/scala/ai/privado/languageEngine/go/passes/config/GoYamlLinkerPass.scala
@@ -1,15 +1,11 @@
-package ai.privado.languageEngine.java.passes.config
+package ai.privado.languageEngine.go.passes.config
 
-import io.shiftleft.codepropertygraph.generated.nodes.*
 import ai.privado.passes.YamlLinkerPass
 import io.shiftleft.codepropertygraph.generated.Cpg
 import io.shiftleft.codepropertygraph.generated.nodes.Literal
-import org.slf4j.LoggerFactory
 import io.shiftleft.semanticcpg.language.*
 
-class JavaYamlLinkerPass(cpg: Cpg) extends YamlLinkerPass(cpg) {
-  private val logger = LoggerFactory.getLogger(this.getClass)
-
+class GoYamlLinkerPass(cpg: Cpg) extends YamlLinkerPass(cpg) {
   override def matchingLiteralsToPropertyNode(propertyName: String): List[Literal] = {
     val propertyKey = propertyName.split("\\.").last
     cpg.literal

--- a/src/main/scala/ai/privado/languageEngine/go/processor/GoProcessor.scala
+++ b/src/main/scala/ai/privado/languageEngine/go/processor/GoProcessor.scala
@@ -68,11 +68,6 @@ object GoProcessor {
             new PropertyParserPass(cpg, sourceRepoLocation, ruleCache, Language.GO).createAndApply()
 
           new GoYamlLinkerPass(cpg).createAndApply()
-
-          cpg.property.foreach(pro => {
-            System.out.println(pro.name + " ---- " + pro.value)
-          })
-
           new SQLParser(cpg, sourceRepoLocation, ruleCache).createAndApply()
           new SQLQueryParser(cpg).createAndApply()
           // Unresolved function report

--- a/src/main/scala/ai/privado/languageEngine/java/passes/config/JavaYamlLinkerPass.scala
+++ b/src/main/scala/ai/privado/languageEngine/java/passes/config/JavaYamlLinkerPass.scala
@@ -1,0 +1,9 @@
+package ai.privado.languageEngine.java.passes.config
+
+import ai.privado.passes.YamlLinkerPass
+import io.shiftleft.codepropertygraph.generated.Cpg
+import org.slf4j.LoggerFactory
+
+class JavaYamlLinkerPass(cpg: Cpg) extends YamlLinkerPass(cpg) {
+  private val logger = LoggerFactory.getLogger(this.getClass)
+}

--- a/src/main/scala/ai/privado/languageEngine/java/passes/config/JavaYamlLinkerPass.scala
+++ b/src/main/scala/ai/privado/languageEngine/java/passes/config/JavaYamlLinkerPass.scala
@@ -1,9 +1,20 @@
 package ai.privado.languageEngine.java.passes.config
 
+import io.shiftleft.codepropertygraph.generated.nodes.*
 import ai.privado.passes.YamlLinkerPass
 import io.shiftleft.codepropertygraph.generated.Cpg
+import io.shiftleft.codepropertygraph.generated.nodes.Literal
 import org.slf4j.LoggerFactory
+import io.shiftleft.semanticcpg.language.*
 
 class JavaYamlLinkerPass(cpg: Cpg) extends YamlLinkerPass(cpg) {
   private val logger = LoggerFactory.getLogger(this.getClass)
+
+  override def matchingLiteralsInGetEnvCalls(propertyName: String): List[Literal] = {
+    val propertyKey = propertyName.split("\\.").last
+    cpg.literal
+      .codeExact("\"" + propertyKey + "\"")
+      .filter(_.inCall.name("(?i).*getenv").nonEmpty)
+      .toList
+  }
 }

--- a/src/main/scala/ai/privado/languageEngine/java/processor/JavaProcessor.scala
+++ b/src/main/scala/ai/privado/languageEngine/java/processor/JavaProcessor.scala
@@ -29,7 +29,7 @@ import ai.privado.entrypoint.{PrivadoInput, TimeMetric}
 import ai.privado.exporter.{ExcelExporter, JSONExporter}
 import ai.privado.languageEngine.base.processor.BaseProcessor
 import ai.privado.languageEngine.java.cache.ModuleCache
-import ai.privado.languageEngine.java.passes.config.{JavaPropertyLinkerPass, ModuleFilePass}
+import ai.privado.languageEngine.java.passes.config.{JavaPropertyLinkerPass, JavaYamlLinkerPass, ModuleFilePass}
 import ai.privado.languageEngine.java.passes.methodFullName.LoggerLombokPass
 import ai.privado.languageEngine.java.passes.module.{DependenciesCategoryPass, DependenciesNodePass}
 import ai.privado.languageEngine.java.semantic.Language.*
@@ -101,7 +101,8 @@ class JavaProcessor(
         new HTMLParserPass(cpg, sourceRepoLocation, ruleCache, privadoInputConfig = privadoInput),
         new SQLParser(cpg, sourceRepoLocation, ruleCache),
         new DBTParserPass(cpg, sourceRepoLocation, ruleCache),
-        new AndroidXmlParserPass(cpg, sourceRepoLocation, ruleCache)
+        new AndroidXmlParserPass(cpg, sourceRepoLocation, ruleCache),
+        new JavaYamlLinkerPass(cpg)
       )
   }
 

--- a/src/main/scala/ai/privado/languageEngine/java/tagger/sink/JavaAPITagger.scala
+++ b/src/main/scala/ai/privado/languageEngine/java/tagger/sink/JavaAPITagger.scala
@@ -109,6 +109,7 @@ class JavaAPITagger(cpg: Cpg, ruleCache: RuleCache, privadoInputConfig: PrivadoI
   override def runOnPart(builder: DiffGraphBuilder, ruleInfo: RuleInfo): Unit = {
     val apiInternalSources = cpg.literal.code("(?:\"|')(" + ruleInfo.combinedRulePattern + ")(?:\"|')").l
     val propertySources    = cpg.property.filter(p => p.value matches (ruleInfo.combinedRulePattern)).usedAt.l
+    val serviceSource      = cpg.property.filter(p => p.value matches ".*(http|https):\\/\\/.*").usedAt.l
 
     // Support to use `identifier` in API's
     val identifierRegex = ruleCache.getSystemConfigByKey(Constants.apiIdentifier)
@@ -159,7 +160,7 @@ class JavaAPITagger(cpg: Cpg, ruleCache: RuleCache, privadoInputConfig: PrivadoI
         logger.debug("Using Enhanced API tagger to find API sinks")
         println(s"${Calendar.getInstance().getTime} - --API TAGGER V2 invoked...")
         sinkTagger(
-          apiInternalSources ++ propertySources ++ identifierSource,
+          apiInternalSources ++ propertySources ++ identifierSource ++ serviceSource,
           apis.methodFullName(commonHttpPackages).l ++ feignAPISinks ++ grpcSinks ++ soapSinks,
           builder,
           ruleInfo,

--- a/src/main/scala/ai/privado/languageEngine/java/tagger/sink/JavaAPITagger.scala
+++ b/src/main/scala/ai/privado/languageEngine/java/tagger/sink/JavaAPITagger.scala
@@ -30,7 +30,7 @@ import ai.privado.languageEngine.java.tagger.Utility.{GRPCTaggerUtility, SOAPTag
 import ai.privado.metric.MetricHandler
 import ai.privado.model.{Constants, Language, NodeType, RuleInfo}
 import ai.privado.tagger.PrivadoParallelCpgPass
-import ai.privado.tagger.utility.APITaggerUtility.sinkTagger
+import ai.privado.tagger.utility.APITaggerUtility.{SERVICE_URL_REGEX_PATTERN, sinkTagger}
 import ai.privado.utility.{ImportUtility, Utilities}
 import io.circe.Json
 import io.joern.dataflowengineoss.queryengine.{EngineConfig, EngineContext}
@@ -109,7 +109,7 @@ class JavaAPITagger(cpg: Cpg, ruleCache: RuleCache, privadoInputConfig: PrivadoI
   override def runOnPart(builder: DiffGraphBuilder, ruleInfo: RuleInfo): Unit = {
     val apiInternalSources = cpg.literal.code("(?:\"|')(" + ruleInfo.combinedRulePattern + ")(?:\"|')").l
     val propertySources    = cpg.property.filter(p => p.value matches (ruleInfo.combinedRulePattern)).usedAt.l
-    val serviceSource      = cpg.property.filter(p => p.value matches ".*(http|https):\\/\\/.*").usedAt.l
+    val serviceSource      = cpg.property.filter(p => p.value matches SERVICE_URL_REGEX_PATTERN).usedAt.l
 
     // Support to use `identifier` in API's
     val identifierRegex = ruleCache.getSystemConfigByKey(Constants.apiIdentifier)
@@ -140,7 +140,7 @@ class JavaAPITagger(cpg: Cpg, ruleCache: RuleCache, privadoInputConfig: PrivadoI
         logger.debug("Using brute API Tagger to find API sinks")
         println(s"${Calendar.getInstance().getTime} - --API TAGGER V1 invoked...")
         sinkTagger(
-          apiInternalSources ++ propertySources ++ identifierSource,
+          apiInternalSources ++ propertySources ++ identifierSource ++ serviceSource,
           apis,
           builder,
           ruleInfo,
@@ -149,7 +149,7 @@ class JavaAPITagger(cpg: Cpg, ruleCache: RuleCache, privadoInputConfig: PrivadoI
           privadoInputConfig.enableAPIDisplay
         )
         sinkTagger(
-          apiInternalSources ++ propertySources ++ identifierSource,
+          apiInternalSources ++ propertySources ++ identifierSource ++ serviceSource,
           feignAPISinks ++ grpcSinks ++ soapSinks,
           builder,
           ruleInfo,
@@ -171,7 +171,7 @@ class JavaAPITagger(cpg: Cpg, ruleCache: RuleCache, privadoInputConfig: PrivadoI
         logger.debug("Skipping API Tagger because valid match not found, only applying Feign client")
         println(s"${Calendar.getInstance().getTime} - --API TAGGER SKIPPED, applying Feign client API...")
         sinkTagger(
-          apiInternalSources ++ propertySources ++ identifierSource,
+          apiInternalSources ++ propertySources ++ identifierSource ++ serviceSource,
           feignAPISinks ++ grpcSinks ++ soapSinks,
           builder,
           ruleInfo,

--- a/src/main/scala/ai/privado/passes/PropertyParserPass.scala
+++ b/src/main/scala/ai/privado/passes/PropertyParserPass.scala
@@ -81,6 +81,8 @@ class PropertyParserPass(cpg: Cpg, projectRoot: String, ruleCache: RuleCache, la
         ).filter(_.matches(".*(settings|config).*"))).toArray
       // Ruby has a lot of yaml files so creating property nodes for all of them, exposes a lot of property nodes,
       // which are incorrect, so we go by the approach of being selective and creating property nodes for only the impacted files
+      case Language.GO =>
+        (configFiles(projectRoot, Set(FileExtensions.YAML, FileExtensions.YML))).toArray
     }
   }
 

--- a/src/main/scala/ai/privado/passes/YamlLinkerPass.scala
+++ b/src/main/scala/ai/privado/passes/YamlLinkerPass.scala
@@ -1,0 +1,40 @@
+package ai.privado.passes
+
+import ai.privado.languageEngine.java.language.NodeStarters
+import ai.privado.tagger.PrivadoParallelCpgPass
+import io.shiftleft.codepropertygraph.generated.{Cpg, EdgeTypes}
+import io.shiftleft.codepropertygraph.generated.nodes.*
+import io.shiftleft.codepropertygraph.generated.nodes.JavaProperty
+import io.shiftleft.semanticcpg.language.*
+
+class YamlLinkerPass(cpg: Cpg) extends PrivadoParallelCpgPass[JavaProperty](cpg) {
+
+  private val YAML_FILE_REGEX: String = ".*(.yaml)"
+
+  override def generateParts(): Array[_ <: AnyRef] = {
+    cpg.property
+      .where(_.file.name(YAML_FILE_REGEX))
+      .iterator
+      .filter(pair => pair.name.nonEmpty && pair.value.nonEmpty)
+      .toArray
+  }
+
+  override def runOnPart(builder: DiffGraphBuilder, property: JavaProperty): Unit = {
+    connectProperty(property, builder)
+  }
+
+  private def connectProperty(propertyNode: JavaProperty, builder: DiffGraphBuilder): Unit = {
+    matchingLiteralsInGetEnvCalls(propertyNode.name).foreach(lit => {
+      builder.addEdge(propertyNode, lit, EdgeTypes.IS_USED_AT)
+      builder.addEdge(lit, propertyNode, EdgeTypes.ORIGINAL_PROPERTY)
+    })
+  }
+
+  private def matchingLiteralsInGetEnvCalls(propertyName: String): List[Literal] = {
+    val propertyKey = propertyName.split("\\.").last
+    cpg.literal
+      .codeExact("\"" + propertyKey + "\"")
+      .filter(_.inCall.name("(?i).*getenv").nonEmpty)
+      .toList
+  }
+}

--- a/src/main/scala/ai/privado/passes/YamlLinkerPass.scala
+++ b/src/main/scala/ai/privado/passes/YamlLinkerPass.scala
@@ -24,11 +24,11 @@ abstract class YamlLinkerPass(cpg: Cpg) extends PrivadoParallelCpgPass[JavaPrope
   }
 
   private def connectProperty(propertyNode: JavaProperty, builder: DiffGraphBuilder): Unit = {
-    matchingLiteralsInGetEnvCalls(propertyNode.name).foreach(lit => {
+    matchingLiteralsToPropertyNode(propertyNode.name).foreach(lit => {
       builder.addEdge(propertyNode, lit, EdgeTypes.IS_USED_AT)
       builder.addEdge(lit, propertyNode, EdgeTypes.ORIGINAL_PROPERTY)
     })
   }
 
-  def matchingLiteralsInGetEnvCalls(propertyName: String): List[Literal]
+  def matchingLiteralsToPropertyNode(propertyName: String): List[Literal]
 }

--- a/src/main/scala/ai/privado/passes/YamlLinkerPass.scala
+++ b/src/main/scala/ai/privado/passes/YamlLinkerPass.scala
@@ -7,7 +7,7 @@ import io.shiftleft.codepropertygraph.generated.nodes.*
 import io.shiftleft.codepropertygraph.generated.nodes.JavaProperty
 import io.shiftleft.semanticcpg.language.*
 
-class YamlLinkerPass(cpg: Cpg) extends PrivadoParallelCpgPass[JavaProperty](cpg) {
+abstract class YamlLinkerPass(cpg: Cpg) extends PrivadoParallelCpgPass[JavaProperty](cpg) {
 
   private val YAML_FILE_REGEX: String = ".*(.yaml)"
 
@@ -30,11 +30,5 @@ class YamlLinkerPass(cpg: Cpg) extends PrivadoParallelCpgPass[JavaProperty](cpg)
     })
   }
 
-  private def matchingLiteralsInGetEnvCalls(propertyName: String): List[Literal] = {
-    val propertyKey = propertyName.split("\\.").last
-    cpg.literal
-      .codeExact("\"" + propertyKey + "\"")
-      .filter(_.inCall.name("(?i).*getenv").nonEmpty)
-      .toList
-  }
+  def matchingLiteralsInGetEnvCalls(propertyName: String): List[Literal]
 }

--- a/src/main/scala/ai/privado/tagger/sink/APITagger.scala
+++ b/src/main/scala/ai/privado/tagger/sink/APITagger.scala
@@ -65,9 +65,6 @@ class APITagger(cpg: Cpg, ruleCache: RuleCache, privadoInput: PrivadoInput)
     val propertySources    = cpg.property.filter(p => p.value matches (ruleInfo.combinedRulePattern)).usedAt.l
     val identifierRegex    = ruleCache.getSystemConfigByKey(Constants.apiIdentifier)
     val serviceSource      = cpg.property.filter(p => p.value matches SERVICE_URL_REGEX_PATTERN).usedAt.l
-    cpg.property.foreach(pro => {
-      System.out.println(pro.name + " --- " + pro.value)
-    })
     val identifierSource = {
       if (!ruleInfo.id.equals(Constants.internalAPIRuleId))
         cpg.identifier(identifierRegex).l ++ cpg.member

--- a/src/main/scala/ai/privado/tagger/sink/APITagger.scala
+++ b/src/main/scala/ai/privado/tagger/sink/APITagger.scala
@@ -29,7 +29,7 @@ import ai.privado.languageEngine.java.language.{NodeStarters, StepsForProperty}
 import ai.privado.languageEngine.java.semantic.JavaSemanticGenerator
 import ai.privado.model.{Constants, Language, NodeType, RuleInfo}
 import ai.privado.tagger.PrivadoParallelCpgPass
-import ai.privado.tagger.utility.APITaggerUtility.sinkTagger
+import ai.privado.tagger.utility.APITaggerUtility.{SERVICE_URL_REGEX_PATTERN, sinkTagger}
 import ai.privado.utility.Utilities
 import io.joern.dataflowengineoss.queryengine.{EngineConfig, EngineContext}
 import io.shiftleft.codepropertygraph.generated.Cpg
@@ -64,6 +64,10 @@ class APITagger(cpg: Cpg, ruleCache: RuleCache, privadoInput: PrivadoInput)
     val apiInternalSources = cpg.literal.code("(?:\"|'|`)(" + ruleInfo.combinedRulePattern + ")(?:\"|'|`)").l
     val propertySources    = cpg.property.filter(p => p.value matches (ruleInfo.combinedRulePattern)).usedAt.l
     val identifierRegex    = ruleCache.getSystemConfigByKey(Constants.apiIdentifier)
+    val serviceSource      = cpg.property.filter(p => p.value matches SERVICE_URL_REGEX_PATTERN).usedAt.l
+    cpg.property.foreach(pro => {
+      System.out.println(pro.name + " --- " + pro.value)
+    })
     val identifierSource = {
       if (!ruleInfo.id.equals(Constants.internalAPIRuleId))
         cpg.identifier(identifierRegex).l ++ cpg.member
@@ -73,7 +77,7 @@ class APITagger(cpg: Cpg, ruleCache: RuleCache, privadoInput: PrivadoInput)
         List()
     }
     sinkTagger(
-      apiInternalSources ++ propertySources ++ identifierSource,
+      apiInternalSources ++ propertySources ++ identifierSource ++ serviceSource,
       apis,
       builder,
       ruleInfo,

--- a/src/test/scala/ai/privado/languageEngine/go/passes/config/GoYamlLinkerPassTest.scala
+++ b/src/test/scala/ai/privado/languageEngine/go/passes/config/GoYamlLinkerPassTest.scala
@@ -27,7 +27,7 @@ import org.scalatest.wordspec.AnyWordSpec
 import io.shiftleft.semanticcpg.language.*
 import ai.privado.languageEngine.java.language.*
 
-class GoYamlLinkerPassTest extends GoYamlFilePassTestBase {
+abstract class GoYamlLinkerPassTest extends GoYamlFileLinkerPassTestBase {
   override val yamlFileContents: String = """
       |config:
       |  default:
@@ -82,7 +82,7 @@ class GoYamlLinkerPassTest extends GoYamlFilePassTestBase {
   }
 }
 
-abstract class GoYamlFilePassTestBase extends AnyWordSpec with Matchers with BeforeAndAfterAll {
+abstract class GoYamlFileLinkerPassTestBase extends AnyWordSpec with Matchers with BeforeAndAfterAll {
 
   var cpg: Cpg = _
   val yamlFileContents: String
@@ -117,6 +117,13 @@ abstract class GoYamlFilePassTestBase extends AnyWordSpec with Matchers with Bef
     new IdentifierTagger(cpg, ruleCache, TaggerCache()).createAndApply()
     new GoAPITagger(cpg, ruleCache, new PrivadoInput).createAndApply()
     super.beforeAll()
+  }
+
+  override def afterAll(): Unit = {
+    inputDir.delete()
+    cpg.close()
+    outputFile.delete()
+    super.afterAll()
   }
 
   val systemConfig = List(

--- a/src/test/scala/ai/privado/languageEngine/go/passes/config/GoYamlLinkerPassTest.scala
+++ b/src/test/scala/ai/privado/languageEngine/go/passes/config/GoYamlLinkerPassTest.scala
@@ -1,0 +1,172 @@
+package ai.privado.languageEngine.go.passes.config
+
+import ai.privado.cache.{RuleCache, TaggerCache}
+import ai.privado.entrypoint.PrivadoInput
+import ai.privado.languageEngine.go.tagger.sink.GoAPITagger
+import ai.privado.languageEngine.go.tagger.source.IdentifierTagger
+import ai.privado.model.{
+  CatLevelOne,
+  ConfigAndRules,
+  Constants,
+  FilterProperty,
+  Language,
+  NodeType,
+  RuleInfo,
+  SystemConfig
+}
+import ai.privado.utility.PropertyParserPass
+import better.files.File
+import io.joern.dataflowengineoss.layers.dataflows.{OssDataFlow, OssDataFlowOptions}
+import io.joern.gosrc2cpg.{Config, GoSrc2Cpg}
+import io.joern.x2cpg.X2Cpg.applyDefaultOverlays
+import io.shiftleft.codepropertygraph.generated.Cpg
+import io.shiftleft.semanticcpg.layers.LayerCreatorContext
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import io.shiftleft.semanticcpg.language.*
+import ai.privado.languageEngine.java.language.*
+
+class GoYamlLinkerPassTest extends GoYamlFilePassTestBase {
+  override val yamlFileContents: String = """
+      |config:
+      |  default:
+      |    API_URL: http://exampleKubernetesService
+      |""".stripMargin
+
+  override val codeFileContents: String = """
+      |package main
+      |
+      |import (
+      | "os"
+      | "net/http"
+      |)
+      |
+      |func main() {
+      | api_url := os.getEnv("API_URL")
+      | resp, err := http.Post(api_url)
+      |}
+      |""".stripMargin
+
+  "Http client get API Sample" should {
+    "Http client should be tagged" in {
+      val callNode = cpg.call.name("Post").head
+      callNode.tag.size shouldBe 6
+      callNode.tag
+        .nameExact(Constants.id)
+        .head
+        .value shouldBe (Constants.thirdPartiesAPIRuleId) + ".exampleKubernetesService"
+      callNode.tag.nameExact(Constants.catLevelOne).head.value shouldBe Constants.sinks
+      callNode.tag.nameExact(Constants.catLevelTwo).head.value shouldBe Constants.third_parties
+      callNode.tag.nameExact(Constants.nodeType).head.value shouldBe "api"
+      callNode.tag
+        .nameExact("third_partiesapi")
+        .head
+        .value shouldBe (Constants.thirdPartiesAPIRuleId + ".exampleKubernetesService")
+      callNode.tag.nameExact("apiUrlSinks.ThirdParties.API.exampleKubernetesService")
+    }
+
+    "create a `property` node for each property" in {
+      val properties = cpg.property.map(x => (x.name, x.value)).toMap
+      properties
+        .get("config.default.API_URL")
+        .contains("http://exampleKubernetesService")
+    }
+
+    "Two way edge between member and propertyNode" in {
+      val properties = cpg.property.usedAt.originalProperty.l.map(property => (property.name, property.value)).toMap
+      properties
+        .get("config.default.API_URL")
+        .contains("http://exampleKubernetesService") shouldBe true
+    }
+  }
+}
+
+abstract class GoYamlFilePassTestBase extends AnyWordSpec with Matchers with BeforeAndAfterAll {
+
+  var cpg: Cpg = _
+  val yamlFileContents: String
+  val codeFileContents: String
+  var inputDir: File   = _
+  var outputFile: File = _
+  val ruleCache        = new RuleCache()
+
+  override def beforeAll(): Unit = {
+    inputDir = File.newTemporaryDirectory()
+    (inputDir / "test.yaml").write(yamlFileContents)
+    (inputDir / "GeneralConfig.go").write(codeFileContents)
+
+    outputFile = File.newTemporaryFile()
+    val config = Config().withInputPath(inputDir.pathAsString).withOutputPath(outputFile.pathAsString)
+
+    val goSrc = new GoSrc2Cpg()
+    val xtocpg = goSrc.createCpg(config).map { cpg =>
+      applyDefaultOverlays(cpg)
+      cpg
+    }
+
+    cpg = xtocpg.get
+
+    ruleCache.setRule(rule)
+
+    val context = new LayerCreatorContext(cpg)
+    val options = new OssDataFlowOptions()
+    new OssDataFlow(options).run(context)
+    new PropertyParserPass(cpg, inputDir.toString(), new RuleCache, Language.GO).createAndApply()
+    new GoYamlLinkerPass(cpg).createAndApply()
+    new IdentifierTagger(cpg, ruleCache, TaggerCache()).createAndApply()
+    new GoAPITagger(cpg, ruleCache, new PrivadoInput).createAndApply()
+    super.beforeAll()
+  }
+
+  val systemConfig = List(
+    SystemConfig(
+      "apiHttpLibraries",
+      "^(?i)(net/http|github.com/parnurzeal/gorequest|(gopkg.in|github.com/go-resty)/resty|valyala/fasthttp|github.com/gojektech/heimdall/v\\\\d/httpclient|github.com/levigross/grequests|github.com/PuerkitoBio/rehttp|github.com/machinebox/graphql).*",
+      Language.GO,
+      "",
+      Array()
+    ),
+    SystemConfig(
+      "apiSinks",
+      "(?i)(?:url|client|open|request|execute|newCall|load|host|access|list|set|put|post|proceed|trace|patch|Path|send|remove|delete|write|read|postForEntity|call|createCall|createEndpoint|dispatch|invoke|getInput|getOutput|getResponse|do)",
+      Language.GO,
+      "",
+      Array()
+    ),
+    SystemConfig(
+      "apiIdentifier",
+      "(?i).*((hook|base|auth|prov|endp|install|request|service|gateway|route|resource)(.){0,12}url|(slack|web)(.){0,4}hook|(rest|api|request|service)(.){0,4}(endpoint|gateway|route)).*",
+      Language.GO,
+      "",
+      Array()
+    )
+  )
+
+  val sinkRule = List(
+    RuleInfo(
+      Constants.thirdPartiesAPIRuleId,
+      "Third Party API",
+      "",
+      FilterProperty.METHOD_FULL_NAME,
+      Array(),
+      List(
+        "(?i)((?:http|https):\\/\\/[a-zA-Z0-9_-][^)\\/(#|,!>\\s]{1,50}\\.\\b(?:com|net|org|de|in|uk|us|io|gov|cn|ml|ai|ly|dev|cloud|me|icu|ru|info|top|tk|tr|cn|ga|cf|nl)\\b).*(?<!png|jpeg|jpg|txt|blob|css|html|js|svg)",
+        "(?i).*((hook|base|auth|prov|endp|install|request|service|gateway|route|resource)(.){0,12}url|(slack|web)(.){0,4}hook|(rest|api|request|service)(.){0,4}(endpoint|gateway|route)).*"
+      ),
+      false,
+      "",
+      Map(),
+      NodeType.API,
+      "",
+      CatLevelOne.SINKS,
+      catLevelTwo = Constants.third_parties,
+      Language.GO,
+      Array()
+    )
+  )
+
+  val rule: ConfigAndRules =
+    ConfigAndRules(List(), sinkRule, List(), List(), List(), List(), List(), List(), systemConfig, List())
+
+}

--- a/src/test/scala/ai/privado/languageEngine/java/passes/config/JavaYamlLinkerPassTest.scala
+++ b/src/test/scala/ai/privado/languageEngine/java/passes/config/JavaYamlLinkerPassTest.scala
@@ -1,3 +1,199 @@
 package ai.privado.languageEngine.java.passes.config
 
-class JavaYamlLinkerPassTest {}
+import ai.privado.cache.{RuleCache, TaggerCache}
+import ai.privado.entrypoint.PrivadoInput
+import ai.privado.languageEngine.java.tagger.sink.JavaAPITagger
+import ai.privado.languageEngine.java.tagger.source.IdentifierTagger
+import ai.privado.model.{
+  CatLevelOne,
+  ConfigAndRules,
+  Constants,
+  FilterProperty,
+  Language,
+  NodeType,
+  RuleInfo,
+  SystemConfig
+}
+import ai.privado.utility.PropertyParserPass
+import better.files.File
+import io.joern.dataflowengineoss.layers.dataflows.{OssDataFlow, OssDataFlowOptions}
+import io.joern.javasrc2cpg.Config
+import io.joern.javasrc2cpg.JavaSrc2Cpg
+import io.joern.x2cpg.X2Cpg.applyDefaultOverlays
+import io.shiftleft.codepropertygraph.generated.Cpg
+import io.shiftleft.semanticcpg.layers.LayerCreatorContext
+import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.matchers.should.Matchers.should
+import org.scalatest.wordspec.AnyWordSpec
+import io.shiftleft.semanticcpg.language.*
+import ai.privado.languageEngine.java.language.*
+
+class JavaYamlLinkerPassTest extends JavaYamlLinkerPassTestBase {
+  override val yamlFileContents =
+    """
+      |config:
+      |  default:
+      |    API_URL: http://exampleKubernetesService
+      |""".stripMargin
+
+  override val codeFileContents =
+    """
+      |import org.apache.http.HttpResponse;
+      |import org.apache.http.client.HttpClient;
+      |import org.apache.http.client.methods.HttpGet;
+      |import org.apache.http.impl.client.HttpClients;
+      |
+      |public class APICaller {
+      |  private String apiUrl;
+      |
+      |  public makeCall() {
+      |    apiUrl = System.getenv("API_URL");
+      |
+      |    HttpClient httpClient = HttpClients.createDefault();
+      |    HttpGet getRequest = new HttpGet(apiUrl);
+      |    HttpResponse response = httpClient.execute(getRequest);
+      |  }
+      |}
+      |""".stripMargin
+
+  "Http client execute API Sample" should {
+    "Http Client execute should be tagged" in {
+      val callNode = cpg.call.name("execute").head
+      callNode.tag.size shouldBe 6
+      callNode.tag
+        .nameExact(Constants.id)
+        .head
+        .value shouldBe (Constants.thirdPartiesAPIRuleId) + ".exampleKubernetesService"
+      callNode.tag.nameExact(Constants.catLevelOne).head.value shouldBe Constants.sinks
+      callNode.tag.nameExact(Constants.catLevelTwo).head.value shouldBe Constants.third_parties
+      callNode.tag.nameExact(Constants.nodeType).head.value shouldBe "api"
+      callNode.tag
+        .nameExact("third_partiesapi")
+        .head
+        .value shouldBe (Constants.thirdPartiesAPIRuleId + ".exampleKubernetesService")
+      callNode.tag.nameExact("apiUrlSinks.ThirdParties.API.exampleKubernetesService")
+    }
+
+    "create a `property` node for each property" in {
+      val properties = cpg.property.map(x => (x.name, x.value)).toMap
+      properties
+        .get("config.default.API_URL")
+        .contains("http://exampleKubernetesService")
+    }
+
+    "Two way edge between member and propertyNode" in {
+      val properties = cpg.property.usedAt.originalProperty.l.map(property => (property.name, property.value)).toMap
+      properties
+        .get("config.default.API_URL")
+        .contains("http://exampleKubernetesService") shouldBe true
+    }
+  }
+}
+
+abstract class JavaYamlLinkerPassTestBase
+    extends AnyWordSpec
+    with Matchers
+    with BeforeAndAfterAll
+    with BeforeAndAfterEach {
+  var cpg: Cpg = _
+  val yamlFileContents: String
+  val codeFileContents: String
+  var inputDir: File   = _
+  var outputFile: File = _
+  val ruleCache        = new RuleCache()
+
+  override def beforeAll(): Unit = {
+    inputDir = File.newTemporaryDirectory()
+    (inputDir / "test.yaml").write(yamlFileContents)
+    (inputDir / "GeneralConfig.java").write(codeFileContents)
+
+    outputFile = File.newTemporaryFile()
+    val config = Config().withInputPath(inputDir.pathAsString).withOutputPath(outputFile.pathAsString)
+
+    cpg = new JavaSrc2Cpg()
+      .createCpg(config)
+      .map { cpg =>
+        applyDefaultOverlays(cpg)
+        cpg
+      }
+      .get
+
+    ruleCache.setRule(rule)
+
+    val context = new LayerCreatorContext(cpg)
+    val options = new OssDataFlowOptions()
+    new OssDataFlow(options).run(context)
+    new PropertyParserPass(cpg, inputDir.toString(), new RuleCache, Language.JAVA).createAndApply()
+    new JavaPropertyLinkerPass(cpg).createAndApply()
+    new JavaYamlLinkerPass(cpg).createAndApply()
+    new IdentifierTagger(cpg, ruleCache, TaggerCache()).createAndApply()
+    new JavaAPITagger(cpg, ruleCache, PrivadoInput()).createAndApply()
+
+    super.beforeAll()
+  }
+
+  override def afterAll(): Unit = {
+    inputDir.delete()
+    cpg.close()
+    outputFile.delete()
+    super.afterAll()
+  }
+
+  val systemConfig = List(
+    SystemConfig(
+      "apiHttpLibraries",
+      "(?i)(org.apache.http|okhttp|org.glassfish.jersey|com.mashape.unirest|java.net.http|java.net.URL|org.springframework.(web|core.io)|groovyx.net.http|org.asynchttpclient|kong.unirest.java|org.concordion.cubano.driver.http|javax.net.ssl|javax.xml.soap|org.apache.axis2|com.sun.xml.messaging.saaj|org.springframework.ws.client|com.eviware.soapui|org.apache.cxf|org.jboss.ws|com.ibm.websphere.sca.extensions.soap|com.sun.xml.ws|org.apache.camel.component.cxf|org.codehaus.xfire|org.apache.synapse|org.apache.wink.client|com.oracle.webservices.internal.api.databinding.Databinding|com.sap.engine.interfaces.webservices.runtime.client).*",
+      Language.JAVA,
+      "",
+      Array()
+    ),
+    SystemConfig(
+      "apiSinks",
+      "(?i)(?:url|client|openConnection|request|execute|newCall|load|host|access|fetch|get|getInputStream|getApod|getForObject|getForEntity|list|set|put|post|proceed|trace|patch|Path|send|sendAsync|remove|delete|write|read|assignment|provider|exchange|postForEntity|postForObject|call|createCall|createEndpoint|dispatch|invoke|newMessage|getInput|getOutput|getResponse|marshall|unmarshall|send|asyncSend)",
+      Language.JAVA,
+      "",
+      Array()
+    ),
+    SystemConfig(
+      "apiIdentifier",
+      "(?i).*((hook|base|auth|prov|endp|install|request|service|gateway|route|resource)(.){0,12}url|(slack|web)(.){0,4}hook|(rest|api|request|service)(.){0,4}(endpoint|gateway|route)).*",
+      Language.JAVA,
+      "",
+      Array()
+    ),
+    SystemConfig(
+      "ignoredSinks",
+      "(?i).*(?<=map|list|jsonobject|json|array|arrays|jsonnode|objectmapper|objectnode).*(put:|get:).*",
+      Language.JAVA,
+      "",
+      Array()
+    )
+  )
+
+  val sinkRule = List(
+    RuleInfo(
+      Constants.thirdPartiesAPIRuleId,
+      "Third Party API",
+      "",
+      FilterProperty.METHOD_FULL_NAME,
+      Array(),
+      List(
+        "(?i)((?:http|https):\\/\\/[a-zA-Z0-9_-][^)\\/(#|,!>\\s]{1,50}\\.\\b(?:com|net|org|de|in|uk|us|io|gov|cn|ml|ai|ly|dev|cloud|me|icu|ru|info|top|tk|tr|cn|ga|cf|nl)\\b).*(?<!png|jpeg|jpg|txt|blob|css|html|js|svg)",
+        "(?i).*((hook|base|auth|prov|endp|install|request|service|gateway|route|resource)(.){0,12}url|(slack|web)(.){0,4}hook|(rest|api|request|service)(.){0,4}(endpoint|gateway|route)).*"
+      ),
+      false,
+      "",
+      Map(),
+      NodeType.API,
+      "",
+      CatLevelOne.SINKS,
+      catLevelTwo = Constants.third_parties,
+      Language.JAVA,
+      Array()
+    )
+  )
+
+  val rule: ConfigAndRules =
+    ConfigAndRules(List(), sinkRule, List(), List(), List(), List(), List(), List(), systemConfig, List())
+}

--- a/src/test/scala/ai/privado/languageEngine/java/passes/config/JavaYamlLinkerPassTest.scala
+++ b/src/test/scala/ai/privado/languageEngine/java/passes/config/JavaYamlLinkerPassTest.scala
@@ -1,0 +1,3 @@
+package ai.privado.languageEngine.java.passes.config
+
+class JavaYamlLinkerPassTest {}

--- a/src/test/scala/ai/privado/languageEngine/java/passes/config/PropertiesFilePassTest.scala
+++ b/src/test/scala/ai/privado/languageEngine/java/passes/config/PropertiesFilePassTest.scala
@@ -107,16 +107,16 @@ class AnnotationTests extends PropertiesFilePassTestBase(".properties") {
 
 class JsonPropertyTests extends PropertiesFilePassTestBase(".json") {
   override val configFileContents = """
-                                      |{
-                                      |    "databases": [
-                                      |      {
-                                      |        "name": "MySQL Database",
-                                      |        "uri": "mysql://username:password@hostname:port/database_name"
-                                      |      }
-                                      |     ],
-                                      |     "mongoUri" : "mongodb://username:password@hostname:port/database_name"
-                                      |}
-                                      |""".stripMargin
+      |{
+      |    "databases": [
+      |      {
+      |        "name": "MySQL Database",
+      |        "uri": "mysql://username:password@hostname:port/database_name"
+      |      }
+      |     ],
+      |     "mongoUri" : "mongodb://username:password@hostname:port/database_name"
+      |}
+      |""".stripMargin
 
   override val codeFileContents = ""
 
@@ -137,9 +137,9 @@ class JsonPropertyTests extends PropertiesFilePassTestBase(".json") {
 }
 class GetPropertyTests extends PropertiesFilePassTestBase(".properties") {
   override val configFileContents = """
-                                      |accounts.datasource.url=jdbc:mariadb://localhost:3306/accounts?useSSL=false
-                                      |internal.logger.api.base=https://logger.privado.ai/
-                                      |""".stripMargin
+      |accounts.datasource.url=jdbc:mariadb://localhost:3306/accounts?useSSL=false
+      |internal.logger.api.base=https://logger.privado.ai/
+      |""".stripMargin
   override val codeFileContents =
     """
       | import org.springframework.core.env.Environment;
@@ -319,7 +319,7 @@ abstract class PropertiesFilePassTestBase(fileExtension: String)
     inputDir = File.newTemporaryDirectory()
     (inputDir / s"test$fileExtension").write(configFileContents)
 
-    //    (inputDir / "unrelated.file").write("foo")
+//    (inputDir / "unrelated.file").write("foo")
     if (propertyFileContents.nonEmpty) {
       (inputDir / "application.properties").write(propertyFileContents)
     }

--- a/src/test/scala/ai/privado/languageEngine/java/passes/config/PropertiesFilePassTest.scala
+++ b/src/test/scala/ai/privado/languageEngine/java/passes/config/PropertiesFilePassTest.scala
@@ -341,8 +341,8 @@ class YamlPropertyTests2 extends PropertiesFilePassTestBase(".yaml") {
         |""".stripMargin
 
   override val propertyFileContents: String = ""
-  "fetch api" should {
-    "ooo" in {
+  "Http client execute API Sample" should {
+    "Http Client execute should be tagged" in {
       val callNode = cpg.call.name("execute").head
       callNode.tag.size shouldBe 6
       callNode.tag

--- a/src/test/scala/ai/privado/languageEngine/java/passes/config/PropertiesFilePassTest.scala
+++ b/src/test/scala/ai/privado/languageEngine/java/passes/config/PropertiesFilePassTest.scala
@@ -23,9 +23,19 @@
 
 package ai.privado.languageEngine.java.passes.config
 
-import ai.privado.cache.RuleCache
+import ai.privado.cache.{RuleCache, TaggerCache}
+import ai.privado.entrypoint.PrivadoInput
 import ai.privado.languageEngine.java.language.*
-import ai.privado.model.Language
+import ai.privado.model.{
+  CatLevelOne,
+  ConfigAndRules,
+  Constants,
+  FilterProperty,
+  Language,
+  NodeType,
+  RuleInfo,
+  SystemConfig
+}
 import ai.privado.utility.PropertyParserPass
 import better.files.File
 import io.joern.javasrc2cpg.{Config, JavaSrc2Cpg}
@@ -37,6 +47,10 @@ import org.scalatest.BeforeAndAfterAll
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import ai.privado.exporter.HttpConnectionMetadataExporter
+import ai.privado.languageEngine.java.tagger.sink.JavaAPITagger
+import ai.privado.languageEngine.javascript.tagger.source.IdentifierTagger
+import io.joern.dataflowengineoss.layers.dataflows.{OssDataFlow, OssDataFlowOptions}
+import io.shiftleft.semanticcpg.layers.LayerCreatorContext
 
 class AnnotationTests extends PropertiesFilePassTestBase(".properties") {
   override val configFileContents: String =
@@ -300,6 +314,67 @@ class XMLPropertyTests extends PropertiesFilePassTestBase(".xml") {
   }
 }
 
+class YamlPropertyTests2 extends PropertiesFilePassTestBase(".yaml") {
+  override val configFileContents = """
+      |config:
+      |  default:
+      |    API_URL: http://exampleKubernetesService
+      |""".stripMargin
+
+  override val codeFileContents = """
+        |import org.apache.http.HttpResponse;
+        |import org.apache.http.client.HttpClient;
+        |import org.apache.http.client.methods.HttpGet;
+        |import org.apache.http.impl.client.HttpClients;
+        |
+        |public class APICaller {
+        |  private String apiUrl;
+        |
+        |  public makeCall() {
+        |    apiUrl = System.getenv("API_URL");
+        |
+        |    HttpClient httpClient = HttpClients.createDefault();
+        |    HttpGet getRequest = new HttpGet(apiUrl);
+        |    HttpResponse response = httpClient.execute(getRequest);
+        |  }
+        |}
+        |""".stripMargin
+
+  override val propertyFileContents: String = ""
+  "fetch api" should {
+    "ooo" in {
+      val callNode = cpg.call.name("execute").head
+      callNode.tag.size shouldBe 6
+      callNode.tag
+        .nameExact(Constants.id)
+        .head
+        .value shouldBe (Constants.thirdPartiesAPIRuleId) + ".exampleKubernetesService"
+      callNode.tag.nameExact(Constants.catLevelOne).head.value shouldBe Constants.sinks
+      callNode.tag.nameExact(Constants.catLevelTwo).head.value shouldBe Constants.third_parties
+      callNode.tag.nameExact(Constants.nodeType).head.value shouldBe "api"
+      callNode.tag
+        .nameExact("third_partiesapi")
+        .head
+        .value shouldBe (Constants.thirdPartiesAPIRuleId + ".exampleKubernetesService")
+      callNode.tag.nameExact("apiUrlSinks.ThirdParties.API.exampleKubernetesService")
+    }
+
+    "create a `property` node for each property" in {
+      val properties = cpg.property.map(x => (x.name, x.value)).toMap
+      properties
+        .get("config.default.API_URL")
+        .contains("http://exampleKubernetesService")
+    }
+
+    "Two way edge between member and propertyNode" in {
+      val properties = cpg.property.usedAt.originalProperty.l.map(property => (property.name, property.value)).toMap
+      properties
+        .get("config.default.API_URL")
+        .contains("http://exampleKubernetesService") shouldBe true
+    }
+  }
+}
+
 /** Base class for tests on properties files and Java code.
   */
 // file extension to support for any file as properties
@@ -314,6 +389,7 @@ abstract class PropertiesFilePassTestBase(fileExtension: String)
   var inputDir: File   = _
   var outputFile: File = _
   val propertyFileContents: String
+  val ruleCache = new RuleCache()
 
   override def beforeAll(): Unit = {
     inputDir = File.newTemporaryDirectory()
@@ -335,8 +411,17 @@ abstract class PropertiesFilePassTestBase(fileExtension: String)
         cpg
       }
       .get
+
+    ruleCache.setRule(rule)
+
+    val context = new LayerCreatorContext(cpg)
+    val options = new OssDataFlowOptions()
+    new OssDataFlow(options).run(context)
     new PropertyParserPass(cpg, inputDir.toString(), new RuleCache, Language.JAVA).createAndApply()
     new JavaPropertyLinkerPass(cpg).createAndApply()
+    new JavaYamlLinkerPass(cpg).createAndApply()
+    new IdentifierTagger(cpg, ruleCache, TaggerCache()).createAndApply()
+    new JavaAPITagger(cpg, ruleCache, PrivadoInput()).createAndApply()
 
     super.beforeAll()
   }
@@ -347,5 +432,62 @@ abstract class PropertiesFilePassTestBase(fileExtension: String)
     outputFile.delete()
     super.afterAll()
   }
+
+  val systemConfig = List(
+    SystemConfig(
+      "apiHttpLibraries",
+      "(?i)(org.apache.http|okhttp|org.glassfish.jersey|com.mashape.unirest|java.net.http|java.net.URL|org.springframework.(web|core.io)|groovyx.net.http|org.asynchttpclient|kong.unirest.java|org.concordion.cubano.driver.http|javax.net.ssl|javax.xml.soap|org.apache.axis2|com.sun.xml.messaging.saaj|org.springframework.ws.client|com.eviware.soapui|org.apache.cxf|org.jboss.ws|com.ibm.websphere.sca.extensions.soap|com.sun.xml.ws|org.apache.camel.component.cxf|org.codehaus.xfire|org.apache.synapse|org.apache.wink.client|com.oracle.webservices.internal.api.databinding.Databinding|com.sap.engine.interfaces.webservices.runtime.client).*",
+      Language.JAVA,
+      "",
+      Array()
+    ),
+    SystemConfig(
+      "apiSinks",
+      "(?i)(?:url|client|openConnection|request|execute|newCall|load|host|access|fetch|get|getInputStream|getApod|getForObject|getForEntity|list|set|put|post|proceed|trace|patch|Path|send|sendAsync|remove|delete|write|read|assignment|provider|exchange|postForEntity|postForObject|call|createCall|createEndpoint|dispatch|invoke|newMessage|getInput|getOutput|getResponse|marshall|unmarshall|send|asyncSend)",
+      Language.JAVA,
+      "",
+      Array()
+    ),
+    SystemConfig(
+      "apiIdentifier",
+      "(?i).*((hook|base|auth|prov|endp|install|request|service|gateway|route|resource)(.){0,12}url|(slack|web)(.){0,4}hook|(rest|api|request|service)(.){0,4}(endpoint|gateway|route)).*",
+      Language.JAVA,
+      "",
+      Array()
+    ),
+    SystemConfig(
+      "ignoredSinks",
+      "(?i).*(?<=map|list|jsonobject|json|array|arrays|jsonnode|objectmapper|objectnode).*(put:|get:).*",
+      Language.JAVA,
+      "",
+      Array()
+    )
+  )
+
+  val sinkRule = List(
+    RuleInfo(
+      Constants.thirdPartiesAPIRuleId,
+      "Third Party API",
+      "",
+      FilterProperty.METHOD_FULL_NAME,
+      Array(),
+      List(
+        "(?i)((?:http|https):\\/\\/[a-zA-Z0-9_-][^)\\/(#|,!>\\s]{1,50}\\.\\b(?:com|net|org|de|in|uk|us|io|gov|cn|ml|ai|ly|dev|cloud|me|icu|ru|info|top|tk|tr|cn|ga|cf|nl)\\b).*(?<!png|jpeg|jpg|txt|blob|css|html|js|svg)",
+        "(?i).*((hook|base|auth|prov|endp|install|request|service|gateway|route|resource)(.){0,12}url|(slack|web)(.){0,4}hook|(rest|api|request|service)(.){0,4}(endpoint|gateway|route)).*"
+      ),
+      false,
+      "",
+      Map(),
+      NodeType.API,
+      "",
+      CatLevelOne.SINKS,
+      catLevelTwo = Constants.third_parties,
+      Language.JAVA,
+      Array()
+    )
+  )
+
+  val rule: ConfigAndRules =
+    ConfigAndRules(List(), sinkRule, List(), List(), List(), List(), List(), List(), systemConfig, List())
 
 }

--- a/src/test/scala/ai/privado/languageEngine/java/passes/config/PropertiesFilePassTest.scala
+++ b/src/test/scala/ai/privado/languageEngine/java/passes/config/PropertiesFilePassTest.scala
@@ -23,19 +23,9 @@
 
 package ai.privado.languageEngine.java.passes.config
 
-import ai.privado.cache.{RuleCache, TaggerCache}
-import ai.privado.entrypoint.PrivadoInput
+import ai.privado.cache.RuleCache
 import ai.privado.languageEngine.java.language.*
-import ai.privado.model.{
-  CatLevelOne,
-  ConfigAndRules,
-  Constants,
-  FilterProperty,
-  Language,
-  NodeType,
-  RuleInfo,
-  SystemConfig
-}
+import ai.privado.model.Language
 import ai.privado.utility.PropertyParserPass
 import better.files.File
 import io.joern.javasrc2cpg.{Config, JavaSrc2Cpg}
@@ -47,10 +37,6 @@ import org.scalatest.BeforeAndAfterAll
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import ai.privado.exporter.HttpConnectionMetadataExporter
-import ai.privado.languageEngine.java.tagger.sink.JavaAPITagger
-import ai.privado.languageEngine.javascript.tagger.source.IdentifierTagger
-import io.joern.dataflowengineoss.layers.dataflows.{OssDataFlow, OssDataFlowOptions}
-import io.shiftleft.semanticcpg.layers.LayerCreatorContext
 
 class AnnotationTests extends PropertiesFilePassTestBase(".properties") {
   override val configFileContents: String =
@@ -121,16 +107,16 @@ class AnnotationTests extends PropertiesFilePassTestBase(".properties") {
 
 class JsonPropertyTests extends PropertiesFilePassTestBase(".json") {
   override val configFileContents = """
-      |{
-      |    "databases": [
-      |      {
-      |        "name": "MySQL Database",
-      |        "uri": "mysql://username:password@hostname:port/database_name"
-      |      }
-      |     ],
-      |     "mongoUri" : "mongodb://username:password@hostname:port/database_name"
-      |}
-      |""".stripMargin
+                                      |{
+                                      |    "databases": [
+                                      |      {
+                                      |        "name": "MySQL Database",
+                                      |        "uri": "mysql://username:password@hostname:port/database_name"
+                                      |      }
+                                      |     ],
+                                      |     "mongoUri" : "mongodb://username:password@hostname:port/database_name"
+                                      |}
+                                      |""".stripMargin
 
   override val codeFileContents = ""
 
@@ -151,9 +137,9 @@ class JsonPropertyTests extends PropertiesFilePassTestBase(".json") {
 }
 class GetPropertyTests extends PropertiesFilePassTestBase(".properties") {
   override val configFileContents = """
-      |accounts.datasource.url=jdbc:mariadb://localhost:3306/accounts?useSSL=false
-      |internal.logger.api.base=https://logger.privado.ai/
-      |""".stripMargin
+                                      |accounts.datasource.url=jdbc:mariadb://localhost:3306/accounts?useSSL=false
+                                      |internal.logger.api.base=https://logger.privado.ai/
+                                      |""".stripMargin
   override val codeFileContents =
     """
       | import org.springframework.core.env.Environment;
@@ -314,67 +300,6 @@ class XMLPropertyTests extends PropertiesFilePassTestBase(".xml") {
   }
 }
 
-class YamlPropertyTests2 extends PropertiesFilePassTestBase(".yaml") {
-  override val configFileContents = """
-      |config:
-      |  default:
-      |    API_URL: http://exampleKubernetesService
-      |""".stripMargin
-
-  override val codeFileContents = """
-        |import org.apache.http.HttpResponse;
-        |import org.apache.http.client.HttpClient;
-        |import org.apache.http.client.methods.HttpGet;
-        |import org.apache.http.impl.client.HttpClients;
-        |
-        |public class APICaller {
-        |  private String apiUrl;
-        |
-        |  public makeCall() {
-        |    apiUrl = System.getenv("API_URL");
-        |
-        |    HttpClient httpClient = HttpClients.createDefault();
-        |    HttpGet getRequest = new HttpGet(apiUrl);
-        |    HttpResponse response = httpClient.execute(getRequest);
-        |  }
-        |}
-        |""".stripMargin
-
-  override val propertyFileContents: String = ""
-  "Http client execute API Sample" should {
-    "Http Client execute should be tagged" in {
-      val callNode = cpg.call.name("execute").head
-      callNode.tag.size shouldBe 6
-      callNode.tag
-        .nameExact(Constants.id)
-        .head
-        .value shouldBe (Constants.thirdPartiesAPIRuleId) + ".exampleKubernetesService"
-      callNode.tag.nameExact(Constants.catLevelOne).head.value shouldBe Constants.sinks
-      callNode.tag.nameExact(Constants.catLevelTwo).head.value shouldBe Constants.third_parties
-      callNode.tag.nameExact(Constants.nodeType).head.value shouldBe "api"
-      callNode.tag
-        .nameExact("third_partiesapi")
-        .head
-        .value shouldBe (Constants.thirdPartiesAPIRuleId + ".exampleKubernetesService")
-      callNode.tag.nameExact("apiUrlSinks.ThirdParties.API.exampleKubernetesService")
-    }
-
-    "create a `property` node for each property" in {
-      val properties = cpg.property.map(x => (x.name, x.value)).toMap
-      properties
-        .get("config.default.API_URL")
-        .contains("http://exampleKubernetesService")
-    }
-
-    "Two way edge between member and propertyNode" in {
-      val properties = cpg.property.usedAt.originalProperty.l.map(property => (property.name, property.value)).toMap
-      properties
-        .get("config.default.API_URL")
-        .contains("http://exampleKubernetesService") shouldBe true
-    }
-  }
-}
-
 /** Base class for tests on properties files and Java code.
   */
 // file extension to support for any file as properties
@@ -389,13 +314,12 @@ abstract class PropertiesFilePassTestBase(fileExtension: String)
   var inputDir: File   = _
   var outputFile: File = _
   val propertyFileContents: String
-  val ruleCache = new RuleCache()
 
   override def beforeAll(): Unit = {
     inputDir = File.newTemporaryDirectory()
     (inputDir / s"test$fileExtension").write(configFileContents)
 
-//    (inputDir / "unrelated.file").write("foo")
+    //    (inputDir / "unrelated.file").write("foo")
     if (propertyFileContents.nonEmpty) {
       (inputDir / "application.properties").write(propertyFileContents)
     }
@@ -411,17 +335,8 @@ abstract class PropertiesFilePassTestBase(fileExtension: String)
         cpg
       }
       .get
-
-    ruleCache.setRule(rule)
-
-    val context = new LayerCreatorContext(cpg)
-    val options = new OssDataFlowOptions()
-    new OssDataFlow(options).run(context)
     new PropertyParserPass(cpg, inputDir.toString(), new RuleCache, Language.JAVA).createAndApply()
     new JavaPropertyLinkerPass(cpg).createAndApply()
-    new JavaYamlLinkerPass(cpg).createAndApply()
-    new IdentifierTagger(cpg, ruleCache, TaggerCache()).createAndApply()
-    new JavaAPITagger(cpg, ruleCache, PrivadoInput()).createAndApply()
 
     super.beforeAll()
   }
@@ -432,62 +347,5 @@ abstract class PropertiesFilePassTestBase(fileExtension: String)
     outputFile.delete()
     super.afterAll()
   }
-
-  val systemConfig = List(
-    SystemConfig(
-      "apiHttpLibraries",
-      "(?i)(org.apache.http|okhttp|org.glassfish.jersey|com.mashape.unirest|java.net.http|java.net.URL|org.springframework.(web|core.io)|groovyx.net.http|org.asynchttpclient|kong.unirest.java|org.concordion.cubano.driver.http|javax.net.ssl|javax.xml.soap|org.apache.axis2|com.sun.xml.messaging.saaj|org.springframework.ws.client|com.eviware.soapui|org.apache.cxf|org.jboss.ws|com.ibm.websphere.sca.extensions.soap|com.sun.xml.ws|org.apache.camel.component.cxf|org.codehaus.xfire|org.apache.synapse|org.apache.wink.client|com.oracle.webservices.internal.api.databinding.Databinding|com.sap.engine.interfaces.webservices.runtime.client).*",
-      Language.JAVA,
-      "",
-      Array()
-    ),
-    SystemConfig(
-      "apiSinks",
-      "(?i)(?:url|client|openConnection|request|execute|newCall|load|host|access|fetch|get|getInputStream|getApod|getForObject|getForEntity|list|set|put|post|proceed|trace|patch|Path|send|sendAsync|remove|delete|write|read|assignment|provider|exchange|postForEntity|postForObject|call|createCall|createEndpoint|dispatch|invoke|newMessage|getInput|getOutput|getResponse|marshall|unmarshall|send|asyncSend)",
-      Language.JAVA,
-      "",
-      Array()
-    ),
-    SystemConfig(
-      "apiIdentifier",
-      "(?i).*((hook|base|auth|prov|endp|install|request|service|gateway|route|resource)(.){0,12}url|(slack|web)(.){0,4}hook|(rest|api|request|service)(.){0,4}(endpoint|gateway|route)).*",
-      Language.JAVA,
-      "",
-      Array()
-    ),
-    SystemConfig(
-      "ignoredSinks",
-      "(?i).*(?<=map|list|jsonobject|json|array|arrays|jsonnode|objectmapper|objectnode).*(put:|get:).*",
-      Language.JAVA,
-      "",
-      Array()
-    )
-  )
-
-  val sinkRule = List(
-    RuleInfo(
-      Constants.thirdPartiesAPIRuleId,
-      "Third Party API",
-      "",
-      FilterProperty.METHOD_FULL_NAME,
-      Array(),
-      List(
-        "(?i)((?:http|https):\\/\\/[a-zA-Z0-9_-][^)\\/(#|,!>\\s]{1,50}\\.\\b(?:com|net|org|de|in|uk|us|io|gov|cn|ml|ai|ly|dev|cloud|me|icu|ru|info|top|tk|tr|cn|ga|cf|nl)\\b).*(?<!png|jpeg|jpg|txt|blob|css|html|js|svg)",
-        "(?i).*((hook|base|auth|prov|endp|install|request|service|gateway|route|resource)(.){0,12}url|(slack|web)(.){0,4}hook|(rest|api|request|service)(.){0,4}(endpoint|gateway|route)).*"
-      ),
-      false,
-      "",
-      Map(),
-      NodeType.API,
-      "",
-      CatLevelOne.SINKS,
-      catLevelTwo = Constants.third_parties,
-      Language.JAVA,
-      Array()
-    )
-  )
-
-  val rule: ConfigAndRules =
-    ConfigAndRules(List(), sinkRule, List(), List(), List(), List(), List(), List(), systemConfig, List())
 
 }


### PR DESCRIPTION
- Added support to detect the internal flow having domain (i.e. `http://exampleService`) present inside the yaml file. 
- Made the implementation generic and can be used in anyLanguage, we only need to define the mapping rule between code and key. 