### PR TITLE
Member filter in data element discovery

### DIFF
--- a/src/main/scala/ai/privado/audit/DataElementDiscovery.scala
+++ b/src/main/scala/ai/privado/audit/DataElementDiscovery.scala
@@ -94,7 +94,11 @@ object DataElementDiscovery {
         classNameSet.foreach(className => {
           cpg.typeDecl
             .where(_.fullName(className))
-            .foreach(typeDeclNode => memberInfoMap.put(typeDeclNode, typeDeclNode.member.l))
+            .foreach(typeDeclNode => {
+              if (typeDeclNode.member.nonEmpty) {
+                memberInfoMap.put(typeDeclNode, typeDeclNode.member.l)
+              }
+            })
         })
       }
       case Failure(exception) => {

--- a/src/test/scala/ai/privado/languageEngine/java/audit/DataElementDiscoveryTest.scala
+++ b/src/test/scala/ai/privado/languageEngine/java/audit/DataElementDiscoveryTest.scala
@@ -159,5 +159,13 @@ class DataElementDiscoveryTest extends DataElementDiscoveryTestBase {
       score shouldBe "0.0"
 
     }
+
+    "filter the class having no member" in {
+      val classList = List("com.test.privado.Controller.UserController", "com.test.privado.Entity.Address")
+      val memberMap = DataElementDiscovery.getMemberUsingClassName(Try(cpg), classList.toSet)
+
+      memberMap.size shouldBe 1
+      memberMap.headOption.get._1.fullName should equal("com.test.privado.Entity.Address")
+    }
   }
 }


### PR DESCRIPTION
Filter out classes in the data element discovery of the audit report that have no member variables defined.