### PR TITLE
Add lineNumber, variableId & nodeType in audit sources report

### DIFF
--- a/src/main/scala/ai/privado/audit/AuditReportConstants.scala
+++ b/src/main/scala/ai/privado/audit/AuditReportConstants.scala
@@ -45,6 +45,8 @@ object AuditReportConstants {
 
   val ELEMENT_DISCOVERY_METHOD_NAME = "Collection Method Full Name"
 
+  val ELEMENT_DISCOVERY_SOURCE_LINE_NUMBER = "Source Line Number"
+
   val ELEMENT_DISCOVERY_EXCLUDE_CLASS_NAME_REGEX = "^(.*)(Controller|Service|Impl|Helper|Util|Processor|Dao)$"
 
   val ELEMENT_DISCOVERY_GET_SET_METHOD_REGEX = "^(get|set).*"

--- a/src/main/scala/ai/privado/audit/AuditReportConstants.scala
+++ b/src/main/scala/ai/privado/audit/AuditReportConstants.scala
@@ -45,7 +45,21 @@ object AuditReportConstants {
 
   val ELEMENT_DISCOVERY_METHOD_NAME = "Collection Method Full Name"
 
-  val ELEMENT_DISCOVERY_SOURCE_LINE_NUMBER = "Source Line Number"
+  val ELEMENT_DISCOVERY_SOURCE_LINE_NUMBER = "Variable Declaration Line Number"
+
+  val ELEMENT_DISCOVERY_VARIABLE_ID = "Variable Id"
+
+  val ELEMENT_DISCOVERY_NODE_TYPE = "Variable Node Type"
+
+  val ELEMENT_DISCOVERY_NODE_TYPE_MEMBER = "Member"
+
+  val ELEMENT_DISCOVERY_NODE_TYPE_METHOD = "Method"
+
+  val ELEMENT_DISCOVERY_NODE_TYPE_METHOD_PARAM = "Method Parameter"
+
+  val ELEMENT_DISCOVERY_NODE_TYPE_IDENTIFIER = "Identifier"
+
+  val ELEMENT_DISCOVERY_NODE_TYPE_LOCAL = "Local"
 
   val ELEMENT_DISCOVERY_EXCLUDE_CLASS_NAME_REGEX = "^(.*)(Controller|Service|Impl|Helper|Util|Processor|Dao)$"
 

--- a/src/main/scala/ai/privado/audit/AuditReportEntryPoint.scala
+++ b/src/main/scala/ai/privado/audit/AuditReportEntryPoint.scala
@@ -8,7 +8,6 @@ import io.shiftleft.codepropertygraph.generated.Cpg
 import io.shiftleft.codepropertygraph.generated.nodes.ModuleDependency
 import org.apache.poi.ss.usermodel.*
 import org.apache.poi.xssf.usermodel.{XSSFCellStyle, XSSFColor, XSSFWorkbook}
-import org.apache.xmlbeans.XmlException
 
 import scala.collection.mutable.ListBuffer
 import scala.util.Try
@@ -25,7 +24,8 @@ object AuditReportEntryPoint {
     sourceRuleId: String,
     inputToCollection: Boolean,
     collectionEndpointPath: String,
-    collectionMethodFullName: String
+    collectionMethodFullName: String,
+    sourceLineNumber: String
   )
 
   implicit val DataElementDiscoveryAuditModelDecoder: Decoder[DataElementDiscoveryAudit] =
@@ -35,6 +35,9 @@ object AuditReportEntryPoint {
 
   def eliminateEmptyCellValueIfExist(str: String): String =
     if (str == AuditReportConstants.AUDIT_EMPTY_CELL_VALUE) "" else str
+
+  private def mapValidLineNumbers(str: String): String =
+    if (str == "-1") "" else str
 
   def createDataElementDiscoveryJson(dataElementDiscoveryData: List[List[String]], repoPath: String) = {
 
@@ -51,7 +54,8 @@ object AuditReportEntryPoint {
         eliminateEmptyCellValueIfExist(item(6)),
         if (item(5) == "YES") true else false,
         eliminateEmptyCellValueIfExist(item(8)),
-        if (item.size >= 10) eliminateEmptyCellValueIfExist(item(9)) else AuditReportConstants.AUDIT_EMPTY_CELL_VALUE
+        if (item.size >= 10) eliminateEmptyCellValueIfExist(item(9)) else AuditReportConstants.AUDIT_EMPTY_CELL_VALUE,
+        if (item.size >= 11) mapValidLineNumbers(item(10)) else AuditReportConstants.AUDIT_EMPTY_CELL_VALUE
       )
     }
     JSONExporter.dataElementDiscoveryAuditFileExport(

--- a/src/main/scala/ai/privado/audit/AuditReportEntryPoint.scala
+++ b/src/main/scala/ai/privado/audit/AuditReportEntryPoint.scala
@@ -25,7 +25,9 @@ object AuditReportEntryPoint {
     inputToCollection: Boolean,
     collectionEndpointPath: String,
     collectionMethodFullName: String,
-    sourceLineNumber: String
+    variableDeclarationLineNumber: String,
+    variableIdentifier: String,
+    variableType: String
   )
 
   implicit val DataElementDiscoveryAuditModelDecoder: Decoder[DataElementDiscoveryAudit] =
@@ -35,9 +37,6 @@ object AuditReportEntryPoint {
 
   def eliminateEmptyCellValueIfExist(str: String): String =
     if (str == AuditReportConstants.AUDIT_EMPTY_CELL_VALUE) "" else str
-
-  private def mapValidLineNumbers(str: String): String =
-    if (str == "-1") "" else str
 
   def createDataElementDiscoveryJson(dataElementDiscoveryData: List[List[String]], repoPath: String) = {
 
@@ -55,7 +54,15 @@ object AuditReportEntryPoint {
         if (item(5) == "YES") true else false,
         eliminateEmptyCellValueIfExist(item(8)),
         if (item.size >= 10) eliminateEmptyCellValueIfExist(item(9)) else AuditReportConstants.AUDIT_EMPTY_CELL_VALUE,
-        if (item.size >= 11) mapValidLineNumbers(item(10)) else AuditReportConstants.AUDIT_EMPTY_CELL_VALUE
+
+        // Line number
+        if (item.size >= 11) eliminateEmptyCellValueIfExist(item(10)) else AuditReportConstants.AUDIT_EMPTY_CELL_VALUE,
+
+        // variable identifier
+        if (item.size >= 12) eliminateEmptyCellValueIfExist(item(11)) else AuditReportConstants.AUDIT_EMPTY_CELL_VALUE,
+
+        // variable type
+        if (item.size >= 13) eliminateEmptyCellValueIfExist(item(12)) else AuditReportConstants.AUDIT_EMPTY_CELL_VALUE
       )
     }
     JSONExporter.dataElementDiscoveryAuditFileExport(

--- a/src/main/scala/ai/privado/audit/AuditReportEntryPoint.scala
+++ b/src/main/scala/ai/privado/audit/AuditReportEntryPoint.scala
@@ -26,8 +26,8 @@ object AuditReportEntryPoint {
     collectionEndpointPath: String,
     collectionMethodFullName: String,
     variableDeclarationLineNumber: String,
-    variableIdentifier: String,
-    variableType: String
+    memberId: String,
+    nodeType: String
   )
 
   implicit val DataElementDiscoveryAuditModelDecoder: Decoder[DataElementDiscoveryAudit] =

--- a/src/main/scala/ai/privado/audit/DataElementDiscovery.scala
+++ b/src/main/scala/ai/privado/audit/DataElementDiscovery.scala
@@ -1,13 +1,13 @@
 package ai.privado.audit
 
-import ai.privado.audit.DataElementDiscovery.{CollectionMethodInfo, getClass, getFileScore, getSourceUsingRules, logger}
+import ai.privado.audit.DataElementDiscovery.getClass
 import ai.privado.cache.TaggerCache
+import ai.privado.dataflow.Dataflow
 import ai.privado.model.{CatLevelOne, Constants, InternalTag}
 import io.shiftleft.codepropertygraph.generated.Cpg
-import io.shiftleft.codepropertygraph.generated.nodes.{File, Identifier, Local, Member, MethodParameterIn, TypeDecl}
-import io.shiftleft.semanticcpg.language._
+import io.shiftleft.codepropertygraph.generated.nodes.*
+import io.shiftleft.semanticcpg.language.*
 import org.slf4j.LoggerFactory
-import ai.privado.dataflow.Dataflow
 
 import scala.collection.mutable
 import scala.collection.mutable.ListBuffer
@@ -239,7 +239,8 @@ object DataElementDiscovery {
       AuditReportConstants.ELEMENT_DISCOVERY_SOURCE_RULE_ID,
       AuditReportConstants.ELEMENT_DISCOVERY_INPUT_COLLECTION,
       AuditReportConstants.ELEMENT_DISCOVERY_COLLECTION_ENDPOINT,
-      AuditReportConstants.ELEMENT_DISCOVERY_METHOD_NAME
+      AuditReportConstants.ELEMENT_DISCOVERY_METHOD_NAME,
+      AuditReportConstants.ELEMENT_DISCOVERY_SOURCE_LINE_NUMBER
     )
 
     // Construct the excel sheet and fill the data
@@ -260,7 +261,8 @@ object DataElementDiscovery {
                   AuditReportConstants.AUDIT_EMPTY_CELL_VALUE,
                   isCollectionInput,
                   info.endpoint,
-                  info.methodDetail
+                  info.methodDetail,
+                  key.lineNumber.getOrElse(-1).toString
                 )
               })
             } else {
@@ -274,7 +276,8 @@ object DataElementDiscovery {
                 AuditReportConstants.AUDIT_EMPTY_CELL_VALUE,
                 isCollectionInput,
                 AuditReportConstants.AUDIT_EMPTY_CELL_VALUE,
-                AuditReportConstants.AUDIT_EMPTY_CELL_VALUE
+                AuditReportConstants.AUDIT_EMPTY_CELL_VALUE,
+                key.lineNumber.getOrElse(-1).toString
               )
             }
             val ruleMemberInfo = taggedMemberInfo.getOrElse(key.fullName, new mutable.HashMap[String, String])
@@ -291,7 +294,8 @@ object DataElementDiscovery {
                     ruleMemberInfo.getOrElse(member.name, "Default value"),
                     AuditReportConstants.AUDIT_EMPTY_CELL_VALUE,
                     AuditReportConstants.AUDIT_EMPTY_CELL_VALUE,
-                    AuditReportConstants.AUDIT_EMPTY_CELL_VALUE
+                    AuditReportConstants.AUDIT_EMPTY_CELL_VALUE,
+                    member.lineNumber.getOrElse(-1).toString
                   )
                 } else {
                   workbookResult += List(
@@ -304,7 +308,8 @@ object DataElementDiscovery {
                     AuditReportConstants.AUDIT_EMPTY_CELL_VALUE,
                     AuditReportConstants.AUDIT_EMPTY_CELL_VALUE,
                     AuditReportConstants.AUDIT_EMPTY_CELL_VALUE,
-                    AuditReportConstants.AUDIT_EMPTY_CELL_VALUE
+                    AuditReportConstants.AUDIT_EMPTY_CELL_VALUE,
+                    member.lineNumber.getOrElse(-1).toString
                   )
                 }
               }
@@ -322,7 +327,8 @@ object DataElementDiscovery {
                   AuditReportConstants.AUDIT_EMPTY_CELL_VALUE,
                   isCollectionInput,
                   info.endpoint,
-                  info.methodDetail
+                  info.methodDetail,
+                  key.lineNumber.getOrElse(-1).toString
                 )
               })
             } else {
@@ -336,7 +342,8 @@ object DataElementDiscovery {
                 AuditReportConstants.AUDIT_EMPTY_CELL_VALUE,
                 isCollectionInput,
                 AuditReportConstants.AUDIT_EMPTY_CELL_VALUE,
-                AuditReportConstants.AUDIT_EMPTY_CELL_VALUE
+                AuditReportConstants.AUDIT_EMPTY_CELL_VALUE,
+                key.lineNumber.getOrElse(-1).toString
               )
             }
             value.foreach {
@@ -351,7 +358,8 @@ object DataElementDiscovery {
                   AuditReportConstants.AUDIT_EMPTY_CELL_VALUE,
                   AuditReportConstants.AUDIT_EMPTY_CELL_VALUE,
                   AuditReportConstants.AUDIT_EMPTY_CELL_VALUE,
-                  AuditReportConstants.AUDIT_EMPTY_CELL_VALUE
+                  AuditReportConstants.AUDIT_EMPTY_CELL_VALUE,
+                  member.lineNumber.getOrElse(-1).toString
                 )
               }
             }
@@ -580,7 +588,8 @@ object DataElementDiscoveryJS {
       AuditReportConstants.ELEMENT_DISCOVERY_SOURCE_RULE_ID,
       AuditReportConstants.ELEMENT_DISCOVERY_INPUT_COLLECTION,
       AuditReportConstants.ELEMENT_DISCOVERY_COLLECTION_ENDPOINT,
-      AuditReportConstants.ELEMENT_DISCOVERY_METHOD_NAME
+      AuditReportConstants.ELEMENT_DISCOVERY_METHOD_NAME,
+      AuditReportConstants.ELEMENT_DISCOVERY_SOURCE_LINE_NUMBER
     )
     // Construct the excel sheet and fill the data
     try {
@@ -596,7 +605,8 @@ object DataElementDiscoveryJS {
             AuditReportConstants.AUDIT_EMPTY_CELL_VALUE,
             AuditReportConstants.AUDIT_EMPTY_CELL_VALUE,
             AuditReportConstants.AUDIT_EMPTY_CELL_VALUE,
-            AuditReportConstants.AUDIT_EMPTY_CELL_VALUE
+            AuditReportConstants.AUDIT_EMPTY_CELL_VALUE,
+            key.lineNumber.getOrElse(-1).toString
           )
           val ruleMemberInfo = taggedMemberInfo.getOrElse(key.fullName, new mutable.HashMap[String, String])
           val addedMembers   = mutable.Set[String]()
@@ -619,7 +629,8 @@ object DataElementDiscoveryJS {
                     ruleMemberInfo.getOrElse(member.name, "Default value"),
                     AuditReportConstants.AUDIT_EMPTY_CELL_VALUE,
                     AuditReportConstants.AUDIT_EMPTY_CELL_VALUE,
-                    AuditReportConstants.AUDIT_EMPTY_CELL_VALUE
+                    AuditReportConstants.AUDIT_EMPTY_CELL_VALUE,
+                    member.lineNumber.getOrElse(-1).toString
                   )
                 } else {
                   workbookResult += List(
@@ -632,7 +643,8 @@ object DataElementDiscoveryJS {
                     AuditReportConstants.AUDIT_EMPTY_CELL_VALUE,
                     AuditReportConstants.AUDIT_EMPTY_CELL_VALUE,
                     AuditReportConstants.AUDIT_EMPTY_CELL_VALUE,
-                    AuditReportConstants.AUDIT_EMPTY_CELL_VALUE
+                    AuditReportConstants.AUDIT_EMPTY_CELL_VALUE,
+                    member.lineNumber.getOrElse(-1).toString
                   )
                 }
               }
@@ -652,7 +664,8 @@ object DataElementDiscoveryJS {
                     ruleMemberInfo.getOrElse(param.name, "Default value"),
                     AuditReportConstants.AUDIT_EMPTY_CELL_VALUE,
                     AuditReportConstants.AUDIT_EMPTY_CELL_VALUE,
-                    AuditReportConstants.AUDIT_EMPTY_CELL_VALUE
+                    AuditReportConstants.AUDIT_EMPTY_CELL_VALUE,
+                    param.lineNumber.getOrElse(-1).toString
                   )
                 } else {
                   workbookResult += List(
@@ -665,7 +678,8 @@ object DataElementDiscoveryJS {
                     AuditReportConstants.AUDIT_EMPTY_CELL_VALUE,
                     AuditReportConstants.AUDIT_EMPTY_CELL_VALUE,
                     AuditReportConstants.AUDIT_EMPTY_CELL_VALUE,
-                    AuditReportConstants.AUDIT_EMPTY_CELL_VALUE
+                    AuditReportConstants.AUDIT_EMPTY_CELL_VALUE,
+                    param.lineNumber.getOrElse(-1).toString
                   )
                 }
               }
@@ -697,7 +711,8 @@ object DataElementDiscoveryJS {
             AuditReportConstants.AUDIT_EMPTY_CELL_VALUE,
             AuditReportConstants.AUDIT_EMPTY_CELL_VALUE,
             AuditReportConstants.AUDIT_EMPTY_CELL_VALUE,
-            AuditReportConstants.AUDIT_EMPTY_CELL_VALUE
+            AuditReportConstants.AUDIT_EMPTY_CELL_VALUE,
+            identifier.lineNumber.getOrElse(-1).toString
           )
       })
 
@@ -723,7 +738,8 @@ object DataElementDiscoveryJS {
             AuditReportConstants.AUDIT_EMPTY_CELL_VALUE,
             AuditReportConstants.AUDIT_EMPTY_CELL_VALUE,
             AuditReportConstants.AUDIT_EMPTY_CELL_VALUE,
-            AuditReportConstants.AUDIT_EMPTY_CELL_VALUE
+            AuditReportConstants.AUDIT_EMPTY_CELL_VALUE,
+            local.lineNumber.getOrElse(-1).toString
           )
       })
 

--- a/src/test/scala/ai/privado/languageEngine/java/audit/DataElementDiscoveryTest.scala
+++ b/src/test/scala/ai/privado/languageEngine/java/audit/DataElementDiscoveryTest.scala
@@ -95,16 +95,16 @@ class DataElementDiscoveryTest extends DataElementDiscoveryTestBase {
     }
 
     "Test final discovery result" in {
-      val classNameList     = new mutable.HashSet[String]()
-      val fileScoreList     = new mutable.HashSet[String]()
-      val memberList        = new mutable.HashSet[String]()
-      val sourceRuleIdMap   = new mutable.HashMap[String, String]()
-      val collectionTagMap  = new mutable.HashMap[String, String]()
-      val endpointMap       = new mutable.HashMap[String, String]()
-      val methodNameMap     = new mutable.HashMap[String, String]()
-      val members           = mutable.HashSet[String]()
-      val uniqueIdentifiers = mutable.ArrayBuffer[String]()
-      val workbookList      = DataElementDiscovery.processDataElementDiscovery(Try(cpg), taggerCache)
+      val classNameList                  = new mutable.HashSet[String]()
+      val fileScoreList                  = new mutable.HashSet[String]()
+      val memberList                     = new mutable.HashSet[String]()
+      val sourceRuleIdMap                = new mutable.HashMap[String, String]()
+      val collectionTagMap               = new mutable.HashMap[String, String]()
+      val endpointMap                    = new mutable.HashMap[String, String]()
+      val methodNameMap                  = new mutable.HashMap[String, String]()
+      val memberLineNumberAndTypeMapping = mutable.HashMap[String, (String, String)]()
+      val uniqueIdentifiers              = mutable.ArrayBuffer[String]()
+      val workbookList                   = DataElementDiscovery.processDataElementDiscovery(Try(cpg), taggerCache)
 
       workbookList.foreach(row => {
         classNameList += row.head
@@ -115,15 +115,16 @@ class DataElementDiscoveryTest extends DataElementDiscoveryTestBase {
         if (!endpointMap.contains(row.head)) endpointMap.put(row.head, row(8))
         if (!methodNameMap.contains(row.head)) methodNameMap.put(row.head, row(9))
         // Bind entity's name to its line number for testing.
-        members += s"${row(3)}+${row(10)}+${row.last}"
+        memberLineNumberAndTypeMapping += (row(3) -> (row(10), row.last))
+//        memberLineNumberAndTypeMapping += s"${row(3)}+${row(10)}+${row.last}"
         uniqueIdentifiers += row(11)
       })
 
-      members should contain("firstName+5+Member")
-      members should contain("accountNo+5+Member")
-      members should contain("invoiceNo+6+Member")
-      members should contain("payment+11+Member")
-      members should not contain ("nonExistentEntity+8+Member")
+      memberLineNumberAndTypeMapping("firstName") shouldBe (/* line number */ "5", "Member")
+      memberLineNumberAndTypeMapping("accountNo") shouldBe (/* line number */ "5", "Member")
+      memberLineNumberAndTypeMapping("invoiceNo") shouldBe (/* line number */ "6", "Member")
+      memberLineNumberAndTypeMapping("payment") shouldBe (/* line number */ "11", "Member")
+      memberLineNumberAndTypeMapping.contains("nonExistentField") shouldBe false
 
       // All identifiers generated via MD5 should be unique
       uniqueIdentifiers.size shouldBe uniqueIdentifiers.distinct.size

--- a/src/test/scala/ai/privado/languageEngine/java/audit/DataElementDiscoveryTest.scala
+++ b/src/test/scala/ai/privado/languageEngine/java/audit/DataElementDiscoveryTest.scala
@@ -95,17 +95,17 @@ class DataElementDiscoveryTest extends DataElementDiscoveryTestBase {
     }
 
     "Test final discovery result" in {
-      val classNameList    = new mutable.HashSet[String]()
-      val fileScoreList    = new mutable.HashSet[String]()
-      val memberList       = new mutable.HashSet[String]()
-      val sourceRuleIdMap  = new mutable.HashMap[String, String]()
-      val collectionTagMap = new mutable.HashMap[String, String]()
-      val endpointMap      = new mutable.HashMap[String, String]()
-      val methodNameMap    = new mutable.HashMap[String, String]()
+      val classNameList     = new mutable.HashSet[String]()
+      val fileScoreList     = new mutable.HashSet[String]()
+      val memberList        = new mutable.HashSet[String]()
+      val sourceRuleIdMap   = new mutable.HashMap[String, String]()
+      val collectionTagMap  = new mutable.HashMap[String, String]()
+      val endpointMap       = new mutable.HashMap[String, String]()
+      val methodNameMap     = new mutable.HashMap[String, String]()
+      val members           = mutable.HashSet[String]()
+      val uniqueIdentifiers = mutable.ArrayBuffer[String]()
+      val workbookList      = DataElementDiscovery.processDataElementDiscovery(Try(cpg), taggerCache)
 
-      val workbookList = DataElementDiscovery.processDataElementDiscovery(Try(cpg), taggerCache)
-
-      val hs = mutable.HashSet[String]()
       workbookList.foreach(row => {
         classNameList += row.head
         fileScoreList += row(2)
@@ -115,14 +115,18 @@ class DataElementDiscoveryTest extends DataElementDiscoveryTestBase {
         if (!endpointMap.contains(row.head)) endpointMap.put(row.head, row(8))
         if (!methodNameMap.contains(row.head)) methodNameMap.put(row.head, row(9))
         // Bind entity's name to its line number for testing.
-        hs += s"${row(3)}+${row.last}"
+        members += s"${row(3)}+${row(10)}+${row.last}"
+        uniqueIdentifiers += row(11)
       })
 
-      hs should contain("firstName+5")
-      hs should contain("accountNo+5")
-      hs should contain("invoiceNo+6")
-      hs should contain("payment+11")
-      hs should not contain ("nonExistentEntity+8")
+      members should contain("firstName+5+Member")
+      members should contain("accountNo+5+Member")
+      members should contain("invoiceNo+6+Member")
+      members should contain("payment+11+Member")
+      members should not contain ("nonExistentEntity+8+Member")
+
+      // All identifiers generated via MD5 should be unique
+      uniqueIdentifiers.size shouldBe uniqueIdentifiers.distinct.size
 
       // Validate class name in result
       classNameList should contain("com.test.privado.Entity.User")

--- a/src/test/scala/ai/privado/languageEngine/java/audit/DataElementDiscoveryTest.scala
+++ b/src/test/scala/ai/privado/languageEngine/java/audit/DataElementDiscoveryTest.scala
@@ -105,6 +105,7 @@ class DataElementDiscoveryTest extends DataElementDiscoveryTestBase {
 
       val workbookList = DataElementDiscovery.processDataElementDiscovery(Try(cpg), taggerCache)
 
+      val hs = mutable.HashSet[String]()
       workbookList.foreach(row => {
         classNameList += row.head
         fileScoreList += row(2)
@@ -113,7 +114,15 @@ class DataElementDiscoveryTest extends DataElementDiscoveryTestBase {
         if (!collectionTagMap.contains(row.head)) collectionTagMap.put(row.head, row(7))
         if (!endpointMap.contains(row.head)) endpointMap.put(row.head, row(8))
         if (!methodNameMap.contains(row.head)) methodNameMap.put(row.head, row(9))
+        // Bind entity's name to its line number for testing.
+        hs += s"${row(3)}+${row.last}"
       })
+
+      hs should contain("firstName+5")
+      hs should contain("accountNo+5")
+      hs should contain("invoiceNo+6")
+      hs should contain("payment+11")
+      hs should not contain ("nonExistentEntity+8")
 
       // Validate class name in result
       classNameList should contain("com.test.privado.Entity.User")


### PR DESCRIPTION
This PR adds the functionality for recording line numbers when generating audit sources and modifies existing tests accordingly.