### PR TITLE
fix failing flink test case

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -8,7 +8,7 @@ ThisBuild / version      := sys.env.getOrElse("BUILD_VERSION", "dev-SNAPSHOT")
 // parsed by project/Versions.scala, updated by updateDependencies.sh
 
 val cpgVersion        = "1.6.11"
-val joernVersion      = "2.0.350"
+val joernVersion      = "2.0.353"
 val overflowdbVersion = "1.192"
 val requests          = "0.8.0"
 val upickle           = "3.1.2"

--- a/src/main/scala/ai/privado/languageEngine/base/processor/BaseProcessor.scala
+++ b/src/main/scala/ai/privado/languageEngine/base/processor/BaseProcessor.scala
@@ -45,6 +45,7 @@ abstract class BaseProcessor(
   s3DatabaseDetailsCache: S3DatabaseDetailsCache,
   appCache: AppCache,
   returnClosedCpg: Boolean,
+  dumpCpgAtBasePath: Boolean = false,
   propertyFilterCache: PropertyFilterCache = new PropertyFilterCache()
 ) {
 

--- a/src/main/scala/ai/privado/languageEngine/csharp/processor/CSharpProcessor.scala
+++ b/src/main/scala/ai/privado/languageEngine/csharp/processor/CSharpProcessor.scala
@@ -87,7 +87,7 @@ class CSharpProcessor(
       s3DatabaseDetailsCache,
       appCache,
       returnClosedCpg,
-      propertyFilterCache
+      propertyFilterCache = propertyFilterCache
     ) {
   private val logger = LoggerFactory.getLogger(getClass)
 

--- a/src/main/scala/ai/privado/languageEngine/default/processor/DefaultProcessor.scala
+++ b/src/main/scala/ai/privado/languageEngine/default/processor/DefaultProcessor.scala
@@ -63,7 +63,7 @@ class DefaultProcessor(
       s3DatabaseDetailsCache,
       appCache,
       returnClosedCpg,
-      propertyFilterCache
+      propertyFilterCache = propertyFilterCache
     ) {
 
   private val logger = LoggerFactory.getLogger(getClass)

--- a/src/main/scala/ai/privado/languageEngine/java/processor/JavaProcessor.scala
+++ b/src/main/scala/ai/privado/languageEngine/java/processor/JavaProcessor.scala
@@ -89,7 +89,7 @@ class JavaProcessor(
       s3DatabaseDetailsCache,
       appCache,
       returnClosedCpg,
-      propertyFilterCache
+      propertyFilterCache = propertyFilterCache
     ) {
 
   override val logger: Logger = LoggerFactory.getLogger(getClass)

--- a/src/main/scala/ai/privado/languageEngine/kotlin/processor/KotlinProcessor.scala
+++ b/src/main/scala/ai/privado/languageEngine/kotlin/processor/KotlinProcessor.scala
@@ -68,6 +68,7 @@ class KotlinProcessor(
   s3DatabaseDetailsCache: S3DatabaseDetailsCache,
   appCache: AppCache,
   returnClosedCpg: Boolean = true,
+  dumpCpgAtBasePath: Boolean = false,
   propertyFilterCache: PropertyFilterCache
 ) extends BaseProcessor(
       ruleCache,
@@ -78,7 +79,8 @@ class KotlinProcessor(
       auditCache,
       s3DatabaseDetailsCache,
       appCache,
-      returnClosedCpg
+      returnClosedCpg,
+      dumpCpgAtBasePath
     ) {
   override val logger   = LoggerFactory.getLogger(getClass)
   private var cpgconfig = Config()
@@ -112,10 +114,13 @@ class KotlinProcessor(
     println(s"${Calendar.getInstance().getTime} - Processing source code using Kotlin engine")
     println(s"${Calendar.getInstance().getTime} - Parsing source code...")
 
-    val cpgOutputPath = s"$sourceRepoLocation/$outputDirectoryName/$cpgOutputFileName"
-
-    // Create the .privado folder if not present
-    createCpgFolder(sourceRepoLocation);
+    val cpgOutputPath =
+      if (dumpCpgAtBasePath) s"$sourceRepoLocation/$cpgOutputFileName"
+      else {
+        // Create the .privado folder if not present
+        createCpgFolder(sourceRepoLocation)
+        s"$sourceRepoLocation/$outputDirectoryName/$cpgOutputFileName"
+      }
     val excludeFileRegex = ruleCache.getExclusionRegex
 
     val cpgconfig = Config(includeJavaSourceFiles = true)

--- a/src/main/scala/ai/privado/languageEngine/php/processor/PhpProcessor.scala
+++ b/src/main/scala/ai/privado/languageEngine/php/processor/PhpProcessor.scala
@@ -63,7 +63,7 @@ class PhpProcessor(
       s3DatabaseDetailsCache,
       appCache,
       returnClosedCpg,
-      propertyFilterCache
+      propertyFilterCache = propertyFilterCache
     ) {
 
   override val logger: Logger = LoggerFactory.getLogger(this.getClass)

--- a/src/test/scala/ai/privado/languageEngine/kotlin/tagger/sink/framework/flink/FlinkUntaggedSinkTaggerTests.scala
+++ b/src/test/scala/ai/privado/languageEngine/kotlin/tagger/sink/framework/flink/FlinkUntaggedSinkTaggerTests.scala
@@ -33,7 +33,7 @@ class FlinkUntaggedSinkTaggerTests extends KotlinFrontendTestSuite {
         |        env.execute("Flink Kafka Example")
         |    }
         |}
-        |""".stripMargin).moreCode("", "sample.kts")
+        |""".stripMargin)
 
     "tag the flink's sink default flink rule" in {
       val List(flinkSink) = cpg.call("addSink").l

--- a/src/test/scala/ai/privado/languageEngine/kotlin/tagger/sink/framework/flink/FlinkUntaggedSinkTaggerTests.scala
+++ b/src/test/scala/ai/privado/languageEngine/kotlin/tagger/sink/framework/flink/FlinkUntaggedSinkTaggerTests.scala
@@ -33,7 +33,7 @@ class FlinkUntaggedSinkTaggerTests extends KotlinFrontendTestSuite {
         |        env.execute("Flink Kafka Example")
         |    }
         |}
-        |""".stripMargin)
+        |""".stripMargin).moreCode("", "sample.kts")
 
     "tag the flink's sink default flink rule" in {
       val List(flinkSink) = cpg.call("addSink").l

--- a/src/test/scala/ai/privado/testfixtures/KotlinFrontendTestSuite.scala
+++ b/src/test/scala/ai/privado/testfixtures/KotlinFrontendTestSuite.scala
@@ -25,6 +25,7 @@ class TestCpgWithKotlin(val fileSuffix: String, val language: Language.Value) ex
       s3DatabaseDetailsCache,
       appCache,
       returnClosedCpg = false,
+      dumpCpgAtBasePath = true,
       propertyFilterCache
     )
   }


### PR DESCRIPTION
- Introduces `dumpCpgAtBasePath`, which if `true` will write the cpg at the sourceRepoPath being scanned and doesn't create a `.privado` folder
- Fixes the kotlin test case failure when using `KotlinFrontendTestSuite`, The test case are failing as we create a `.privado` folder before parsing the code, which promptly the current subdirectory fetching logic to only consider `.privado` folder content for kotlin scans which inturn have 0 kotlin file, resulting into empty CPG