### PR TITLE
[SQLParser] Fix SQL lineNumber when query is found in .sql file

### DIFF
--- a/src/main/scala/ai/privado/passes/SQLParser.scala
+++ b/src/main/scala/ai/privado/passes/SQLParser.scala
@@ -91,7 +91,8 @@ class SQLParser(cpg: Cpg, projectRoot: String, ruleCache: RuleCache) extends Pri
                   parsedQueryItem,
                   query,
                   queryLineNumber,
-                  queryOrder
+                  queryOrder,
+                  fileName = Option(sqlFileName)
                 )
               }
             case None =>

--- a/src/main/scala/ai/privado/utility/SQLParser.scala
+++ b/src/main/scala/ai/privado/utility/SQLParser.scala
@@ -155,7 +155,7 @@ object SQLParser {
   private def createSQLColumnItem(column: ASTNodeAccess, sqlTable: SQLTable) = {
     SQLColumn(
       column.toString,
-      Try(column.getASTNode.jjtGetFirstToken().beginLine).getOrElse(NUMBER_ONE) + sqlTable.lineNumber - 1,
+      Try(column.getASTNode.jjtGetFirstToken().beginLine).getOrElse(NUMBER_ONE),
       Try(column.getASTNode.jjtGetFirstToken().beginColumn).getOrElse(NUMBER_MINUSONE)
     )
   }
@@ -206,8 +206,10 @@ object SQLNodeBuilder {
     builder.addEdge(tableNode, fileNode, EdgeTypes.SOURCE_FILE)
 
     queryModel.column.zipWithIndex.foreach { case (queryColumn: SQLColumn, columnIndex) =>
+      /* As queries from .sql files are processed individually,
+        an offset equal to the lineNumber of the query in the original file - 1 is added to the isolated column lineNumber */
       val lineNumber = fileName match
-        case Some(f) if f.endsWith(".sql") => queryColumn.lineNumber + tableNode.lineNumber.get - 1
+        case Some(f) if f.endsWith(".sql") => queryColumn.lineNumber + queryLineNumber - 1
         case _                             => queryColumn.lineNumber
 
       val columnNode = NewSqlColumnNode()

--- a/src/test/scala/ai/privado/passes/SQLParserTest.scala
+++ b/src/test/scala/ai/privado/passes/SQLParserTest.scala
@@ -108,6 +108,13 @@ class SQLParserTest extends AnyWordSpec with Matchers with BeforeAndAfterAll {
       id1.name shouldBe "id"
       candidate1.name shouldBe "candidate"
     }
+
+    "have correct attributes for members" in {
+      val List(id, created_at, candidate) = cpg.sqlQuery.sqlTable.lineNumber(2).sqlColumn.l
+      id.lineNumber shouldBe Some(3)
+      created_at.lineNumber shouldBe Some(4)
+      candidate.lineNumber shouldBe Some(5)
+    }
   }
 
   def code(code: String): Cpg = {


### PR DESCRIPTION
This PR includes a fix to display correct `lineNumber` of columns in a SQL query. This only includes queries from `.sql` files, as those queries are parsed individually.