### PR TITLE
add - test cpg base for languages

### DIFF
--- a/src/test/scala/ai/privado/languageEngine/csharp/CSharpTestCpgBase.scala
+++ b/src/test/scala/ai/privado/languageEngine/csharp/CSharpTestCpgBase.scala
@@ -1,0 +1,29 @@
+package ai.privado.languageEngine.csharp
+
+import ai.privado.TestCpgBase
+import ai.privado.cache.RuleCache
+import ai.privado.entrypoint.PrivadoInput
+import ai.privado.languageEngine.base.processor.BaseProcessor
+import ai.privado.languageEngine.csharp.processor.CSharpProcessor
+import ai.privado.model.Language
+import ai.privado.rule.RuleInfoTestData
+
+abstract class CSharpTestCpgBase(
+  withRuleCache: RuleCache = RuleInfoTestData.ruleCache,
+  withPrivadoInput: PrivadoInput = PrivadoInput()
+) extends TestCpgBase(withPrivadoInput) {
+  override def getProcessor(sourceCodeLocation: String): BaseProcessor = {
+    appCache.init(sourceCodeLocation)
+    appCache.repoLanguage = Language.CSHARP
+    new CSharpProcessor(
+      withRuleCache,
+      withPrivadoInput.copy(sourceLocation = Set(sourceCodeLocation)),
+      sourceCodeLocation,
+      dataFlowCache,
+      auditCache,
+      s3DatabaseDetailsCache,
+      appCache,
+      returnClosedCpg = false
+    )
+  }
+}

--- a/src/test/scala/ai/privado/languageEngine/kotlin/KotlinTestCpgBase.scala
+++ b/src/test/scala/ai/privado/languageEngine/kotlin/KotlinTestCpgBase.scala
@@ -1,0 +1,31 @@
+package ai.privado.languageEngine.kotlin
+
+import ai.privado.TestCpgBase
+import ai.privado.cache.{PropertyFilterCache, RuleCache}
+import ai.privado.entrypoint.PrivadoInput
+import ai.privado.languageEngine.base.processor.BaseProcessor
+import ai.privado.languageEngine.kotlin.processor.KotlinProcessor
+import ai.privado.model.Language
+import ai.privado.rule.RuleInfoTestData
+
+abstract class KotlinTestCpgBase(
+  withRuleCache: RuleCache = RuleInfoTestData.ruleCache,
+  withPrivadoInput: PrivadoInput = PrivadoInput()
+) extends TestCpgBase(withPrivadoInput) {
+  override def getProcessor(sourceCodeLocation: String): BaseProcessor = {
+    appCache.init(sourceCodeLocation)
+    appCache.repoLanguage = Language.KOTLIN
+    new KotlinProcessor(
+      withRuleCache,
+      withPrivadoInput.copy(sourceLocation = Set(sourceCodeLocation)),
+      sourceCodeLocation,
+      dataFlowCache,
+      auditCache,
+      s3DatabaseDetailsCache,
+      appCache,
+      returnClosedCpg = false,
+      new PropertyFilterCache()
+    )
+  }
+
+}

--- a/src/test/scala/ai/privado/languageEngine/php/PhpTestCpgBase.scala
+++ b/src/test/scala/ai/privado/languageEngine/php/PhpTestCpgBase.scala
@@ -1,0 +1,31 @@
+package ai.privado.languageEngine.php
+
+import ai.privado.TestCpgBase
+import ai.privado.cache.{PropertyFilterCache, RuleCache}
+import ai.privado.entrypoint.PrivadoInput
+import ai.privado.languageEngine.base.processor.BaseProcessor
+import ai.privado.languageEngine.php.processor.PhpProcessor
+import ai.privado.model.Language
+import ai.privado.rule.RuleInfoTestData
+
+abstract class PhpTestCpgBase(
+  withRuleCache: RuleCache = RuleInfoTestData.ruleCache,
+  withPrivadoInput: PrivadoInput = PrivadoInput()
+) extends TestCpgBase(withPrivadoInput) {
+  override def getProcessor(sourceCodeLocation: String): BaseProcessor = {
+    appCache.init(sourceCodeLocation)
+    appCache.repoLanguage = Language.PHP
+    new PhpProcessor(
+      withRuleCache,
+      withPrivadoInput.copy(sourceLocation = Set(sourceCodeLocation)),
+      sourceCodeLocation,
+      dataFlowCache,
+      auditCache,
+      s3DatabaseDetailsCache,
+      appCache,
+      returnClosedCpg = false,
+      new PropertyFilterCache()
+    )
+  }
+
+}


### PR DESCRIPTION
Created abstract Language specific TestBaseCpg for Php, CSharp, Kotlin.

Ruby, Python, Javascript, GoLang are currently out of scope as they don't extend the BaseProcessor, there are tech debts for now, which needs to be picked in future PR's