### PR TITLE
CSharp: Basic API tagger

### DIFF
--- a/src/main/scala/ai/privado/languageEngine/csharp/processor/CSharpProcessor.scala
+++ b/src/main/scala/ai/privado/languageEngine/csharp/processor/CSharpProcessor.scala
@@ -117,7 +117,7 @@ class CSharpProcessor(
       .withInputPath(sourceRepoLocation)
       .withOutputPath(cpgOutputPath)
       .withIgnoredFilesRegex(excludeFileRegex)
-      .withDownloadDependencies(!config.skipDownloadDependencies)
+      .withDownloadDependencies(Try(!config.skipDownloadDependencies).getOrElse(false))
 
     val xtocpg = new CSharpSrc2Cpg().createCpg(cpgconfig).map { cpg =>
       println(

--- a/src/main/scala/ai/privado/languageEngine/csharp/tagger/PrivadoTagger.scala
+++ b/src/main/scala/ai/privado/languageEngine/csharp/tagger/PrivadoTagger.scala
@@ -26,6 +26,7 @@ package ai.privado.languageEngine.csharp.tagger
 import ai.privado.cache.{AppCache, DataFlowCache, RuleCache, TaggerCache}
 import ai.privado.entrypoint.PrivadoInput
 import ai.privado.languageEngine.csharp.tagger.collection.CollectionTagger
+import ai.privado.languageEngine.csharp.tagger.sink.{CSharpAPISinkTagger, CSharpAPITagger}
 import ai.privado.languageEngine.csharp.tagger.source.IdentifierTagger
 import ai.privado.tagger.PrivadoBaseTagger
 import ai.privado.tagger.sink.RegularSinkTagger
@@ -51,6 +52,9 @@ class PrivadoTagger(cpg: Cpg) extends PrivadoBaseTagger {
     new LiteralTagger(cpg, rules).createAndApply()
     new IdentifierTagger(cpg, rules, taggerCache).createAndApply()
     new SqlQueryTagger(cpg, rules).createAndApply()
+
+    CSharpAPISinkTagger.applyTagger(cpg, rules, privadoInputConfig, appCache)
+
     new RegularSinkTagger(cpg, rules).createAndApply()
     new CollectionTagger(cpg, rules).createAndApply()
 

--- a/src/main/scala/ai/privado/languageEngine/csharp/tagger/sink/CSharpAPISinkTagger.scala
+++ b/src/main/scala/ai/privado/languageEngine/csharp/tagger/sink/CSharpAPISinkTagger.scala
@@ -1,0 +1,17 @@
+package ai.privado.languageEngine.csharp.tagger.sink
+
+import ai.privado.cache.{AppCache, RuleCache}
+import ai.privado.entrypoint.PrivadoInput
+import ai.privado.tagger.sink.api.APISinkTagger
+import io.shiftleft.codepropertygraph.generated.Cpg
+
+object CSharpAPISinkTagger extends APISinkTagger {
+
+  override def applyTagger(cpg: Cpg, ruleCache: RuleCache, privadoInput: PrivadoInput, appCache: AppCache): Unit = {
+
+    super.applyTagger(cpg, ruleCache, privadoInput, appCache)
+
+    new CSharpAPITagger(cpg, ruleCache, privadoInput, appCache).createAndApply()
+  }
+
+}

--- a/src/main/scala/ai/privado/languageEngine/csharp/tagger/sink/CSharpAPITagger.scala
+++ b/src/main/scala/ai/privado/languageEngine/csharp/tagger/sink/CSharpAPITagger.scala
@@ -1,0 +1,39 @@
+/*
+ * This file is part of Privado OSS.
+ *
+ * Privado is an open source static code analysis tool to discover data flows in the code.
+ * Copyright (C) 2022 Privado, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * For more information, contact support@privado.ai
+ *
+ */
+package ai.privado.languageEngine.csharp.tagger.sink
+
+import ai.privado.cache.{AppCache, RuleCache}
+import ai.privado.entrypoint.PrivadoInput
+import ai.privado.metric.MetricHandler
+import ai.privado.tagger.sink.APITagger
+import io.circe.Json
+import io.shiftleft.codepropertygraph.generated.Cpg
+import org.slf4j.LoggerFactory
+
+class CSharpAPITagger(cpg: Cpg, ruleCache: RuleCache, privadoInput: PrivadoInput, appCache: AppCache)
+    extends APITagger(cpg, ruleCache, privadoInput, appCache) {
+  private val logger = LoggerFactory.getLogger(this.getClass)
+
+  MetricHandler.metricsData("apiTaggerVersion") = Json.fromString("Common HTTP Libraries Used")
+
+}

--- a/src/test/scala/ai/privado/languageEngine/csharp/CSharpTestBase.scala
+++ b/src/test/scala/ai/privado/languageEngine/csharp/CSharpTestBase.scala
@@ -24,6 +24,7 @@ import ai.privado.model.SourceCodeModel
 import ai.privado.rule.RuleInfoTestData
 import ai.privado.tagger.source.LiteralTagger
 
+@deprecated
 abstract class CSharpTestBase extends AnyWordSpec with Matchers with BeforeAndAfterAll with BeforeAndAfterEach {
 
   private val cpgs        = mutable.ArrayBuffer.empty[Cpg]
@@ -45,25 +46,6 @@ abstract class CSharpTestBase extends AnyWordSpec with Matchers with BeforeAndAf
       "",
       CatLevelOne.SINKS,
       "",
-      Language.CSHARP,
-      Array()
-    ),
-    RuleInfo(
-      Constants.thirdPartiesAPIRuleId,
-      "Third Party API",
-      "",
-      FilterProperty.METHOD_FULL_NAME,
-      Array(),
-      List(
-        "((?i)((?:http:|https:|ftp:|ssh:|udp:|wss:){0,1}(\\/){0,2}[a-zA-Z0-9_-][^)\\/(#|,!>\\s]{1,50}\\.(?:com|net|org|de|in|uk|us|io|gov|cn|ml|ai|ly|dev|cloud|me|icu|ru|info|top|tk|tr|cn|ga|cf|nl)).*(?<!png|jpeg|jpg|txt|blob|css|html|js|svg))"
-      ),
-      false,
-      "",
-      Map(),
-      NodeType.API,
-      "",
-      CatLevelOne.SINKS,
-      catLevelTwo = Constants.third_parties,
       Language.CSHARP,
       Array()
     )
@@ -89,24 +71,6 @@ abstract class CSharpTestBase extends AnyWordSpec with Matchers with BeforeAndAf
     )
   )
 
-  val systemConfig = List(
-    SystemConfig("apiHttpLibraries", "^(?i)(HttpClient).*", Language.CSHARP, "", Array()),
-    SystemConfig(
-      "apiSinks",
-      "(?i)((Get|Post|Put|Patch|Delete)(String|ByteArray|Stream)?Async)",
-      Language.CSHARP,
-      "",
-      Array()
-    ),
-    SystemConfig(
-      "apiIdentifier",
-      "(?i).*((hook|base|auth|prov|endp|install|request|service|gateway|route|resource)(.){0,12}url|(slack|web)(.){0,4}hook|(rest|api|request|service)(.){0,4}(endpoint|gateway|route)).*",
-      Language.CSHARP,
-      "",
-      Array()
-    )
-  )
-
   val configAndRules: ConfigAndRules =
     ConfigAndRules(
       RuleInfoTestData.sourceRule,
@@ -117,7 +81,7 @@ abstract class CSharpTestBase extends AnyWordSpec with Matchers with BeforeAndAf
       List(),
       List(),
       List(),
-      systemConfig,
+      List(),
       List()
     )
 

--- a/src/test/scala/ai/privado/languageEngine/csharp/tagger/sink/CSharpAPITaggerTest.scala
+++ b/src/test/scala/ai/privado/languageEngine/csharp/tagger/sink/CSharpAPITaggerTest.scala
@@ -1,50 +1,70 @@
 package ai.privado.languageEngine.csharp.tagger.sink
 
-import ai.privado.languageEngine.csharp.CSharpTestBase
+import ai.privado.entrypoint.PrivadoInput
 import ai.privado.model.{CatLevelOne, Constants, SourceCodeModel}
+import ai.privado.testfixtures.CSharpFrontendTestSuite
 import io.shiftleft.semanticcpg.language.*
+import ai.privado.cache.RuleCache
+import ai.privado.model.*
+import ai.privado.rule.RuleInfoTestData
+import ai.privado.tagger.sink.api.APIValidator
 
-class CSharpAPITaggerTest extends CSharpTestBase {
+class CSharpAPITaggerTest extends CSharpFrontendTestSuite with APIValidator {
 
-  "API call made using HTTP library" should {
-    "be tagged as part of API tagger" in {
-      val (cpg, _) = code(
-        List(
-          SourceCodeModel(
-            """
-              |using System;
-              |using System.Net.Http;
-              |using System.Threading.Tasks;
-              |
-              |class Program
-              |{
-              |    private static readonly HttpClient client = new HttpClient();
-              |
-              |    static async Task Main()
-              |    {
-              |            var user = new Dictionary<string, string>
-              |            {
-              |               { "email", "hello@example.com" },
-              |               { "car", "Mini" }
-              |            };
-              |            var content = new FormUrlEncodedContent(user);
-              |            var response = await client.PostAsync("http://www.example.com", content);
-              |            var responseString = await response.Content.ReadAsStringAsync();
-              |    }
-              |}
-              |""".stripMargin,
-            "Test.cs"
-          )
-        )
-      )
+  val systemConfig = List(
+    SystemConfig("apiHttpLibraries", "^(?i)(HttpClient).*", Language.CSHARP, "", Array()),
+    SystemConfig(
+      "apiSinks",
+      "(?i)((Get|Post|Put|Patch|Delete)(String|ByteArray|Stream)?Async)",
+      Language.CSHARP,
+      "",
+      Array()
+    ),
+    SystemConfig(
+      "apiIdentifier",
+      "(?i).*((hook|base|auth|prov|endp|install|request|service|gateway|route|resource)(.){0,12}url|(slack|web)(.){0,4}hook|(rest|api|request|service)(.){0,4}(endpoint|gateway|route)).*",
+      Language.CSHARP,
+      "",
+      Array()
+    )
+  )
+  val ruleCache = RuleCache().setRule(RuleInfoTestData.rule.copy(systemConfig = systemConfig))
 
-      val List(postCall) = cpg.call.nameExact("PostAsync").l
-      postCall.tag.size shouldBe 6
-      postCall.tag.nameExact("id").value.head shouldBe "Sinks.ThirdParties.API.example.com"
-      postCall.tag.nameExact("nodeType").value.head shouldBe "api"
-      postCall.tag.nameExact("catLevelOne").value.head shouldBe "sinks"
-      postCall.tag.nameExact("catLevelTwo").value.head shouldBe "third_parties"
-      postCall.tag.nameExact("third_partiesapi").value.head shouldBe "Sinks.ThirdParties.API.example.com"
+  "API call made using System.Net.Http library" should {
+    val cpg = code(
+      """
+        |using System;
+        |using System.Net.Http;
+        |using System.Threading.Tasks;
+        |
+        |class Program
+        |{
+        |    private static readonly HttpClient client = new HttpClient();
+        |
+        |    static async Task Main()
+        |    {
+        |            var user = new Dictionary<string, string>
+        |            {
+        |               { "email", "hello@example.com" },
+        |               { "car", "Mini" }
+        |            };
+        |            var content = new FormUrlEncodedContent(user);
+        |            var response = await client.PostAsync("http://www.example.com", content);
+        |            var responseString = await response.Content.ReadAsStringAsync();
+        |    }
+        |}
+        |""".stripMargin,
+      "Test.cs"
+    ).withRuleCache(ruleCache)
+
+    "tag sink as api sink" in {
+      val List(getUserCall) = cpg.call("PostAsync").l
+      assertAPISinkCall(getUserCall)
+    }
+
+    "tag sink with endpoint" in {
+      val List(getUserCall) = cpg.call("PostAsync").l
+      assertAPIEndpointURL(getUserCall, "\"http://www.example.com\"")
     }
   }
 }

--- a/src/test/scala/ai/privado/languageEngine/csharp/tagger/sink/CSharpAPITaggerTest.scala
+++ b/src/test/scala/ai/privado/languageEngine/csharp/tagger/sink/CSharpAPITaggerTest.scala
@@ -1,0 +1,50 @@
+package ai.privado.languageEngine.csharp.tagger.sink
+
+import ai.privado.languageEngine.csharp.CSharpTestBase
+import ai.privado.model.{CatLevelOne, Constants, SourceCodeModel}
+import io.shiftleft.semanticcpg.language.*
+
+class CSharpAPITaggerTest extends CSharpTestBase {
+
+  "API call made using HTTP library" should {
+    "be tagged as part of API tagger" in {
+      val (cpg, _) = code(
+        List(
+          SourceCodeModel(
+            """
+              |using System;
+              |using System.Net.Http;
+              |using System.Threading.Tasks;
+              |
+              |class Program
+              |{
+              |    private static readonly HttpClient client = new HttpClient();
+              |
+              |    static async Task Main()
+              |    {
+              |            var user = new Dictionary<string, string>
+              |            {
+              |               { "email", "hello@example.com" },
+              |               { "car", "Mini" }
+              |            };
+              |            var content = new FormUrlEncodedContent(user);
+              |            var response = await client.PostAsync("http://www.example.com", content);
+              |            var responseString = await response.Content.ReadAsStringAsync();
+              |    }
+              |}
+              |""".stripMargin,
+            "Test.cs"
+          )
+        )
+      )
+
+      val List(postCall) = cpg.call.nameExact("PostAsync").l
+      postCall.tag.size shouldBe 6
+      postCall.tag.nameExact("id").value.head shouldBe "Sinks.ThirdParties.API.example.com"
+      postCall.tag.nameExact("nodeType").value.head shouldBe "api"
+      postCall.tag.nameExact("catLevelOne").value.head shouldBe "sinks"
+      postCall.tag.nameExact("catLevelTwo").value.head shouldBe "third_parties"
+      postCall.tag.nameExact("third_partiesapi").value.head shouldBe "Sinks.ThirdParties.API.example.com"
+    }
+  }
+}


### PR DESCRIPTION
Adds basic API tagging with support for `System.Net.Http` based API calls