### PR TITLE
Add audit sources support for Go and Python

### DIFF
--- a/src/main/scala/ai/privado/languageEngine/go/processor/GoProcessor.scala
+++ b/src/main/scala/ai/privado/languageEngine/go/processor/GoProcessor.scala
@@ -9,13 +9,14 @@ import ai.privado.languageEngine.go.passes.SQLQueryParser
 import ai.privado.languageEngine.go.passes.config.GoYamlLinkerPass
 import ai.privado.languageEngine.go.passes.orm.ORMParserPass
 import ai.privado.languageEngine.go.semantic.Language.tagger
+import ai.privado.languageEngine.java.language.*
 import ai.privado.metric.MetricHandler
 import ai.privado.model.Constants.*
 import ai.privado.model.{CatLevelOne, Constants, Language}
 import ai.privado.passes.*
 import ai.privado.semantic.Language.*
-import ai.privado.utility.{PropertyParserPass, UnresolvedReportUtility}
 import ai.privado.utility.Utilities.createCpgFolder
+import ai.privado.utility.{PropertyParserPass, UnresolvedReportUtility}
 import better.files.File
 import io.joern.dataflowengineoss.layers.dataflows.{OssDataFlow, OssDataFlowOptions}
 import io.joern.gosrc2cpg.{Config, GoSrc2Cpg}
@@ -24,7 +25,6 @@ import io.shiftleft.codepropertygraph
 import io.shiftleft.semanticcpg.language.*
 import io.shiftleft.semanticcpg.layers.LayerCreatorContext
 import org.slf4j.LoggerFactory
-import ai.privado.languageEngine.java.language.*
 
 import java.util.Calendar
 import scala.collection.mutable.ListBuffer
@@ -132,7 +132,8 @@ object GoProcessor {
           if (ScanProcessor.config.generateAuditReport) {
             ExcelExporter.auditExport(
               outputAuditFileName,
-              AuditReportEntryPoint.getAuditWorkbookPy(auditCache, xtocpg, ruleCache),
+              AuditReportEntryPoint
+                .getAuditWorkbookGoAndPy(xtocpg, taggerCache, sourceRepoLocation, auditCache, ruleCache),
               sourceRepoLocation
             ) match {
               case Left(err) =>

--- a/src/main/scala/ai/privado/languageEngine/python/processor/PythonProcessor.scala
+++ b/src/main/scala/ai/privado/languageEngine/python/processor/PythonProcessor.scala
@@ -13,21 +13,13 @@ import ai.privado.languageEngine.python.tagger.PythonS3Tagger
 import ai.privado.metric.MetricHandler
 import ai.privado.model.Constants.*
 import ai.privado.model.{CatLevelOne, Constants, Language}
-import ai.privado.passes.{
-  DBTParserPass,
-  ExperimentalLambdaDataFlowSupportPass,
-  HTMLParserPass,
-  JsonPropertyParserPass,
-  SQLParser,
-  SQLPropertyPass
-}
+import ai.privado.passes.*
 import ai.privado.semantic.Language.*
 import ai.privado.utility.Utilities.createCpgFolder
 import ai.privado.utility.{PropertyParserPass, UnresolvedReportUtility}
 import better.files.File
 import io.joern.dataflowengineoss.layers.dataflows.{OssDataFlow, OssDataFlowOptions}
 import io.joern.pysrc2cpg.*
-import io.joern.pysrc2cpg.PythonImportResolverPass
 import io.joern.x2cpg.X2Cpg
 import io.joern.x2cpg.passes.base.AstLinkerPass
 import io.joern.x2cpg.passes.callgraph.NaiveCallLinker
@@ -35,7 +27,6 @@ import io.shiftleft.codepropertygraph
 import io.shiftleft.semanticcpg.language.*
 import io.shiftleft.semanticcpg.layers.LayerCreatorContext
 import org.slf4j.LoggerFactory
-import io.joern.pysrc2cpg.DynamicTypeHintFullNamePass
 
 import java.nio.file.Paths
 import java.util.Calendar
@@ -163,7 +154,7 @@ object PythonProcessor {
           if (privadoInput.generateAuditReport) {
             ExcelExporter.auditExport(
               outputAuditFileName,
-              AuditReportEntryPoint.getAuditWorkbookPy(auditCache, xtocpg, ruleCache),
+              AuditReportEntryPoint.getAuditWorkbookGoAndPy(xtocpg, taggerCache, sourceRepoLocation, auditCache, ruleCache),
               sourceRepoLocation
             ) match {
               case Left(err) =>

--- a/src/main/scala/ai/privado/languageEngine/python/processor/PythonProcessor.scala
+++ b/src/main/scala/ai/privado/languageEngine/python/processor/PythonProcessor.scala
@@ -4,7 +4,6 @@ import ai.privado.audit.AuditReportEntryPoint
 import ai.privado.cache.*
 import ai.privado.entrypoint.{PrivadoInput, TimeMetric}
 import ai.privado.exporter.{ExcelExporter, JSONExporter}
-import ai.privado.languageEngine.javascript.passes.config.JsConfigPropertyPass
 import ai.privado.languageEngine.python.config.PythonConfigPropertyPass
 import ai.privado.languageEngine.python.passes.PrivadoPythonTypeHintCallLinker
 import ai.privado.languageEngine.python.passes.config.PythonPropertyLinkerPass
@@ -154,7 +153,8 @@ object PythonProcessor {
           if (privadoInput.generateAuditReport) {
             ExcelExporter.auditExport(
               outputAuditFileName,
-              AuditReportEntryPoint.getAuditWorkbookGoAndPy(xtocpg, taggerCache, sourceRepoLocation, auditCache, ruleCache),
+              AuditReportEntryPoint
+                .getAuditWorkbookGoAndPy(xtocpg, taggerCache, sourceRepoLocation, auditCache, ruleCache),
               sourceRepoLocation
             ) match {
               case Left(err) =>

--- a/src/test/scala/ai/privado/languageEngine/go/audit/DataElementDiscoveryTest.scala
+++ b/src/test/scala/ai/privado/languageEngine/go/audit/DataElementDiscoveryTest.scala
@@ -1,0 +1,137 @@
+package ai.privado.languageEngine.go.audit
+
+import ai.privado.audit.{DataElementDiscovery, DataElementDiscoveryJS}
+import ai.privado.languageEngine.go.audit.TestData.AuditTestClassData
+import ai.privado.languageEngine.go.tagger.collection.CollectionTagger
+import ai.privado.languageEngine.go.tagger.source.IdentifierTagger
+import io.shiftleft.codepropertygraph.generated.nodes.Member
+
+import scala.collection.mutable
+import scala.util.Try
+
+class DataElementDiscoveryTest extends DataElementDiscoveryTestBase {
+
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+    new IdentifierTagger(cpg, ruleCache, taggerCache).createAndApply()
+    new CollectionTagger(cpg, ruleCache).createAndApply()
+  }
+
+  override val goFileContentMap: Map[String, String] = getContent()
+
+  def getContent(): Map[String, String] = {
+    val testClassMap = mutable.Map[String, String]()
+
+    testClassMap.put("User", AuditTestClassData.user)
+    testClassMap.put("Account", AuditTestClassData.account)
+    testClassMap.put("Address", AuditTestClassData.address)
+    testClassMap.toMap
+  }
+
+  "DataElementDiscovery" should {
+    "Test discovery of class name in codebase" in {
+      val classNameList = DataElementDiscoveryJS.getSourceUsingRules(Try(cpg))
+
+      classNameList.size shouldBe 4
+      classNameList should contain("entity.User")
+      classNameList should contain("entity.Account")
+      classNameList should contain("entity.Address")
+      classNameList should not contain ("nonExistent.Type")
+    }
+
+    "Test discovery of class Name in package from class name" in {
+      val classList = List("entity.User", "entity.Account")
+
+      val discoveryList = DataElementDiscovery.extractClassFromPackage(Try(cpg), classList.toSet)
+      discoveryList.size shouldBe 4
+      discoveryList should contain("entity.User")
+      discoveryList should contain("entity.Account")
+    }
+
+    "Test class member variable" in {
+      val classList = List("entity.User", "entity.Account")
+
+      val memberMap = DataElementDiscovery.getMemberUsingClassName(Try(cpg), classList.toSet)
+
+      val classMemberMap = new mutable.HashMap[String, List[Member]]()
+
+      memberMap.foreach { case (key, value) =>
+        classMemberMap.put(key.fullName, value)
+      }
+
+      classMemberMap.keys.toList should contain("entity.User")
+      classMemberMap("entity.User").size shouldBe 1
+      classMemberMap("entity.User").head.name should equal("firstName")
+
+      classMemberMap.keys.toList should contain("entity.Account")
+      classMemberMap("entity.Account").size shouldBe 1
+      classMemberMap("entity.Account").head.name should equal("accountNo")
+    }
+
+    "Test final discovery result" in {
+      val classNameList                  = new mutable.HashSet[String]()
+      val fileScoreList                  = new mutable.HashSet[String]()
+      val memberList                     = new mutable.HashSet[String]()
+      val sourceRuleIdMap                = new mutable.HashMap[String, String]()
+      val collectionTagMap               = new mutable.HashMap[String, String]()
+      val endpointMap                    = new mutable.HashMap[String, String]()
+      val methodNameMap                  = new mutable.HashMap[String, String]()
+      val memberLineNumberAndTypeMapping = mutable.HashMap[String, (String, String)]()
+      val workbookList                   = DataElementDiscoveryJS.processDataElementDiscovery(Try(cpg), taggerCache)
+
+      workbookList.foreach(row => {
+        classNameList += row.head
+        fileScoreList += row(2)
+        memberList += row(3)
+
+        memberLineNumberAndTypeMapping += (row(3) -> (row(10), row.last))
+
+        // Prevent overwriting last sane value.
+        if (row(6) != "--") {
+          sourceRuleIdMap.put(row(3), row(6))
+        }
+
+        if (!collectionTagMap.contains(row.head)) collectionTagMap.put(row.head, row(7))
+        if (!endpointMap.contains(row.head)) endpointMap.put(row.head, row(8))
+        if (!methodNameMap.contains(row.head)) methodNameMap.put(row.head, row(9))
+      })
+
+      memberLineNumberAndTypeMapping("firstName") shouldBe (/* line number */ "5", "Member")
+      memberLineNumberAndTypeMapping("fName") shouldBe (/* line number */ "13", "Identifier")
+      memberLineNumberAndTypeMapping("accountNo") shouldBe (/* line number */ "5", "Member")
+      memberLineNumberAndTypeMapping("accNo") shouldBe (/* line number */ "9", "Identifier")
+      memberLineNumberAndTypeMapping("houseNo") shouldBe (/* line number */ "5", "Member")
+      memberLineNumberAndTypeMapping.contains("nonExistentField") shouldBe false
+
+      // Validate class name in result
+      classNameList should contain("entity.User")
+      classNameList should contain("entity.Account")
+      classNameList should contain("entity.Address")
+
+      classNameList should not contain ("nonExistent.Type")
+
+      // Validate class member in result
+      memberList should contain("firstName")
+      memberList should contain("accountNo")
+      memberList should contain("houseNo")
+      memberList should not contain ("nonExistentMember")
+
+      fileScoreList should contain("1.5")
+
+      // validate source Rule ID in result
+      sourceRuleIdMap("firstName") should equal("Data.Sensitive.FirstName")
+    }
+
+    "Test file score " in {
+      DataElementDiscoveryJS.getFileScoreJS("User.go", Try(cpg)) shouldBe "1.5"
+    }
+
+    "filter the class having no member" in {
+      val classList = List("nonExistent.Type", "entity.Address")
+      val memberMap = DataElementDiscovery.getMemberUsingClassName(Try(cpg), classList.toSet)
+
+      memberMap.size shouldBe 1
+      memberMap.headOption.get._1.fullName should equal("entity.Address")
+    }
+  }
+}

--- a/src/test/scala/ai/privado/languageEngine/go/audit/DataElementDiscoveryTestBase.scala
+++ b/src/test/scala/ai/privado/languageEngine/go/audit/DataElementDiscoveryTestBase.scala
@@ -1,0 +1,77 @@
+package ai.privado.languageEngine.go.audit
+
+import ai.privado.cache.{RuleCache, TaggerCache}
+import ai.privado.model.*
+import better.files.File
+import io.joern.gosrc2cpg.{Config, GoSrc2Cpg}
+import io.joern.x2cpg.X2Cpg.applyDefaultOverlays
+import io.shiftleft.codepropertygraph.generated.Cpg
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+import scala.compiletime.uninitialized
+
+abstract class DataElementDiscoveryTestBase extends AnyWordSpec with Matchers with BeforeAndAfterAll {
+
+  var cpg: Cpg = uninitialized
+  val goFileContentMap: Map[String, String]
+  var inputDir: File  = uninitialized
+  var outputDir: File = uninitialized
+  val ruleCache       = new RuleCache()
+
+  override def beforeAll(): Unit = {
+    inputDir = File.newTemporaryDirectory()
+    for ((key, content) <- goFileContentMap) {
+      (inputDir / s"$key.go").write(content)
+    }
+
+    outputDir = File.newTemporaryDirectory()
+
+    val config = Config(fetchDependencies = true)
+      .withInputPath(inputDir.pathAsString)
+      .withOutputPath(outputDir.pathAsString)
+    val goSrc2Cpg = new GoSrc2Cpg(None)
+    val xtocpg = goSrc2Cpg.createCpg(config).map { cpg =>
+      applyDefaultOverlays(cpg)
+      cpg
+    }
+
+    cpg = xtocpg.get
+
+    ruleCache.setRule(rule)
+    super.beforeAll()
+  }
+
+  override def afterAll(): Unit = {
+    inputDir.delete()
+    cpg.close()
+    outputDir.delete()
+    super.afterAll()
+  }
+
+  val sourceRule: List[RuleInfo] = List(
+    RuleInfo(
+      "Data.Sensitive.FirstName",
+      "FirstName",
+      "",
+      FilterProperty.METHOD_FULL_NAME,
+      Array(),
+      List("(?i).*firstName.*"),
+      false,
+      "",
+      Map(),
+      NodeType.REGULAR,
+      "",
+      CatLevelOne.SOURCES,
+      "",
+      Language.GO,
+      Array()
+    )
+  )
+
+  val rule: ConfigAndRules =
+    ConfigAndRules(sourceRule, List(), List(), List(), List(), List(), List(), List(), List(), List())
+
+  val taggerCache = new TaggerCache()
+}

--- a/src/test/scala/ai/privado/languageEngine/go/audit/TestData/AuditTestClassData.scala
+++ b/src/test/scala/ai/privado/languageEngine/go/audit/TestData/AuditTestClassData.scala
@@ -1,0 +1,43 @@
+package ai.privado.languageEngine.go.audit.TestData
+
+object AuditTestClassData {
+  val user: String = """
+      |package entity
+      |
+      |type User struct {
+      |	firstName string
+      |}
+      |
+      |func (u User) getFirstName() string {
+      |	return u.firstName
+      |}
+      |
+      |func (u *User) setFirstName(fName string) {
+      |	u.firstName = fName
+      |}
+      |""".stripMargin
+
+  val account: String = """
+      |package entity
+      |
+      |type Account struct {
+      |	accountNo string
+      |}
+      |
+      |func (a *Account) setAccountNo(accNo string) {
+      |	a.accountNo = accNo;
+      |}
+      |""".stripMargin
+
+  val address: String = """
+        |package entity
+        |
+        |type Address struct {
+        |	houseNo string
+        |}
+        |
+        |func (a Address) getHouseNo() string {
+        |	return a.houseNo;
+        |}
+        |""".stripMargin
+}

--- a/src/test/scala/ai/privado/languageEngine/python/audit/DataElementDiscoveryTest.scala
+++ b/src/test/scala/ai/privado/languageEngine/python/audit/DataElementDiscoveryTest.scala
@@ -1,0 +1,139 @@
+package ai.privado.languageEngine.python.audit
+
+import ai.privado.audit.{DataElementDiscovery, DataElementDiscoveryJS}
+import ai.privado.languageEngine.python.audit.TestData.AuditTestClassData
+import ai.privado.languageEngine.python.tagger.collection.CollectionTagger
+import ai.privado.languageEngine.python.tagger.source.IdentifierTagger
+import io.shiftleft.codepropertygraph.generated.nodes.Member
+
+import scala.collection.mutable
+import scala.util.Try
+
+class DataElementDiscoveryTest extends DataElementDiscoveryTestBase {
+
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+    new IdentifierTagger(cpg, ruleCache, taggerCache).createAndApply()
+    new CollectionTagger(cpg, ruleCache).createAndApply()
+  }
+
+  override val pyFileContentMap: Map[String, String] = getContent()
+
+  def getContent(): Map[String, String] = {
+    val testClassMap = mutable.Map[String, String]()
+
+    testClassMap.put("User", AuditTestClassData.user)
+    testClassMap.put("Account", AuditTestClassData.account)
+    testClassMap.put("Address", AuditTestClassData.address)
+    testClassMap.toMap
+  }
+
+  "DataElementDiscovery" should {
+    "Test discovery of class name in codebase" in {
+      val classNameList = DataElementDiscoveryJS.getSourceUsingRules(Try(cpg))
+
+      classNameList should contain("User.py:<module>.User")
+      classNameList should contain("Account.py:<module>.Account")
+      classNameList should contain("Address.py:<module>.Address")
+      classNameList should not contain ("NonExistent.py:<module>.NonExistent")
+    }
+
+    "Test discovery of class Name in package from class name" in {
+      val classList = List("User.py:<module>.User", "Account.py:<module>.Account")
+
+      val discoveryList = DataElementDiscovery.extractClassFromPackage(Try(cpg), classList.toSet)
+      discoveryList should contain("User.py:<module>.User")
+      discoveryList should contain("Account.py:<module>.Account")
+    }
+
+    "Test class member variable" in {
+      val classList = List("User.py:<module>.User", "Account.py:<module>.Account")
+
+      val memberMap = DataElementDiscovery.getMemberUsingClassName(Try(cpg), classList.toSet)
+
+      val classMemberMap = new mutable.HashMap[String, List[Member]]()
+
+      memberMap.foreach { case (key, value) =>
+        classMemberMap.put(key.fullName, value)
+      }
+
+      classMemberMap.keys.toList should contain("User.py:<module>.User")
+
+      // __init__, field, getter, setter
+      classMemberMap("User.py:<module>.User").size shouldBe 4
+      classMemberMap("User.py:<module>.User").last.name should equal("setFirstName")
+
+      classMemberMap.keys.toList should contain("Account.py:<module>.Account")
+
+      // __init__, field, setter
+      classMemberMap("Account.py:<module>.Account").size shouldBe 3
+      classMemberMap("Account.py:<module>.Account").last.name should equal("setAccountNo")
+    }
+
+    "Test final discovery result" in {
+      val classNameList                  = new mutable.HashSet[String]()
+      val fileScoreList                  = new mutable.HashSet[String]()
+      val memberList                     = new mutable.HashSet[String]()
+      val sourceRuleIdMap                = new mutable.HashMap[String, String]()
+      val collectionTagMap               = new mutable.HashMap[String, String]()
+      val endpointMap                    = new mutable.HashMap[String, String]()
+      val methodNameMap                  = new mutable.HashMap[String, String]()
+      val memberLineNumberAndTypeMapping = mutable.HashMap[String, (String, String)]()
+      val workbookList                   = DataElementDiscoveryJS.processDataElementDiscovery(Try(cpg), taggerCache)
+
+      workbookList.foreach(row => {
+        classNameList += row.head
+        fileScoreList += row(2)
+        memberList += row(3)
+
+        memberLineNumberAndTypeMapping += (row(3) -> (row(10), row.last))
+
+        // Prevent overwriting last sane value.
+        if (row(6) != "--") {
+          sourceRuleIdMap.put(row(3), row(6))
+        }
+
+        if (!collectionTagMap.contains(row.head)) collectionTagMap.put(row.head, row(7))
+        if (!endpointMap.contains(row.head)) endpointMap.put(row.head, row(8))
+        if (!methodNameMap.contains(row.head)) methodNameMap.put(row.head, row(9))
+      })
+
+      memberLineNumberAndTypeMapping("firstName") shouldBe (/* line number */ "4", "Member")
+      memberLineNumberAndTypeMapping("fName") shouldBe (/* line number */ "4", "Identifier")
+      memberLineNumberAndTypeMapping("accountNo") shouldBe (/* line number */ "4", "Member")
+      memberLineNumberAndTypeMapping("fName") shouldBe (/* line number */ "4", "Identifier")
+      memberLineNumberAndTypeMapping("houseNo") shouldBe (/* line number */ "4", "Member")
+      memberLineNumberAndTypeMapping("hNo") shouldBe (/* line number */ "4", "Identifier")
+      memberLineNumberAndTypeMapping.contains("nonExistentField") shouldBe false
+
+      // Validate class name in result
+      classNameList should contain("User.py:<module>.User")
+      classNameList should contain("Account.py:<module>.Account")
+      classNameList should contain("Address.py:<module>.Address")
+      classNameList should not contain ("NonExistent.py:<module>.NonExistent")
+
+      // Validate class member in result
+      memberList should contain("firstName")
+      memberList should contain("accountNo")
+      memberList should contain("houseNo")
+      memberList should not contain ("nonExistentMember")
+
+      fileScoreList should contain("1.5")
+
+      // validate source Rule ID in result
+      sourceRuleIdMap("firstName") should equal("Data.Sensitive.FirstName")
+    }
+
+    "Test file score " in {
+      DataElementDiscoveryJS.getFileScoreJS("User.py", Try(cpg)) shouldBe "1.5"
+    }
+
+    "filter the class having no member" in {
+      val classList = List("NonExistent.py:<module>.NonExistent", "Address.py:<module>.Address")
+      val memberMap = DataElementDiscovery.getMemberUsingClassName(Try(cpg), classList.toSet)
+
+      memberMap.size shouldBe 1
+      memberMap.headOption.get._1.fullName should equal("Address.py:<module>.Address")
+    }
+  }
+}

--- a/src/test/scala/ai/privado/languageEngine/python/audit/DataElementDiscoveryTestBase.scala
+++ b/src/test/scala/ai/privado/languageEngine/python/audit/DataElementDiscoveryTestBase.scala
@@ -1,0 +1,77 @@
+package ai.privado.languageEngine.python.audit
+
+import ai.privado.cache.{RuleCache, TaggerCache}
+import ai.privado.model.*
+import better.files.File
+import io.joern.pysrc2cpg.{Py2CpgOnFileSystem, Py2CpgOnFileSystemConfig}
+import io.shiftleft.codepropertygraph.generated.Cpg
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+import scala.compiletime.uninitialized
+
+abstract class DataElementDiscoveryTestBase extends AnyWordSpec with Matchers with BeforeAndAfterAll {
+
+  var cpg: Cpg = uninitialized
+  val pyFileContentMap: Map[String, String]
+  var inputDir: File  = uninitialized
+  var outputDir: File = uninitialized
+  val ruleCache       = new RuleCache()
+
+  override def beforeAll(): Unit = {
+    inputDir = File.newTemporaryDirectory()
+    for ((key, content) <- pyFileContentMap) {
+      (inputDir / s"$key.py").write(content)
+    }
+
+    outputDir = File.newTemporaryDirectory()
+
+    val excludeFileRegex = ruleCache.getExclusionRegex
+    val config = Py2CpgOnFileSystemConfig(Option(File(".venv").path), ignoreVenvDir = true)
+      .withInputPath(inputDir.toString)
+      .withOutputPath(outputDir.toString)
+      .withIgnoredFilesRegex(excludeFileRegex)
+
+    val xtocpg = new Py2CpgOnFileSystem().createCpg(config).map { cpg =>
+      cpg
+    }
+
+    cpg = xtocpg.get
+
+    ruleCache.setRule(rule)
+    super.beforeAll()
+  }
+
+  override def afterAll(): Unit = {
+    inputDir.delete()
+    cpg.close()
+    outputDir.delete()
+    super.afterAll()
+  }
+
+  val sourceRule: List[RuleInfo] = List(
+    RuleInfo(
+      "Data.Sensitive.FirstName",
+      "FirstName",
+      "",
+      FilterProperty.METHOD_FULL_NAME,
+      Array(),
+      List("(?i).*firstName.*"),
+      false,
+      "",
+      Map(),
+      NodeType.REGULAR,
+      "",
+      CatLevelOne.SOURCES,
+      "",
+      Language.GO,
+      Array()
+    )
+  )
+
+  val rule: ConfigAndRules =
+    ConfigAndRules(sourceRule, List(), List(), List(), List(), List(), List(), List(), List(), List())
+
+  val taggerCache = new TaggerCache()
+}

--- a/src/test/scala/ai/privado/languageEngine/python/audit/TestData/AuditTestClassData.scala
+++ b/src/test/scala/ai/privado/languageEngine/python/audit/TestData/AuditTestClassData.scala
@@ -1,0 +1,33 @@
+package ai.privado.languageEngine.python.audit.TestData
+
+object AuditTestClassData {
+  val user: String = """
+      |class User:
+      |  def __init__(self, fName):
+      |    self.firstName = fName
+      |
+      |  def getFirstName(self):
+      |    return self.firstName
+      |  
+      |  def setFirstName(self, fName):
+      |    self.firstName = fName
+      |""".stripMargin
+
+  val account: String = """
+      |class Account:
+      |  def __init__(self, accNo):
+      |    self.accountNo = accNo
+      |
+      |  def setAccountNo(self, accNo):
+      |    self.accountNo = accNo
+      |""".stripMargin
+
+  val address: String = """
+      |class Address:
+      |  def __init__(self, hNo):
+      |    self.houseNo = hNo
+      |
+      |  def setHouseNo(self, hNo):
+      |    self.houseNo = hNo
+      |""".stripMargin
+}


### PR DESCRIPTION
Adds audit sources support for Go and Python. Opened a new PR over #1125 as it was outdated and had too many conflicts.