### PR TITLE
Add `processDataElementDiscovery()` in `getAuditWorkbookPy()`

### DIFF
--- a/src/main/scala/ai/privado/audit/AuditReportEntryPoint.scala
+++ b/src/main/scala/ai/privado/audit/AuditReportEntryPoint.scala
@@ -8,7 +8,6 @@ import io.shiftleft.codepropertygraph.generated.Cpg
 import io.shiftleft.codepropertygraph.generated.nodes.ModuleDependency
 import org.apache.poi.ss.usermodel.*
 import org.apache.poi.xssf.usermodel.{XSSFCellStyle, XSSFColor, XSSFWorkbook}
-import org.apache.xmlbeans.XmlException
 
 import scala.collection.mutable.ListBuffer
 import scala.util.Try
@@ -109,8 +108,20 @@ object AuditReportEntryPoint {
     workbook
   }
 
-  def getAuditWorkbookPy(auditCache: AuditCache, xtocpg: Try[Cpg], ruleCache: RuleCache): Workbook = {
-    val workbook: Workbook = new XSSFWorkbook()
+  def getAuditWorkbookPy(
+    xtocpg: Try[Cpg],
+    taggerCache: TaggerCache,
+    repoPath: String,
+    auditCache: AuditCache,
+    ruleCache: RuleCache
+  ): Workbook = {
+    val workbook: Workbook       = new XSSFWorkbook()
+    val dataElementDiscoveryData = DataElementDiscoveryJS.processDataElementDiscovery(xtocpg, taggerCache)
+    createDataElementDiscoveryJson(dataElementDiscoveryData, repoPath = repoPath)
+    createSheet(workbook, AuditReportConstants.AUDIT_ELEMENT_DISCOVERY_SHEET_NAME, dataElementDiscoveryData)
+    // Changed Background colour when tagged
+    changeTaggedBackgroundColour(workbook, List(4, 6))
+
     createSheet(
       workbook,
       AuditReportConstants.AUDIT_DATA_FLOW_SHEET_NAME,

--- a/src/main/scala/ai/privado/languageEngine/go/processor/GoProcessor.scala
+++ b/src/main/scala/ai/privado/languageEngine/go/processor/GoProcessor.scala
@@ -132,7 +132,7 @@ object GoProcessor {
           if (ScanProcessor.config.generateAuditReport) {
             ExcelExporter.auditExport(
               outputAuditFileName,
-              AuditReportEntryPoint.getAuditWorkbookPy(auditCache, xtocpg, ruleCache),
+              AuditReportEntryPoint.getAuditWorkbookPy(xtocpg, taggerCache, sourceRepoLocation, auditCache, ruleCache),
               sourceRepoLocation
             ) match {
               case Left(err) =>

--- a/src/main/scala/ai/privado/languageEngine/python/processor/PythonProcessor.scala
+++ b/src/main/scala/ai/privado/languageEngine/python/processor/PythonProcessor.scala
@@ -163,7 +163,7 @@ object PythonProcessor {
           if (privadoInput.generateAuditReport) {
             ExcelExporter.auditExport(
               outputAuditFileName,
-              AuditReportEntryPoint.getAuditWorkbookPy(auditCache, xtocpg, ruleCache),
+              AuditReportEntryPoint.getAuditWorkbookPy(xtocpg, taggerCache, sourceRepoLocation, auditCache, ruleCache),
               sourceRepoLocation
             ) match {
               case Left(err) =>

--- a/src/test/scala/ai/privado/languageEngine/go/audit/DataElementDiscoveryTest.scala
+++ b/src/test/scala/ai/privado/languageEngine/go/audit/DataElementDiscoveryTest.scala
@@ -1,0 +1,128 @@
+package ai.privado.languageEngine.go.audit
+
+import ai.privado.audit.{DataElementDiscovery, DataElementDiscoveryJS}
+import ai.privado.languageEngine.go.audit.TestData.AuditTestClassData
+import ai.privado.languageEngine.go.tagger.collection.CollectionTagger
+import ai.privado.languageEngine.go.tagger.source.IdentifierTagger
+import io.shiftleft.codepropertygraph.generated.nodes.Member
+
+import scala.collection.mutable
+import scala.util.Try
+
+class DataElementDiscoveryTest extends DataElementDiscoveryTestBase {
+
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+    new IdentifierTagger(cpg, ruleCache, taggerCache).createAndApply()
+    new CollectionTagger(cpg, ruleCache).createAndApply()
+  }
+
+  override val goFileContentMap: Map[String, String] = getContent()
+
+  def getContent(): Map[String, String] = {
+    val testClassMap = mutable.Map[String, String]()
+
+    testClassMap.put("User", AuditTestClassData.user)
+    testClassMap.put("Account", AuditTestClassData.account)
+    testClassMap.put("Address", AuditTestClassData.address)
+    testClassMap.toMap
+  }
+
+  "DataElementDiscovery" should {
+    "Test discovery of class name in codebase" in {
+      val classNameList = DataElementDiscoveryJS.getSourceUsingRules(Try(cpg))
+
+      classNameList.size shouldBe 4
+      classNameList should contain("entity.User")
+      classNameList should contain("entity.Account")
+      classNameList should contain("entity.Address")
+      classNameList should not contain ("nonExistent.Type")
+    }
+
+    "Test discovery of class Name in package from class name" in {
+      val classList = List("entity.User", "entity.Account")
+
+      val discoveryList = DataElementDiscovery.extractClassFromPackage(Try(cpg), classList.toSet)
+      discoveryList.size shouldBe 4
+      discoveryList should contain("entity.User")
+      discoveryList should contain("entity.Account")
+    }
+
+    "Test class member variable" in {
+      val classList = List("entity.User", "entity.Account")
+
+      val memberMap = DataElementDiscovery.getMemberUsingClassName(Try(cpg), classList.toSet)
+
+      val classMemberMap = new mutable.HashMap[String, List[Member]]()
+
+      memberMap.foreach { case (key, value) =>
+        classMemberMap.put(key.fullName, value)
+      }
+
+      classMemberMap.keys.toList should contain("entity.User")
+      classMemberMap("entity.User").size shouldBe 1
+      classMemberMap("entity.User").head.name should equal("firstName")
+
+      classMemberMap.keys.toList should contain("entity.Account")
+      classMemberMap("entity.Account").size shouldBe 1
+      classMemberMap("entity.Account").head.name should equal("accountNo")
+    }
+
+    "Test final discovery result" in {
+      val classNameList    = new mutable.HashSet[String]()
+      val fileScoreList    = new mutable.HashSet[String]()
+      val memberList       = new mutable.HashSet[String]()
+      val sourceRuleIdMap  = new mutable.HashMap[String, String]()
+      val collectionTagMap = new mutable.HashMap[String, String]()
+      val endpointMap      = new mutable.HashMap[String, String]()
+      val methodNameMap    = new mutable.HashMap[String, String]()
+
+      val workbookList = DataElementDiscoveryJS.processDataElementDiscovery(Try(cpg), taggerCache)
+
+      workbookList.foreach(row => {
+        classNameList += row.head
+        fileScoreList += row(2)
+        memberList += row(3)
+
+        // Prevent overwriting last sane value.
+        if (row(6) != "--") {
+          sourceRuleIdMap.put(row(3), row(6))
+        }
+
+        if (!collectionTagMap.contains(row.head)) collectionTagMap.put(row.head, row(7))
+        if (!endpointMap.contains(row.head)) endpointMap.put(row.head, row(8))
+        if (!methodNameMap.contains(row.head)) methodNameMap.put(row.head, row(9))
+      })
+
+      // Validate class name in result
+      classNameList should contain("entity.User")
+      classNameList should contain("entity.Account")
+      classNameList should contain("entity.Address")
+
+      classNameList should not contain ("nonExistent.Type")
+
+      // Validate class member in result
+      memberList should contain("firstName")
+      memberList should contain("accountNo")
+      memberList should contain("houseNo")
+      memberList should not contain ("nonExistentMember")
+
+      fileScoreList should contain("1.5")
+
+      // validate source Rule ID in result
+      sourceRuleIdMap("firstName") should equal("Data.Sensitive.FirstName")
+    }
+
+    "Test file score " in {
+      DataElementDiscoveryJS.getFileScoreJS("User.go", Try(cpg)) shouldBe "1.5"
+    }
+
+    "filter the class having no member" in {
+      val classList = List("nonExistent.Type", "entity.Address")
+      val memberMap = DataElementDiscovery.getMemberUsingClassName(Try(cpg), classList.toSet)
+
+      memberMap.size shouldBe 1
+      memberMap.headOption.get._1.fullName should equal("entity.Address")
+    }
+  }
+}

--- a/src/test/scala/ai/privado/languageEngine/go/audit/DataElementDiscoveryTestBase.scala
+++ b/src/test/scala/ai/privado/languageEngine/go/audit/DataElementDiscoveryTestBase.scala
@@ -1,0 +1,77 @@
+package ai.privado.languageEngine.go.audit
+
+import ai.privado.cache.{RuleCache, TaggerCache}
+import ai.privado.model.*
+import better.files.File
+import io.joern.gosrc2cpg.{Config, GoSrc2Cpg}
+import io.joern.x2cpg.X2Cpg.applyDefaultOverlays
+import io.shiftleft.codepropertygraph.generated.Cpg
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+import scala.compiletime.uninitialized
+
+abstract class DataElementDiscoveryTestBase extends AnyWordSpec with Matchers with BeforeAndAfterAll {
+
+  var cpg: Cpg = uninitialized
+  val goFileContentMap: Map[String, String]
+  var inputDir: File  = uninitialized
+  var outputDir: File = uninitialized
+  val ruleCache       = new RuleCache()
+
+  override def beforeAll(): Unit = {
+    inputDir = File.newTemporaryDirectory()
+    for ((key, content) <- goFileContentMap) {
+      (inputDir / s"$key.go").write(content)
+    }
+
+    outputDir = File.newTemporaryDirectory()
+
+    val config = Config(fetchDependencies = true)
+      .withInputPath(inputDir.pathAsString)
+      .withOutputPath(outputDir.pathAsString)
+    val goSrc2Cpg = new GoSrc2Cpg(None)
+    val xtocpg = goSrc2Cpg.createCpg(config).map { cpg =>
+      applyDefaultOverlays(cpg)
+      cpg
+    }
+
+    cpg = xtocpg.get
+
+    ruleCache.setRule(rule)
+    super.beforeAll()
+  }
+
+  override def afterAll(): Unit = {
+    inputDir.delete()
+    cpg.close()
+    outputDir.delete()
+    super.afterAll()
+  }
+
+  val sourceRule: List[RuleInfo] = List(
+    RuleInfo(
+      "Data.Sensitive.FirstName",
+      "FirstName",
+      "",
+      FilterProperty.METHOD_FULL_NAME,
+      Array(),
+      List("(?i).*firstName.*"),
+      false,
+      "",
+      Map(),
+      NodeType.REGULAR,
+      "",
+      CatLevelOne.SOURCES,
+      "",
+      Language.GO,
+      Array()
+    )
+  )
+
+  val rule: ConfigAndRules =
+    ConfigAndRules(sourceRule, List(), List(), List(), List(), List(), List(), List(), List(), List())
+
+  val taggerCache = new TaggerCache()
+}

--- a/src/test/scala/ai/privado/languageEngine/go/audit/TestData/AuditTestClassData.scala
+++ b/src/test/scala/ai/privado/languageEngine/go/audit/TestData/AuditTestClassData.scala
@@ -1,0 +1,43 @@
+package ai.privado.languageEngine.go.audit.TestData
+
+object AuditTestClassData {
+  val user: String = """
+      |package entity
+      |
+      |type User struct {
+      |	firstName string
+      |}
+      |
+      |func (u User) getFirstName() string {
+      |	return u.firstName
+      |}
+      |
+      |func (u *User) setFirstName(firstName string) {
+      |	u.firstName = firstName
+      |}
+      |""".stripMargin
+
+  val account: String = """
+      |package entity
+      |
+      |type Account struct {
+      |	accountNo string
+      |}
+      |
+      |func (a *Account) setAccountNo(accountNo string) {
+      |	a.accountNo = accountNo;
+      |}
+      |""".stripMargin
+
+  val address: String = """
+        |package entity
+        |
+        |type Address struct {
+        |	houseNo string
+        |}
+        |
+        |func (a Address) getHouseNo() string {
+        |	return a.houseNo;
+        |}
+        |""".stripMargin
+}

--- a/src/test/scala/ai/privado/languageEngine/python/audit/DataElementDiscoveryTest.scala
+++ b/src/test/scala/ai/privado/languageEngine/python/audit/DataElementDiscoveryTest.scala
@@ -1,0 +1,129 @@
+package ai.privado.languageEngine.python.audit
+
+import ai.privado.audit.{DataElementDiscovery, DataElementDiscoveryJS}
+import ai.privado.languageEngine.python.audit.TestData.AuditTestClassData
+import ai.privado.languageEngine.python.tagger.collection.CollectionTagger
+import ai.privado.languageEngine.python.tagger.source.IdentifierTagger
+import io.shiftleft.codepropertygraph.generated.nodes.Member
+
+import scala.collection.mutable
+import scala.util.Try
+
+class DataElementDiscoveryTest extends DataElementDiscoveryTestBase {
+
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+    new IdentifierTagger(cpg, ruleCache, taggerCache).createAndApply()
+    new CollectionTagger(cpg, ruleCache).createAndApply()
+  }
+
+  override val pyFileContentMap: Map[String, String] = getContent()
+
+  def getContent(): Map[String, String] = {
+    val testClassMap = mutable.Map[String, String]()
+
+    testClassMap.put("User", AuditTestClassData.user)
+    testClassMap.put("Account", AuditTestClassData.account)
+    testClassMap.put("Address", AuditTestClassData.address)
+    testClassMap.toMap
+  }
+
+  "DataElementDiscovery" should {
+    "Test discovery of class name in codebase" in {
+      val classNameList = DataElementDiscoveryJS.getSourceUsingRules(Try(cpg))
+
+      classNameList should contain("User.py:<module>.User")
+      classNameList should contain("Account.py:<module>.Account")
+      classNameList should contain("Address.py:<module>.Address")
+      classNameList should not contain ("NonExistent.py:<module>.NonExistent")
+    }
+
+    "Test discovery of class Name in package from class name" in {
+      val classList = List("User.py:<module>.User", "Account.py:<module>.Account")
+
+      val discoveryList = DataElementDiscovery.extractClassFromPackage(Try(cpg), classList.toSet)
+      discoveryList should contain("User.py:<module>.User")
+      discoveryList should contain("Account.py:<module>.Account")
+    }
+
+    "Test class member variable" in {
+      val classList = List("User.py:<module>.User", "Account.py:<module>.Account")
+
+      val memberMap = DataElementDiscovery.getMemberUsingClassName(Try(cpg), classList.toSet)
+
+      val classMemberMap = new mutable.HashMap[String, List[Member]]()
+
+      memberMap.foreach { case (key, value) =>
+        classMemberMap.put(key.fullName, value)
+      }
+
+      classMemberMap.keys.toList should contain("User.py:<module>.User")
+
+      // __init__, field, getter, setter
+      classMemberMap("User.py:<module>.User").size shouldBe 4
+      classMemberMap("User.py:<module>.User").last.name should equal("setFirstName")
+
+      classMemberMap.keys.toList should contain("Account.py:<module>.Account")
+
+      // __init__, field, setter
+      classMemberMap("Account.py:<module>.Account").size shouldBe 3
+      classMemberMap("Account.py:<module>.Account").last.name should equal("setAccountNo")
+    }
+
+    "Test final discovery result" in {
+      val classNameList    = new mutable.HashSet[String]()
+      val fileScoreList    = new mutable.HashSet[String]()
+      val memberList       = new mutable.HashSet[String]()
+      val sourceRuleIdMap  = new mutable.HashMap[String, String]()
+      val collectionTagMap = new mutable.HashMap[String, String]()
+      val endpointMap      = new mutable.HashMap[String, String]()
+      val methodNameMap    = new mutable.HashMap[String, String]()
+
+      val workbookList = DataElementDiscoveryJS.processDataElementDiscovery(Try(cpg), taggerCache)
+
+      workbookList.foreach(row => {
+        classNameList += row.head
+        fileScoreList += row(2)
+        memberList += row(3)
+
+        // Prevent overwriting last sane value.
+        if (row(6) != "--") {
+          sourceRuleIdMap.put(row(3), row(6))
+        }
+
+        if (!collectionTagMap.contains(row.head)) collectionTagMap.put(row.head, row(7))
+        if (!endpointMap.contains(row.head)) endpointMap.put(row.head, row(8))
+        if (!methodNameMap.contains(row.head)) methodNameMap.put(row.head, row(9))
+      })
+
+      // Validate class name in result
+      classNameList should contain("User.py:<module>.User")
+      classNameList should contain("Account.py:<module>.Account")
+      classNameList should contain("Address.py:<module>.Address")
+      classNameList should not contain ("NonExistent.py:<module>.NonExistent")
+
+      // Validate class member in result
+      memberList should contain("firstName")
+      memberList should contain("accountNo")
+      memberList should contain("houseNo")
+      memberList should not contain ("nonExistentMember")
+
+      fileScoreList should contain("1.5")
+
+      // validate source Rule ID in result
+      sourceRuleIdMap("firstName") should equal("Data.Sensitive.FirstName")
+    }
+
+    "Test file score " in {
+      DataElementDiscoveryJS.getFileScoreJS("User.py", Try(cpg)) shouldBe "1.5"
+    }
+
+    "filter the class having no member" in {
+      val classList = List("NonExistent.py:<module>.NonExistent", "Address.py:<module>.Address")
+      val memberMap = DataElementDiscovery.getMemberUsingClassName(Try(cpg), classList.toSet)
+
+      memberMap.size shouldBe 1
+      memberMap.headOption.get._1.fullName should equal("Address.py:<module>.Address")
+    }
+  }
+}

--- a/src/test/scala/ai/privado/languageEngine/python/audit/DataElementDiscoveryTestBase.scala
+++ b/src/test/scala/ai/privado/languageEngine/python/audit/DataElementDiscoveryTestBase.scala
@@ -1,0 +1,77 @@
+package ai.privado.languageEngine.python.audit
+
+import ai.privado.cache.{RuleCache, TaggerCache}
+import ai.privado.model.*
+import better.files.File
+import io.joern.pysrc2cpg.{Py2CpgOnFileSystem, Py2CpgOnFileSystemConfig}
+import io.shiftleft.codepropertygraph.generated.Cpg
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+import scala.compiletime.uninitialized
+
+abstract class DataElementDiscoveryTestBase extends AnyWordSpec with Matchers with BeforeAndAfterAll {
+
+  var cpg: Cpg = uninitialized
+  val pyFileContentMap: Map[String, String]
+  var inputDir: File  = uninitialized
+  var outputDir: File = uninitialized
+  val ruleCache       = new RuleCache()
+
+  override def beforeAll(): Unit = {
+    inputDir = File.newTemporaryDirectory()
+    for ((key, content) <- pyFileContentMap) {
+      (inputDir / s"$key.py").write(content)
+    }
+
+    outputDir = File.newTemporaryDirectory()
+
+    val excludeFileRegex = ruleCache.getExclusionRegex
+    val config = Py2CpgOnFileSystemConfig(Option(File(".venv").path), ignoreVenvDir = true)
+      .withInputPath(inputDir.toString)
+      .withOutputPath(outputDir.toString)
+      .withIgnoredFilesRegex(excludeFileRegex)
+
+    val xtocpg = new Py2CpgOnFileSystem().createCpg(config).map { cpg =>
+      cpg
+    }
+
+    cpg = xtocpg.get
+
+    ruleCache.setRule(rule)
+    super.beforeAll()
+  }
+
+  override def afterAll(): Unit = {
+    inputDir.delete()
+    cpg.close()
+    outputDir.delete()
+    super.afterAll()
+  }
+
+  val sourceRule: List[RuleInfo] = List(
+    RuleInfo(
+      "Data.Sensitive.FirstName",
+      "FirstName",
+      "",
+      FilterProperty.METHOD_FULL_NAME,
+      Array(),
+      List("(?i).*firstName.*"),
+      false,
+      "",
+      Map(),
+      NodeType.REGULAR,
+      "",
+      CatLevelOne.SOURCES,
+      "",
+      Language.GO,
+      Array()
+    )
+  )
+
+  val rule: ConfigAndRules =
+    ConfigAndRules(sourceRule, List(), List(), List(), List(), List(), List(), List(), List(), List())
+
+  val taggerCache = new TaggerCache()
+}

--- a/src/test/scala/ai/privado/languageEngine/python/audit/TestData/AuditTestClassData.scala
+++ b/src/test/scala/ai/privado/languageEngine/python/audit/TestData/AuditTestClassData.scala
@@ -1,0 +1,33 @@
+package ai.privado.languageEngine.python.audit.TestData
+
+object AuditTestClassData {
+  val user: String = """
+      |class User:
+      |  def __init__(self, firstName):
+      |    self.firstName = firstName
+      |
+      |  def getFirstName(self):
+      |    return self.firstName
+      |  
+      |  def setFirstName(self, firstName):
+      |    self.firstName = firstName
+      |""".stripMargin
+
+  val account: String = """
+      |class Account:
+      |  def __init__(self, accountNo):
+      |    self.accountNo = accountNo
+      |
+      |  def setAccountNo(self, accountNo):
+      |    self.accountNo = accountNo
+      |""".stripMargin
+
+  val address: String = """
+      |class Address:
+      |  def __init__(self, houseNo):
+      |    self.houseNo = houseNo
+      |
+      |  def setHouseNo(self, houseNo):
+      |    self.houseNo = houseNo
+      |""".stripMargin
+}


### PR DESCRIPTION
This PR adds audit workbook generation and population support for Python and Go.

Reason: Python and Go use the same `IdentifierTagger` as that of JS with some very minute differences.