### PR TITLE
updated htmlunit version (#1057)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -60,7 +60,7 @@ libraryDependencies ++= Seq(
   "org.apache.poi"                   % "poi-ooxml"                  % "5.2.2",
   "com.github.jsqlparser"            % "jsqlparser"                 % "4.6",
   "org.apache.maven"                 % "maven-model"                % "3.9.0",
-  "net.sourceforge.htmlunit"         % "htmlunit"                   % "2.70.0",
+  "org.htmlunit"                     % "htmlunit"                   % "4.0.0",
   "org.yaml"                         % "snakeyaml"                  % "1.33",
   "org.scala-lang"                   % "scala-reflect"              % "2.13.8",
   "org.scala-lang"                   % "scala-compiler"             % "2.13.8",

--- a/src/main/scala/ai/privado/passes/HTMLParserPass.scala
+++ b/src/main/scala/ai/privado/passes/HTMLParserPass.scala
@@ -28,9 +28,9 @@ import ai.privado.entrypoint.PrivadoInput
 import ai.privado.model.Constants
 import ai.privado.tagger.PrivadoParallelCpgPass
 import ai.privado.utility.Utilities
-import com.gargoylesoftware.htmlunit.html.*
-import com.gargoylesoftware.htmlunit.html.HtmlScript
-import com.gargoylesoftware.htmlunit.{BrowserVersion, WebClient}
+import org.htmlunit.html.*
+import org.htmlunit.html.HtmlScript
+import org.htmlunit.{BrowserVersion, WebClient}
 import io.shiftleft.codepropertygraph.generated.Cpg
 import io.shiftleft.codepropertygraph.generated.nodes.{NewFile, NewTemplateDom}
 import org.slf4j.LoggerFactory


### PR DESCRIPTION
Resolved very critical vulnerability in net.sourceforge.htmlunit by replacing it with org.htmlunit
<img width="961" alt="Screenshot 2024-04-04 at 1 39 28 PM" src="https://github.com/Privado-Inc/privado-core/assets/32206192/92d027db-4519-4b5d-bbc8-d32d9129b13e">

