### PR TITLE
add support to tag api by matching url like parameter

### DIFF
--- a/src/main/scala/ai/privado/entrypoint/CommandParser.scala
+++ b/src/main/scala/ai/privado/entrypoint/CommandParser.scala
@@ -43,6 +43,7 @@ case class PrivadoInput(
   disableReadDataflow: Boolean = false,
   enableAPIDisplay: Boolean = false,
   enableLambdaFlows: Boolean = false,
+  enableAPIByParameter: Boolean = false,
   ignoreExcludeRules: Boolean = false,
   ignoreSinkSkipRules: Boolean = false,
   skipUpload: Boolean = false,
@@ -85,6 +86,8 @@ object CommandConstants {
   val ENABLE_API_DISPLAY_ABBR                      = "ead"
   val ENABLE_LAMBDA_FLOWS                          = "enable-lambda-flows"
   val ENABLE_LAMBDA_FLOWS_ABBR                     = "elf"
+  val ENABLE_API_BY_PARAMETER                      = "enable-api-by-parameter"
+  val ENABLE_API_BY_PARAMETER_ABBR                 = "eabyp"
   val IGNORE_EXCLUDE_RULES                         = "ignore-exclude-rules"
   val IGNORE_EXCLUDE_RULES_ABBR                    = "ier"
   val UPLOAD                                       = "upload"
@@ -211,6 +214,11 @@ object CommandParser {
               .optional()
               .action((_, c) => c.copy(enableLambdaFlows = true))
               .text("Enable lambda flows"),
+            opt[Unit](CommandConstants.ENABLE_API_BY_PARAMETER)
+              .abbr(CommandConstants.ENABLE_API_BY_PARAMETER_ABBR)
+              .optional()
+              .action((_, c) => c.copy(enableAPIByParameter = true))
+              .text("Enable API tagging by parameter name match"),
             opt[Unit](CommandConstants.IGNORE_EXCLUDE_RULES)
               .abbr(CommandConstants.IGNORE_EXCLUDE_RULES_ABBR)
               .optional()

--- a/src/main/scala/ai/privado/languageEngine/java/tagger/PrivadoTagger.scala
+++ b/src/main/scala/ai/privado/languageEngine/java/tagger/PrivadoTagger.scala
@@ -40,6 +40,7 @@ import ai.privado.languageEngine.java.tagger.collection.{
   SOAPCollectionTagger
 }
 import ai.privado.languageEngine.java.tagger.config.JavaDBConfigTagger
+import ai.privado.languageEngine.java.tagger.sink.api.JavaAPISinkTagger
 import ai.privado.languageEngine.java.tagger.sink.{InheritMethodTagger, JavaAPITagger, MessagingConsumerCustomTagger}
 import ai.privado.languageEngine.java.tagger.source.{IdentifierTagger, InSensitiveCallTagger}
 import ai.privado.tagger.PrivadoBaseTagger
@@ -81,6 +82,8 @@ class PrivadoTagger(cpg: Cpg) extends PrivadoBaseTagger {
     new RegularSinkTagger(cpg, ruleCache).createAndApply()
 
     new JavaS3Tagger(cpg, s3DatabaseDetailsCache).createAndApply()
+
+    JavaAPISinkTagger.applyTagger(cpg, ruleCache, privadoInputConfig)
 
     new JavaAPITagger(cpg, ruleCache, privadoInputConfig).createAndApply()
     // Custom Rule tagging

--- a/src/main/scala/ai/privado/languageEngine/java/tagger/sink/JavaAPITagger.scala
+++ b/src/main/scala/ai/privado/languageEngine/java/tagger/sink/JavaAPITagger.scala
@@ -28,7 +28,7 @@ import ai.privado.languageEngine.java.language.*
 import ai.privado.languageEngine.java.semantic.JavaSemanticGenerator
 import ai.privado.languageEngine.java.tagger.Utility.{GRPCTaggerUtility, SOAPTaggerUtility}
 import ai.privado.metric.MetricHandler
-import ai.privado.model.{Constants, Language, NodeType, RuleInfo}
+import ai.privado.model.{Constants, InternalTag, Language, NodeType, RuleInfo}
 import ai.privado.tagger.PrivadoParallelCpgPass
 import ai.privado.tagger.utility.APITaggerUtility.{SERVICE_URL_REGEX_PATTERN, sinkTagger}
 import ai.privado.utility.{ImportUtility, Utilities}
@@ -135,6 +135,8 @@ class JavaAPITagger(cpg: Cpg, ruleCache: RuleCache, privadoInputConfig: PrivadoI
         List()
     }
 
+    val markedAPISinks = cpg.call.where(_.tag.nameExact(InternalTag.API_SINK_MARKED.toString)).l
+
     apiTaggerToUse match {
       case APITaggerVersionJava.V1Tagger =>
         logger.debug("Using brute API Tagger to find API sinks")
@@ -150,7 +152,7 @@ class JavaAPITagger(cpg: Cpg, ruleCache: RuleCache, privadoInputConfig: PrivadoI
         )
         sinkTagger(
           apiInternalSources ++ propertySources ++ identifierSource ++ serviceSource,
-          feignAPISinks ++ grpcSinks ++ soapSinks,
+          feignAPISinks ++ grpcSinks ++ soapSinks ++ markedAPISinks,
           builder,
           ruleInfo,
           ruleCache,
@@ -161,7 +163,7 @@ class JavaAPITagger(cpg: Cpg, ruleCache: RuleCache, privadoInputConfig: PrivadoI
         println(s"${Calendar.getInstance().getTime} - --API TAGGER V2 invoked...")
         sinkTagger(
           apiInternalSources ++ propertySources ++ identifierSource ++ serviceSource,
-          apis.methodFullName(commonHttpPackages).l ++ feignAPISinks ++ grpcSinks ++ soapSinks,
+          apis.methodFullName(commonHttpPackages).l ++ feignAPISinks ++ grpcSinks ++ soapSinks ++ markedAPISinks,
           builder,
           ruleInfo,
           ruleCache,
@@ -172,7 +174,7 @@ class JavaAPITagger(cpg: Cpg, ruleCache: RuleCache, privadoInputConfig: PrivadoI
         println(s"${Calendar.getInstance().getTime} - --API TAGGER SKIPPED, applying Feign client API...")
         sinkTagger(
           apiInternalSources ++ propertySources ++ identifierSource ++ serviceSource,
-          feignAPISinks ++ grpcSinks ++ soapSinks,
+          feignAPISinks ++ grpcSinks ++ soapSinks ++ markedAPISinks,
           builder,
           ruleInfo,
           ruleCache,

--- a/src/main/scala/ai/privado/languageEngine/java/tagger/sink/api/JavaAPISinkByMethodFullNameTagger.scala
+++ b/src/main/scala/ai/privado/languageEngine/java/tagger/sink/api/JavaAPISinkByMethodFullNameTagger.scala
@@ -1,0 +1,28 @@
+package ai.privado.languageEngine.java.tagger.sink.api
+
+import ai.privado.cache.RuleCache
+import ai.privado.model.{Constants, InternalTag}
+import ai.privado.tagger.{PrivadoParallelCpgPass, PrivadoSimpleCpgPass}
+import io.shiftleft.codepropertygraph.generated.{Cpg, Operators}
+import io.shiftleft.codepropertygraph.generated.nodes.Call
+import io.shiftleft.semanticcpg.language.*
+import ai.privado.utility.Utilities.{addRuleTags, storeForTag}
+
+import scala.jdk.CollectionConverters.CollectionHasAsScala
+import scala.language.postfixOps
+
+class JavaAPISinkByMethodFullNameTagger(cpg: Cpg, ruleCache: RuleCache) extends PrivadoSimpleCpgPass(cpg) {
+
+  private val apiMethodFullNameRegex = ruleCache.getSystemConfigByKey(Constants.apiMethodFullNames)
+
+  val cacheCall: List[Call] = cpg.call.or(_.nameNot(Operators.ALL.asScala.toSeq.appended("init"): _*)).l
+  override def run(builder: DiffGraphBuilder): Unit = {
+    if (apiMethodFullNameRegex.nonEmpty) {
+      val sinkCalls = cacheCall.methodFullName(apiMethodFullNameRegex).toArray
+
+      // Mark the nodes as API sink
+      sinkCalls.foreach(storeForTag(builder, _, ruleCache)(InternalTag.API_SINK_MARKED.toString))
+    }
+  }
+
+}

--- a/src/main/scala/ai/privado/languageEngine/java/tagger/sink/api/JavaAPISinkByParameterTagger.scala
+++ b/src/main/scala/ai/privado/languageEngine/java/tagger/sink/api/JavaAPISinkByParameterTagger.scala
@@ -1,0 +1,64 @@
+package ai.privado.languageEngine.java.tagger.sink.api
+
+import ai.privado.cache.RuleCache
+import ai.privado.model.{InternalTag, RuleInfo}
+import ai.privado.tagger.PrivadoParallelCpgPass
+import io.shiftleft.codepropertygraph.generated.{Cpg, Operators}
+import io.shiftleft.semanticcpg.language.*
+
+import scala.jdk.CollectionConverters.CollectionHasAsScala
+import ai.privado.utility.Utilities.storeForTag
+
+class JavaAPISinkByParameterTagger(cpg: Cpg, ruleCache: RuleCache) extends PrivadoParallelCpgPass[String](cpg) {
+  override def generateParts(): Array[String] = {
+
+    /* Below query looks for methods whose parameter names ends with `url|endpoint`,
+    for such method, get the typeFullName of the returned object by this method
+     */
+
+    val typeFullNameByUrlLikeMatch = cpg.method
+      .where(_.parameter.filter(_.index != 0).name("(?i).*(url|endpoint)"))
+      .signature
+      .map(_.split("\\(").headOption.getOrElse(""))
+      .filter(_.nonEmpty)
+      .l
+
+    /* Below query looks for methods whose parameter names ends with `config`, and is part of a constructor
+        for such method, get the typeFullName of the object for which this constructor is added
+     */
+    val typeFullNameByConfigLikeMatch = cpg.method
+      .where(_.parameter.filter(_.index != 0).name("(?i).*(config)"))
+      .where(_.name("<init>"))
+      .fullName
+      .map(_.split("[.]<init").headOption.getOrElse(""))
+      .filter(_.nonEmpty)
+      .l
+
+    (typeFullNameByUrlLikeMatch ++ typeFullNameByConfigLikeMatch).dedup.toArray
+  }
+
+  override def runOnPart(builder: DiffGraphBuilder, typeFullName: String): Unit = {
+
+    cpg.member.typeFullName(typeFullName).foreach { m =>
+      val memberName = m.name
+      val fileName   = m.file.name.headOption.getOrElse("")
+
+      /* Below query looks for fieldIdentifier in the given file and return calls which are made on top of this fieldIdentifier
+       The 1st callIn returns the field Access node and the 2nd returns the actual call
+       */
+
+      val sinkCalls = cpg.fieldAccess.fieldIdentifier
+        .canonicalName(memberName)
+        .where(_.file.nameExact(fileName))
+        .l
+        .inCall
+        .inCall
+        .where(_.nameNot(Operators.ALL.asScala.toSeq.appended("<init>"): _*))
+        .l
+
+      // Mark the nodes as API sink
+      sinkCalls.foreach(storeForTag(builder, _, ruleCache)(InternalTag.API_SINK_MARKED.toString))
+
+    }
+  }
+}

--- a/src/main/scala/ai/privado/languageEngine/java/tagger/sink/api/JavaAPISinkTagger.scala
+++ b/src/main/scala/ai/privado/languageEngine/java/tagger/sink/api/JavaAPISinkTagger.scala
@@ -1,0 +1,20 @@
+package ai.privado.languageEngine.java.tagger.sink.api
+
+import ai.privado.cache.RuleCache
+import ai.privado.entrypoint.PrivadoInput
+import ai.privado.tagger.sink.api.APISinkTagger
+import io.shiftleft.codepropertygraph.generated.Cpg
+
+object JavaAPISinkTagger extends APISinkTagger {
+
+  /** Wrapper method to tag all the api taggers
+    * @param cpg
+    * @param ruleCache
+    */
+  override def applyTagger(cpg: Cpg, ruleCache: RuleCache, privadoInput: PrivadoInput): Unit = {
+
+    if (privadoInput.enableAPIByParameter)
+      new JavaAPISinkByParameterTagger(cpg, ruleCache).createAndApply()
+  }
+
+}

--- a/src/main/scala/ai/privado/languageEngine/java/tagger/sink/api/JavaAPISinkTagger.scala
+++ b/src/main/scala/ai/privado/languageEngine/java/tagger/sink/api/JavaAPISinkTagger.scala
@@ -15,6 +15,8 @@ object JavaAPISinkTagger extends APISinkTagger {
 
     if (privadoInput.enableAPIByParameter)
       new JavaAPISinkByParameterTagger(cpg, ruleCache).createAndApply()
+
+    new JavaAPISinkByMethodFullNameTagger(cpg, ruleCache).createAndApply()
   }
 
 }

--- a/src/main/scala/ai/privado/model/Constants.scala
+++ b/src/main/scala/ai/privado/model/Constants.scala
@@ -157,6 +157,7 @@ object Constants {
   val cookieSourceRuleId           = "Data.Sensitive.OnlineIdentifiers.Cookies"
   val ignoredSinks                 = "ignoredSinks"
   val apiSinks                     = "apiSinks"
+  val apiMethodFullNames           = "apiMethodFullNames"
   val apiHttpLibraries             = "apiHttpLibraries"
   val apiIdentifier                = "apiIdentifier"
   val apiGraphqlLibraries          = "apiGraphqlLibraries"

--- a/src/main/scala/ai/privado/model/PrivadoTag.scala
+++ b/src/main/scala/ai/privado/model/PrivadoTag.scala
@@ -45,6 +45,9 @@ object InternalTag extends Enumeration {
   val PROBABLE_ASSET                           = Value("PROBABLE_ASSET")
   val SOURCE_PROPERTY                          = Value("SOURCE_PROPERTY")
 
+  // API Tags
+  val API_SINK_MARKED = Value("API_SINK_MARKED")
+
   lazy val valuesAsString = InternalTag.values.map(value => value.toString())
 
 }

--- a/src/main/scala/ai/privado/tagger/sink/api/APISinkTagger.scala
+++ b/src/main/scala/ai/privado/tagger/sink/api/APISinkTagger.scala
@@ -1,0 +1,11 @@
+package ai.privado.tagger.sink.api
+
+import ai.privado.cache.RuleCache
+import ai.privado.entrypoint.PrivadoInput
+import io.shiftleft.codepropertygraph.generated.Cpg
+
+trait APISinkTagger {
+
+  def applyTagger(cpg: Cpg, ruleCache: RuleCache, privadoInput: PrivadoInput): Unit = ???
+
+}

--- a/src/test/scala/ai/privado/RuleInfoTestData.scala
+++ b/src/test/scala/ai/privado/RuleInfoTestData.scala
@@ -1,6 +1,6 @@
 package ai.privado
 
-import ai.privado.model.{CatLevelOne, ConfigAndRules, FilterProperty, Language, NodeType, RuleInfo}
+import ai.privado.model.{CatLevelOne, ConfigAndRules, Constants, FilterProperty, Language, NodeType, RuleInfo}
 
 object RuleInfoTestData {
 
@@ -126,6 +126,39 @@ object RuleInfoTestData {
     )
   )
 
+  val apiLiteralRule = List(
+    RuleInfo(
+      Constants.thirdPartiesAPIRuleId,
+      "Third Party API",
+      "",
+      FilterProperty.METHOD_FULL_NAME,
+      Array(),
+      List(
+        "((?i)((?:http:|https:|ftp:|ssh:|udp:|wss:){0,1}(\\/){0,2}[a-zA-Z0-9_-][^)\\/(#|,!>\\s]{1,50}\\.(?:com|net|org|de|in|uk|us|io|gov|cn|ml|ai|ly|dev|cloud|me|icu|ru|info|top|tk|tr|cn|ga|cf|nl)).*(?<!png|jpeg|jpg|txt|blob|css|html|js|svg))"
+      ),
+      false,
+      "",
+      Map(),
+      NodeType.API,
+      "",
+      CatLevelOne.SINKS,
+      catLevelTwo = Constants.third_parties,
+      Language.UNKNOWN,
+      Array()
+    )
+  )
+
   val rule: ConfigAndRules =
-    ConfigAndRules(sourceRule, List(), List(), List(), List(), List(), List(), List(), List(), List())
+    ConfigAndRules(
+      sources = sourceRule,
+      sinks = apiLiteralRule,
+      List(),
+      List(),
+      List(),
+      List(),
+      List(),
+      List(),
+      List(),
+      List()
+    )
 }

--- a/src/test/scala/ai/privado/languageEngine/java/JavaTestBase.scala
+++ b/src/test/scala/ai/privado/languageEngine/java/JavaTestBase.scala
@@ -1,0 +1,36 @@
+package ai.privado.languageEngine.java
+
+import ai.privado.languageEngine.ruby.RubyTestBase.code
+import ai.privado.model.SourceCodeModel
+import better.files.File
+import io.joern.dataflowengineoss.layers.dataflows.{OssDataFlow, OssDataFlowOptions}
+import io.joern.javasrc2cpg.{Config, JavaSrc2Cpg}
+import io.joern.x2cpg.X2Cpg.applyDefaultOverlays
+import io.shiftleft.codepropertygraph.generated.Cpg
+import io.shiftleft.semanticcpg.layers.LayerCreatorContext
+
+object JavaTestBase {
+  def code(sourceCodes: List[SourceCodeModel], applyPostProcessingPass: Boolean = false): (Cpg, Config) = {
+
+    val (cpg, config) = code(sourceCodes)
+
+    val context = new LayerCreatorContext(cpg)
+    val options = new OssDataFlowOptions()
+    new OssDataFlow(options).run(context)
+
+    (cpg, config)
+  }
+
+  private def code(sourceCodes: List[SourceCodeModel]): (Cpg, Config) = {
+    val inputDir = File.newTemporaryDirectory()
+    for (sourceCode <- sourceCodes) {
+      (inputDir / sourceCode.fileName).write(sourceCode.sourceCode)
+    }
+    val outputFile = File.newTemporaryFile()
+
+    val config = Config().withInputPath(inputDir.pathAsString).withOutputPath(outputFile.pathAsString)
+    val cpg    = new JavaSrc2Cpg().createCpg(config).get
+    applyDefaultOverlays(cpg)
+    (cpg, config)
+  }
+}

--- a/src/test/scala/ai/privado/languageEngine/java/tagger/sink/api/JavaAPISinkByMethodFullNameTaggerTest.scala
+++ b/src/test/scala/ai/privado/languageEngine/java/tagger/sink/api/JavaAPISinkByMethodFullNameTaggerTest.scala
@@ -1,0 +1,74 @@
+package ai.privado.languageEngine.java.tagger.sink.api
+
+import ai.privado.RuleInfoTestData
+import ai.privado.cache.RuleCache
+import ai.privado.entrypoint.PrivadoInput
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import ai.privado.languageEngine.java.JavaTestBase.*
+import ai.privado.model.{ConfigAndRules, Constants, InternalTag, Language, SourceCodeModel, SystemConfig}
+import io.shiftleft.semanticcpg.language.*
+
+class JavaAPISinkByMethodFullNameTaggerTest extends AnyWordSpec with Matchers with BeforeAndAfterAll {
+
+  "call which match api methodFullName regex" should {
+    "match" in {
+
+      val (cpg, config) = code(
+        List(
+          SourceCodeModel(
+            """
+          |
+          |import java.io.BufferedReader;
+          |import java.io.IOException;
+          |import java.io.InputStreamReader;
+          |import java.net.HttpURLConnection;
+          |import java.net.URL;
+          |
+          |public class HttpRequestExample {
+          |    public static void main(String[] args) {
+          |        try {
+          |            // Specify the URL to send the request to
+          |            URL url = new URL("https://jsonplaceholder.typicode.com/posts/1");
+          |
+          |            // Open a connection to the URL
+          |            HttpURLConnection connection = (HttpURLConnection) url.openConnection();
+          |
+          |            // Set request method to GET
+          |            connection.setRequestMethod("GET");
+          |
+          |            // Get the response code
+          |            int responseCode = connection.getResponseCode();
+          |            }
+          |      }
+          |}
+          |""".stripMargin,
+            "HttpRequestExample.java"
+          )
+        )
+      )
+
+      val ruleCache = RuleCache()
+      ruleCache.setRule(
+        ConfigAndRules(systemConfig =
+          List(
+            SystemConfig(
+              Constants.apiMethodFullNames,
+              "java.net.HttpURLConnection.*",
+              Language.UNKNOWN,
+              "",
+              Array[String]()
+            )
+          )
+        )
+      )
+      JavaAPISinkTagger.applyTagger(cpg, ruleCache = ruleCache, privadoInput = PrivadoInput())
+
+      val apiSinks = cpg.call("getResponseCode").l
+
+      apiSinks.tag.nameExact(InternalTag.API_SINK_MARKED.toString).size shouldBe 1
+    }
+  }
+
+}

--- a/src/test/scala/ai/privado/languageEngine/java/tagger/sink/api/JavaAPISinkByParameterTaggerTest.scala
+++ b/src/test/scala/ai/privado/languageEngine/java/tagger/sink/api/JavaAPISinkByParameterTaggerTest.scala
@@ -78,7 +78,7 @@ class JavaAPISinkByParameterTaggerTest extends AnyWordSpec with Matchers with Be
       val privadoInput = PrivadoInput(enableAPIByParameter = true)
       val ruleCache    = RuleCache()
       ruleCache.setRule(RuleInfoTestData.rule.copy())
-      JavaAPISinkTagger.applyTagger(cpg, ruleCache = RuleCache(), privadoInput = privadoInput)
+      JavaAPISinkTagger.applyTagger(cpg, ruleCache = ruleCache, privadoInput = privadoInput)
 
       new JavaAPITagger(cpg, ruleCache, privadoInputConfig = privadoInput).createAndApply()
 

--- a/src/test/scala/ai/privado/languageEngine/java/tagger/sink/api/JavaAPISinkByParameterTaggerTest.scala
+++ b/src/test/scala/ai/privado/languageEngine/java/tagger/sink/api/JavaAPISinkByParameterTaggerTest.scala
@@ -1,0 +1,97 @@
+package ai.privado.languageEngine.java.tagger.sink.api
+
+import ai.privado.RuleInfoTestData
+import ai.privado.cache.RuleCache
+import ai.privado.entrypoint.PrivadoInput
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import ai.privado.languageEngine.java.JavaTestBase.*
+import ai.privado.languageEngine.java.tagger.sink.JavaAPITagger
+import ai.privado.model.{CatLevelOne, Constants, InternalTag, NodeType, SourceCodeModel}
+import io.shiftleft.semanticcpg.language.*
+
+class JavaAPISinkByParameterTaggerTest extends AnyWordSpec with Matchers with BeforeAndAfterAll {
+
+  "Api by matching a variable like parameter" should {
+    "be tagged as a API sink" in {
+
+      val (cpg, config) = code(
+        List(
+          SourceCodeModel(
+            """
+          |import java.util.List;
+          |import ai.privado.client.Client;
+          |
+          |public class EndpointClient {
+          |
+          |    private String config;
+          |
+          |    public EndpointClient(String config) {
+          |         this.config = config;
+          |    }
+          |
+          |
+          |    public Client getClient(String endpoint) {
+          |        // Logic to create and return a client based on the endpoint
+          |        return new Client(endpoint);
+          |    }
+          |}
+          |
+          |""".stripMargin,
+            "EndpointClient.java"
+          ),
+          SourceCodeModel(
+            """
+          |import java.util.List;
+          |import ai.privado.client.Client;
+          |
+          |public class Main {
+          |    private Client client;
+          |
+          |    private EndpointClient endpointClient;
+          |
+          |    public Main(String endpoint, String config) {
+          |        this.client = new Client(endpoint);
+          |        this.endpointClient = new EndpointClient(config);
+          |    }
+          |
+          |    public List<String> getAllDetails() {
+          |        String url = "https://www.myproduction.com/user";
+          |
+          |        return client.getAllDetails(url); // This should be marked as API Sink by url like matching
+          |    }
+          |
+          |    public List<String> getDetailsByEndpoint() {
+          |         String url = "https://www.myproduction.com/user/endpoint";
+          |
+          |         return endpointClient.getDetailsByEndpoint(url); // This should be marked as API Sink by config like matching
+          |
+          |    }
+          |}
+          |""".stripMargin,
+            "Main.java"
+          )
+        )
+      )
+
+      val privadoInput = PrivadoInput(enableAPIByParameter = true)
+      val ruleCache    = RuleCache()
+      ruleCache.setRule(RuleInfoTestData.rule.copy())
+      JavaAPISinkTagger.applyTagger(cpg, ruleCache = RuleCache(), privadoInput = privadoInput)
+
+      new JavaAPITagger(cpg, ruleCache, privadoInputConfig = privadoInput).createAndApply()
+
+      val apiSink = cpg.call("getAllDetails").l
+      apiSink.tag.nameExact(InternalTag.API_SINK_MARKED.toString).size shouldBe 1
+      apiSink.tag.nameExact(Constants.catLevelOne).value.headOption shouldBe Some(CatLevelOne.SINKS.name)
+      apiSink.tag.nameExact(Constants.nodeType).value.headOption shouldBe Some(NodeType.API.toString)
+
+      val apiSinkByEndpoint = cpg.call("getDetailsByEndpoint").l
+      apiSinkByEndpoint.tag.nameExact(InternalTag.API_SINK_MARKED.toString).size shouldBe 1
+      apiSinkByEndpoint.tag.nameExact(Constants.catLevelOne).value.headOption shouldBe Some(CatLevelOne.SINKS.name)
+      apiSinkByEndpoint.tag.nameExact(Constants.nodeType).value.headOption shouldBe Some(NodeType.API.toString)
+    }
+  }
+
+}

--- a/src/test/scala/ai/privado/model/SourceCodeModel.scala
+++ b/src/test/scala/ai/privado/model/SourceCodeModel.scala
@@ -1,3 +1,2 @@
 package ai.privado.model
-
 case class SourceCodeModel(sourceCode: String, fileName: String)


### PR DESCRIPTION
This PR contains
- Support for tagging API by methodFullName by specifying the regex in `privado->config->systemConfig->file.yaml` under the key `apiMethodFullNames`
- Support for tagging API by deriving API client by looking at the parameter names, this has been kept under the flag `enable-api-by-parameter` for now

This PR also proposes to refactor the current API tagger implementation such as tagging API sinks as `API_SINK_MARKED`, based on respective detection logic.
All these tagged API's can be collected in the APITagger and dataflow from literal to them can be computed and tagged appropriately
