### PR TITLE
Store Egress from Code in a different key and remove parentheses from variable string

### DIFF
--- a/src/main/scala/ai/privado/exporter/ExporterUtility.scala
+++ b/src/main/scala/ai/privado/exporter/ExporterUtility.scala
@@ -348,6 +348,9 @@ object ExporterUtility {
       output.addOne(Constants.ingressUrls -> Utilities.ingressUrls.toArray.asJson)
       output.addOne(Constants.egressUrls  -> httpConnectionMetadataExporter.getEgressUrls.toArray.asJson)
       output.addOne(
+        Constants.egressUrlsFromCode -> httpConnectionMetadataExporter.getEgressUrlsFromCodeFiles.toArray.asJson
+      )
+      output.addOne(
         Constants.httpEndPointBasePaths -> httpConnectionMetadataExporter.getEndPointBasePath.toArray.asJson
       )
     }

--- a/src/main/scala/ai/privado/exporter/HttpConnectionMetadataExporter.scala
+++ b/src/main/scala/ai/privado/exporter/HttpConnectionMetadataExporter.scala
@@ -47,7 +47,8 @@ class HttpConnectionMetadataExporter(cpg: Cpg, ruleCache: RuleCache) {
   private val ESCAPE_STRING_SLASHES                                = "(\\\")"
   private val IMPORT_REGEX_WITH_SLASHES                            = "(?s)^(?=.*/)(?!.*/$).*"
 
-  private val SLASH_SYMBOL = "/"
+  private val SLASH_SYMBOL          = "/"
+  private val FORMAT_STRING_SYMBOLS = "[{}]"
 
   private val LAMBDA_SERVERLESS_BASE_PATH = "service"
   private val LAMBDA_SERVERLESS_FILE_NAME = ".*serverless.yml"
@@ -65,7 +66,8 @@ class HttpConnectionMetadataExporter(cpg: Cpg, ruleCache: RuleCache) {
             if arg.isLiteral then arg.code // collect literal
             // const loginPath = "api/v1" + "/login" --- Addition Case(javascript, python, java)
             // const signupPath = `api/v1/${signup}` --- Format String Case for javascript(similar applicable for python, java)
-            else if node.name.equals("<operator>.addition") || node.name.equals("<operator>.formatString") then arg.code
+            else if node.name.equals("<operator>.addition") || node.name.equals("<operator>.formatString") then
+              arg.code.replaceAll(FORMAT_STRING_SYMBOLS, "")
             // const loginPath = "api/v1/login" --- Assignment Case(similar applicable for python, java)
             else if node.name.equals("<operator>.assignment") && arg.isLiteral then arg.code
             else ""
@@ -80,12 +82,9 @@ class HttpConnectionMetadataExporter(cpg: Cpg, ruleCache: RuleCache) {
     egressLiterals
   }
 
-  def getEgressUrls: List[String] = {
+  def getEgressUrlsFromCodeFiles: List[String] = {
     var egressUrls = List[String]()
 
-    egressUrls = egressUrls.concat(
-      cpg.property.or(_.value(STRING_START_WITH_SLASH), _.value(STRING_CONTAINS_TWO_SLASH)).value.dedup.l
-    )
     /* We have verified literals for these languages, so we need to analyze other languages before broadening the rule.
        It can happen that literals may come from imports as well, which was the case for JavaScript, and we handled it.
        Therefore, we might need to do a few things specific to each language. */
@@ -94,6 +93,16 @@ class HttpConnectionMetadataExporter(cpg: Cpg, ruleCache: RuleCache) {
     ) {
       egressUrls = egressUrls.concat(getLiteralsFromLanguageFiles)
     }
+
+    egressUrls.dedup.l
+  }
+
+  def getEgressUrls: List[String] = {
+    var egressUrls = List[String]()
+
+    egressUrls = egressUrls.concat(
+      cpg.property.or(_.value(STRING_START_WITH_SLASH), _.value(STRING_CONTAINS_TWO_SLASH)).value.dedup.l
+    )
 
     egressUrls = egressUrls.concat(addUrlFromFeignClient())
     egressUrls.dedup.l

--- a/src/main/scala/ai/privado/model/Constants.scala
+++ b/src/main/scala/ai/privado/model/Constants.scala
@@ -110,6 +110,7 @@ object Constants {
   val violations                   = "violations"
   val ingressUrls                  = "ingressUrls"
   val egressUrls                   = "egressUrls"
+  val egressUrlsFromCode           = "egressUrlsFromCode"
   val httpEndPointBasePaths        = "httpEndPointBasePaths"
   val outputFileName               = "privado.json"
   val outputDirectoryName          = ".privado"

--- a/src/test/scala/ai/privado/exporter/JavaLanguageEgressTest.scala
+++ b/src/test/scala/ai/privado/exporter/JavaLanguageEgressTest.scala
@@ -75,8 +75,8 @@ class JavaLanguageEgressTest extends JavaTaggingTestBase {
 
   "Java code egresses" should {
     "collect egress url for java code" in {
-      val propertyExporter          = new HttpConnectionMetadataExporter(cpg, ruleCache)
-      val egressesFromLanguageFiles = propertyExporter.getLiteralsFromLanguageFiles
+      val httpConnectionExporter    = new HttpConnectionMetadataExporter(cpg, ruleCache)
+      val egressesFromLanguageFiles = httpConnectionExporter.getEgressUrlsFromCodeFiles
       egressesFromLanguageFiles.size shouldBe 5
       egressesFromLanguageFiles shouldBe List(
         "api/v1/login",

--- a/src/test/scala/ai/privado/exporter/JavaScriptLanguageEgressTest.scala
+++ b/src/test/scala/ai/privado/exporter/JavaScriptLanguageEgressTest.scala
@@ -23,10 +23,11 @@
 
 package ai.privado.exporter
 
+import ai.privado.cache.AppCache
 import ai.privado.entrypoint.PrivadoInput
 import ai.privado.exporter.HttpConnectionMetadataExporter
 import ai.privado.languageEngine.javascript.JavascriptTaggingTestBase
-import ai.privado.model.ConfigAndRules
+import ai.privado.model.{ConfigAndRules, Language}
 import ai.privado.tagger.sink.RegularSinkTagger
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.matchers.should.Matchers
@@ -36,9 +37,6 @@ import scala.collection.mutable
 
 class JavaScriptLanguageEgressTest extends JavascriptTaggingTestBase {
 
-  override def beforeAll(): Unit = {
-    super.beforeAll()
-  }
   override val rule: ConfigAndRules            = ConfigAndRules()
   override val packageJsonFileContents: String = ""
 
@@ -54,8 +52,8 @@ class JavaScriptLanguageEgressTest extends JavascriptTaggingTestBase {
 
   "Javascript code egresses" should {
     "collect egress url for javascript code" in {
-      val propertyExporter          = new HttpConnectionMetadataExporter(cpg, ruleCache)
-      val egressesFromLanguageFiles = propertyExporter.getLiteralsFromLanguageFiles
+      val httpConnectionExporter    = new HttpConnectionMetadataExporter(cpg, ruleCache)
+      val egressesFromLanguageFiles = httpConnectionExporter.getEgressUrlsFromCodeFiles
       egressesFromLanguageFiles.size shouldBe 6
       egressesFromLanguageFiles shouldBe List(
         "v1/api/userid",

--- a/src/test/scala/ai/privado/exporter/PythonLanguageEgressTest.scala
+++ b/src/test/scala/ai/privado/exporter/PythonLanguageEgressTest.scala
@@ -23,12 +23,12 @@
 
 package ai.privado.exporter
 
-import ai.privado.cache.RuleCache
+import ai.privado.cache.{AppCache, RuleCache}
 import ai.privado.entrypoint.PrivadoInput
 import ai.privado.exporter.HttpConnectionMetadataExporter
 import ai.privado.languageEngine.javascript.JavascriptTaggingTestBase
 import ai.privado.languageEngine.python.{PrivadoPySrc2CpgFixture, PrivadoPySrcTestCpg}
-import ai.privado.model.ConfigAndRules
+import ai.privado.model.{ConfigAndRules, Language}
 import ai.privado.tagger.sink.RegularSinkTagger
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.matchers.should.Matchers
@@ -74,17 +74,22 @@ class PythonLanguageEgressTest extends PrivadoPySrc2CpgFixture {
       | API_5 =      "api/v2" + "/ce/customers"
       |""".stripMargin)
 
+  override def beforeAll(): Unit = {
+    AppCache.repoLanguage = Language.PYTHON
+    super.beforeAll()
+  }
+
   "Python code egresses" should {
     "collect egress url for python code" in {
-      val propertyExporter          = new HttpConnectionMetadataExporter(cpg, ruleCache)
-      val egressesFromLanguageFiles = propertyExporter.getLiteralsFromLanguageFiles
+      val httpConnectionExporter    = new HttpConnectionMetadataExporter(cpg, ruleCache)
+      val egressesFromLanguageFiles = httpConnectionExporter.getEgressUrlsFromCodeFiles
       egressesFromLanguageFiles.size shouldBe 6
       egressesFromLanguageFiles shouldBe List(
-        "/ce/something/customers/{customerId}/init",
-        "/ce/customers/{customerId}/repo/{repoId}/file",
-        "/ce/customers/{customerId}/scan/{repoId}",
+        "/ce/something/customers/customerId/init",
+        "/ce/customers/customerId/repo/repoId/file",
+        "/ce/customers/customerId/scan/repoId",
         "api/v1",
-        "/ce/customers/{customerId}/scan/{repoId}/data",
+        "/ce/customers/customerId/scan/repoId/data",
         "api/v2/ce/customers"
       )
 

--- a/src/test/scala/ai/privado/languageEngine/javascript/JavascriptTaggingTestBase.scala
+++ b/src/test/scala/ai/privado/languageEngine/javascript/JavascriptTaggingTestBase.scala
@@ -23,8 +23,8 @@
 
 package ai.privado.languageEngine.javascript
 
-import ai.privado.cache.RuleCache
-import ai.privado.model.ConfigAndRules
+import ai.privado.cache.{AppCache, RuleCache}
+import ai.privado.model.{ConfigAndRules, Language}
 import better.files.File
 import io.joern.jssrc2cpg.{Config, JsSrc2Cpg}
 import io.shiftleft.codepropertygraph.generated.Cpg
@@ -52,6 +52,7 @@ abstract class JavascriptTaggingTestBase extends AnyWordSpec with Matchers with 
     cpg = new JsSrc2Cpg().createCpg(config).get
 
     // Caching Rule
+    AppCache.repoLanguage = Language.JAVASCRIPT
     ruleCache.setRule(rule)
     super.beforeAll()
   }


### PR DESCRIPTION
### Egress From Code Changes
- We need to analysis Egress From Code so moving them in a separate key 
- `<operator>.formatString` itself has some call nodes in case of python so instead of doing for language specific, replacing `{}` with empty string 
- Test cases were failing because of known language so explicitly set `AppCache.repoLanguage` in test cases