### PR TITLE
fix: incorrect PHP parser vendoring

### DIFF
--- a/src/main/scala/ai/privado/languageEngine/php/processor/PhpProcessor.scala
+++ b/src/main/scala/ai/privado/languageEngine/php/processor/PhpProcessor.scala
@@ -110,6 +110,13 @@ object PhpProcessor {
       }
     }
 
-    Paths.get(fixedDir, "/bin/php-parser/php-parser.php").toAbsolutePath.toString
+    val parserPath = Environment.isProduction match {
+      case Some(_) => Paths.get("/home", "privado-core-build", "php-parser", "php-parser.php")
+      case None    => Paths.get(fixedDir, "bin", "php-parser", "php-parser.php")
+    }
+
+    println(s"${TimeMetric.getNewTime()} - Using PHP logger from $parserPath")
+    parserPath.toAbsolutePath.toString
+
   }
 }


### PR DESCRIPTION
Vendored utilities are copied to a different path as part of Docker's build steps (ref. to the last couple of `COPY` commands in `Dockerfile`). Because this was not accounted for in the previous integration PR, there was an issue running a scan on PHP repositories. This PR fixes it.