### PR TITLE
Change `updateDependencies.sh` to resolve versions from GH packages

### DIFF
--- a/updateDependencies.sh
+++ b/updateDependencies.sh
@@ -11,7 +11,7 @@ check_installed() {
 
 check_installed curl
 
-# check if xmllint is installed
+# check if jq is installed
 if type jq > /dev/null; then
   USE_JQ=1 #true
 else

--- a/updateDependencies.sh
+++ b/updateDependencies.sh
@@ -29,7 +29,7 @@ function latest_version {
   local NAME=$1
   local REPO_URL=${repos[$NAME]}
   local CURL_PARAMS="--silent --show-error"
-  local TOKEN=$(printenv GITHUB_TOKEN)
+  local TOKEN=$(printenv GITHUB_TOKEN) # important to add this to an environment variable as the package registry is private
 
   if (( $USE_JQ ))
   then


### PR DESCRIPTION
Changes: 
1. Use `jq` instead of `xmllint` to parse response. ( GH Packages works with json )

PS: Would require a GH token in the environment to run this because the package registry is private to an organization. 