### PR TITLE
Update the audit sources support for JS, Python, PHP, Go & CSharp

### DIFF
--- a/src/main/scala/ai/privado/audit/AuditReportConstants.scala
+++ b/src/main/scala/ai/privado/audit/AuditReportConstants.scala
@@ -61,6 +61,8 @@ object AuditReportConstants {
 
   val ELEMENT_DISCOVERY_NODE_TYPE_LOCAL = "Local"
 
+  val ELEMENT_DISCOVERY_NODE_TYPE_FIELD_IDENTIFIER = "FieldIdentifier"
+
   val ELEMENT_DISCOVERY_EXCLUDE_CLASS_NAME_REGEX = "^(.*)(Controller|Service|Impl|Helper|Util|Processor|Dao)$"
 
   val ELEMENT_DISCOVERY_GET_SET_METHOD_REGEX = "^(get|set).*"

--- a/src/main/scala/ai/privado/audit/AuditReportEntryPoint.scala
+++ b/src/main/scala/ai/privado/audit/AuditReportEntryPoint.scala
@@ -141,7 +141,7 @@ object AuditReportEntryPoint {
     workbook
   }
 
-  // Audit report generation for all major lanaguges
+  // Audit report generation for all major languages
   def getAuditWorkbookForLanguage(
     xtocpg: Try[Cpg],
     taggerCache: TaggerCache,
@@ -152,11 +152,10 @@ object AuditReportEntryPoint {
   ): Workbook = {
     val workbook: Workbook = new XSSFWorkbook()
     val dataElementDiscoveryData = lang match {
-      case Language.RUBY | Language.CSHARP =>
-        println(lang)
-        DataElementDiscovery.processDataElementDiscoveryForIdentifierAndFieldIdentfier(xtocpg, true)
+      case Language.RUBY =>
+        DataElementDiscovery.processDataElementDiscoveryForIdentifierAndFieldIdentfier(xtocpg, lang)
       case _ =>
-        DataElementDiscovery.processDataElementDiscovery(xtocpg, taggerCache, lang != Language.GO)
+        DataElementDiscovery.processDataElementDiscovery(xtocpg, taggerCache, lang)
     }
     createDataElementDiscoveryJson(dataElementDiscoveryData, repoPath = repoPath)
     createSheet(workbook, AuditReportConstants.AUDIT_ELEMENT_DISCOVERY_SHEET_NAME, dataElementDiscoveryData)

--- a/src/main/scala/ai/privado/audit/AuditReportEntryPoint.scala
+++ b/src/main/scala/ai/privado/audit/AuditReportEntryPoint.scala
@@ -85,10 +85,10 @@ object AuditReportEntryPoint {
     lang: Language = Language.JAVA
   ): Workbook = {
     lang match {
-      case Language.JAVASCRIPT =>
-        getAuditWorkbookJS(xtocpg, taggerCache, repoPath, auditCache, ruleCache)
-      case Language.GO | Language.PYTHON =>
-        getAuditWorkbookGoAndPy(xtocpg, taggerCache, repoPath, auditCache, ruleCache)
+      case Language.JAVASCRIPT | Language.PHP | Language.CSHARP | Language.PYTHON =>
+        getAuditWorkbookJSAndPy(xtocpg, taggerCache, repoPath, auditCache, ruleCache)
+      case Language.GO =>
+        getAuditWorkbookGo(xtocpg, taggerCache, repoPath, auditCache, ruleCache)
       case Language.JAVA | Language.KOTLIN =>
         getAuditWorkbookJava(xtocpg, taggerCache, dependencies, repoPath, auditCache, ruleCache)
       case _ =>
@@ -107,7 +107,7 @@ object AuditReportEntryPoint {
   ): Workbook = {
     val workbook: Workbook = new XSSFWorkbook()
     // Set Element Discovery Data into Sheet
-    val dataElementDiscoveryData = DataElementDiscovery.processDataElementDiscovery(xtocpg, taggerCache)
+    val dataElementDiscoveryData = DataElementDiscoveryJava.processDataElementDiscovery(xtocpg, taggerCache)
     createDataElementDiscoveryJson(dataElementDiscoveryData, repoPath)
     createSheet(workbook, AuditReportConstants.AUDIT_ELEMENT_DISCOVERY_SHEET_NAME, dataElementDiscoveryData)
     // Changed Background colour when tagged
@@ -143,7 +143,7 @@ object AuditReportEntryPoint {
     workbook
   }
 
-  def getAuditWorkbookGoAndPy(
+  def getAuditWorkbookGo(
     xtocpg: Try[Cpg],
     taggerCache: TaggerCache,
     repoPath: String,
@@ -151,7 +151,7 @@ object AuditReportEntryPoint {
     ruleCache: RuleCache
   ): Workbook = {
     val workbook: Workbook       = new XSSFWorkbook()
-    val dataElementDiscoveryData = DataElementDiscoveryJS.processDataElementDiscovery(xtocpg, taggerCache)
+    val dataElementDiscoveryData = DataElementDiscovery.processDataElementDiscovery(xtocpg, taggerCache, false)
     createDataElementDiscoveryJson(dataElementDiscoveryData, repoPath = repoPath)
     createSheet(workbook, AuditReportConstants.AUDIT_ELEMENT_DISCOVERY_SHEET_NAME, dataElementDiscoveryData)
     // Changed Background colour when tagged
@@ -173,7 +173,7 @@ object AuditReportEntryPoint {
   }
 
   // Audit report generation for Python and javaScript
-  def getAuditWorkbookJS(
+  def getAuditWorkbookJSAndPy(
     xtocpg: Try[Cpg],
     taggerCache: TaggerCache,
     repoPath: String,
@@ -181,7 +181,7 @@ object AuditReportEntryPoint {
     ruleCache: RuleCache
   ): Workbook = {
     val workbook: Workbook       = new XSSFWorkbook()
-    val dataElementDiscoveryData = DataElementDiscoveryJS.processDataElementDiscovery(xtocpg, taggerCache)
+    val dataElementDiscoveryData = DataElementDiscovery.processDataElementDiscovery(xtocpg, taggerCache)
 
     createDataElementDiscoveryJson(dataElementDiscoveryData, repoPath = repoPath)
     createSheet(workbook, AuditReportConstants.AUDIT_ELEMENT_DISCOVERY_SHEET_NAME, dataElementDiscoveryData)

--- a/src/main/scala/ai/privado/audit/AuditReportEntryPoint.scala
+++ b/src/main/scala/ai/privado/audit/AuditReportEntryPoint.scala
@@ -88,57 +88,10 @@ object AuditReportEntryPoint {
       case Language.JAVASCRIPT | Language.PHP | Language.CSHARP | Language.PYTHON | Language.GO | Language.RUBY =>
         getAuditWorkbookForLanguage(xtocpg, taggerCache, repoPath, auditCache, ruleCache, lang)
       case Language.JAVA | Language.KOTLIN =>
-        getAuditWorkbookJava(xtocpg, taggerCache, dependencies, repoPath, auditCache, ruleCache)
+        getAuditWorkbookForLanguage(xtocpg, taggerCache, repoPath, auditCache, ruleCache, lang, dependencies)
       case _ =>
         new XSSFWorkbook()
     }
-  }
-
-  // Audit report generation for java
-  def getAuditWorkbookJava(
-    xtocpg: Try[Cpg],
-    taggerCache: TaggerCache,
-    dependencies: Set[ModuleDependency],
-    repoPath: String,
-    auditCache: AuditCache,
-    ruleCache: RuleCache
-  ): Workbook = {
-    val workbook: Workbook = new XSSFWorkbook()
-    // Set Element Discovery Data into Sheet
-    val dataElementDiscoveryData = DataElementDiscoveryJava.processDataElementDiscovery(xtocpg, taggerCache)
-    createDataElementDiscoveryJson(dataElementDiscoveryData, repoPath)
-    createSheet(workbook, AuditReportConstants.AUDIT_ELEMENT_DISCOVERY_SHEET_NAME, dataElementDiscoveryData)
-    // Changed Background colour when tagged
-    changeTaggedBackgroundColour(workbook, List(4, 6))
-
-    // Set Dependency Report data into Sheet
-    createSheet(
-      workbook,
-      AuditReportConstants.AUDIT_DEPENDENCY_SHEET_NAME,
-      DependencyReport.processDependencyAudit(dependencies)
-    )
-
-    // Set Data Flow report into Sheet
-    createSheet(
-      workbook,
-      AuditReportConstants.AUDIT_DATA_FLOW_SHEET_NAME,
-      DataFlowReport.processDataFlowAudit(auditCache)
-    )
-
-    // Set Unresolved flow into Sheet
-    createSheet(
-      workbook,
-      AuditReportConstants.AUDIT_UNRESOLVED_SHEET_NAME,
-      UnresolvedFlowReport.processUnresolvedFlow(auditCache)
-    )
-
-    createSheet(workbook, AuditReportConstants.AUDIT_URL_SHEET_NAME, LiteralReport.processURLAudit(xtocpg))
-
-    createSheet(workbook, AuditReportConstants.AUDIT_HTTP_SHEET_NAME, LiteralReport.processHTTPAudit(xtocpg))
-
-    createSheet(workbook, AuditReportConstants.AUDIT_API_SHEET_NAME, APIReport.processAPIAudit(xtocpg, ruleCache))
-
-    workbook
   }
 
   // Audit report generation for all major languages
@@ -148,17 +101,22 @@ object AuditReportEntryPoint {
     repoPath: String,
     auditCache: AuditCache,
     ruleCache: RuleCache,
-    lang: Language
+    lang: Language,
+    dependencies: Set[ModuleDependency] = Set()
   ): Workbook = {
     val workbook: Workbook = new XSSFWorkbook()
     val dataElementDiscoveryData = lang match {
+      case Language.JAVA | Language.KOTLIN =>
+        DataElementDiscoveryJava.processDataElementDiscovery(xtocpg, taggerCache)
       case Language.RUBY =>
         DataElementDiscovery.processDataElementDiscoveryForIdentifierAndFieldIdentfier(xtocpg, lang)
       case _ =>
         DataElementDiscovery.processDataElementDiscovery(xtocpg, taggerCache, lang)
     }
     createDataElementDiscoveryJson(dataElementDiscoveryData, repoPath = repoPath)
+
     createSheet(workbook, AuditReportConstants.AUDIT_ELEMENT_DISCOVERY_SHEET_NAME, dataElementDiscoveryData)
+
     // Changed Background colour when tagged
     changeTaggedBackgroundColour(workbook, List(4, 6))
     createSheet(
@@ -172,6 +130,22 @@ object AuditReportEntryPoint {
     createSheet(workbook, AuditReportConstants.AUDIT_HTTP_SHEET_NAME, LiteralReport.processHTTPAudit(xtocpg))
 
     createSheet(workbook, AuditReportConstants.AUDIT_API_SHEET_NAME, APIReport.processAPIAudit(xtocpg, ruleCache))
+
+    if (lang == Language.JAVA || lang == Language.KOTLIN) {
+      // Set Unresolved flow into Sheet
+      createSheet(
+        workbook,
+        AuditReportConstants.AUDIT_UNRESOLVED_SHEET_NAME,
+        UnresolvedFlowReport.processUnresolvedFlow(auditCache)
+      )
+
+      // Set Dependency Report data into Sheet
+      createSheet(
+        workbook,
+        AuditReportConstants.AUDIT_DEPENDENCY_SHEET_NAME,
+        DependencyReport.processDependencyAudit(dependencies)
+      )
+    }
 
     workbook
   }

--- a/src/main/scala/ai/privado/languageEngine/go/processor/GoProcessor.scala
+++ b/src/main/scala/ai/privado/languageEngine/go/processor/GoProcessor.scala
@@ -133,7 +133,7 @@ object GoProcessor {
             ExcelExporter.auditExport(
               outputAuditFileName,
               AuditReportEntryPoint
-                .getAuditWorkbookGoAndPy(xtocpg, taggerCache, sourceRepoLocation, auditCache, ruleCache),
+                .getAuditWorkbookGo(xtocpg, taggerCache, sourceRepoLocation, auditCache, ruleCache),
               sourceRepoLocation
             ) match {
               case Left(err) =>

--- a/src/main/scala/ai/privado/languageEngine/go/processor/GoProcessor.scala
+++ b/src/main/scala/ai/privado/languageEngine/go/processor/GoProcessor.scala
@@ -133,7 +133,14 @@ object GoProcessor {
             ExcelExporter.auditExport(
               outputAuditFileName,
               AuditReportEntryPoint
-                .getAuditWorkbookGo(xtocpg, taggerCache, sourceRepoLocation, auditCache, ruleCache),
+                .getAuditWorkbookForLanguage(
+                  xtocpg,
+                  taggerCache,
+                  sourceRepoLocation,
+                  auditCache,
+                  ruleCache,
+                  Language.GO
+                ),
               sourceRepoLocation
             ) match {
               case Left(err) =>

--- a/src/main/scala/ai/privado/languageEngine/python/processor/PythonProcessor.scala
+++ b/src/main/scala/ai/privado/languageEngine/python/processor/PythonProcessor.scala
@@ -154,7 +154,7 @@ object PythonProcessor {
             ExcelExporter.auditExport(
               outputAuditFileName,
               AuditReportEntryPoint
-                .getAuditWorkbookGoAndPy(xtocpg, taggerCache, sourceRepoLocation, auditCache, ruleCache),
+                .getAuditWorkbookJSAndPy(xtocpg, taggerCache, sourceRepoLocation, auditCache, ruleCache),
               sourceRepoLocation
             ) match {
               case Left(err) =>

--- a/src/main/scala/ai/privado/languageEngine/python/processor/PythonProcessor.scala
+++ b/src/main/scala/ai/privado/languageEngine/python/processor/PythonProcessor.scala
@@ -154,7 +154,14 @@ object PythonProcessor {
             ExcelExporter.auditExport(
               outputAuditFileName,
               AuditReportEntryPoint
-                .getAuditWorkbookJSAndPy(xtocpg, taggerCache, sourceRepoLocation, auditCache, ruleCache),
+                .getAuditWorkbookForLanguage(
+                  xtocpg,
+                  taggerCache,
+                  sourceRepoLocation,
+                  auditCache,
+                  ruleCache,
+                  Language.PYTHON
+                ),
               sourceRepoLocation
             ) match {
               case Left(err) =>

--- a/src/test/scala/ai/privado/languageEngine/go/audit/DataElementDiscoveryTest.scala
+++ b/src/test/scala/ai/privado/languageEngine/go/audit/DataElementDiscoveryTest.scala
@@ -5,6 +5,7 @@ import ai.privado.languageEngine.go.audit.TestData.AuditTestClassData
 import ai.privado.languageEngine.go.tagger.collection.CollectionTagger
 import ai.privado.languageEngine.go.tagger.source.IdentifierTagger
 import io.shiftleft.codepropertygraph.generated.nodes.Member
+import ai.privado.model.Language
 
 import scala.collection.mutable
 import scala.util.Try
@@ -42,7 +43,7 @@ class DataElementDiscoveryTest extends DataElementDiscoveryTestBase {
     "Test class member variable" in {
       val classList = List("entity.User", "entity.Account")
 
-      val memberMap = DataElementDiscoveryUtils.getMemberUsingClassName(Try(cpg), classList.toSet)
+      val memberMap = DataElementDiscoveryUtils.getMemberUsingClassName(Try(cpg), classList.toSet, Language.GO)
 
       val classMemberMap = new mutable.HashMap[String, List[Member]]()
 
@@ -68,7 +69,7 @@ class DataElementDiscoveryTest extends DataElementDiscoveryTestBase {
       val endpointMap                    = new mutable.HashMap[String, String]()
       val methodNameMap                  = new mutable.HashMap[String, String]()
       val memberLineNumberAndTypeMapping = mutable.HashMap[String, (String, String)]()
-      val workbookList = DataElementDiscovery.processDataElementDiscovery(Try(cpg), taggerCache, false)
+      val workbookList = DataElementDiscovery.processDataElementDiscovery(Try(cpg), taggerCache, Language.GO)
 
       workbookList.foreach(row => {
         classNameList += row.head
@@ -107,8 +108,6 @@ class DataElementDiscoveryTest extends DataElementDiscoveryTestBase {
       memberList should contain("houseNo")
       memberList should not contain ("nonExistentMember")
 
-      fileScoreList should contain("1.5")
-
       // validate source Rule ID in result
       sourceRuleIdMap("firstName") should equal("Data.Sensitive.FirstName")
     }
@@ -119,7 +118,7 @@ class DataElementDiscoveryTest extends DataElementDiscoveryTestBase {
 
     "filter the class having no member" in {
       val classList = List("nonExistent.Type", "entity.Address")
-      val memberMap = DataElementDiscoveryUtils.getMemberUsingClassName(Try(cpg), classList.toSet)
+      val memberMap = DataElementDiscoveryUtils.getMemberUsingClassName(Try(cpg), classList.toSet, Language.GO)
 
       memberMap.size shouldBe 1
       memberMap.headOption.get._1.fullName should equal("entity.Address")

--- a/src/test/scala/ai/privado/languageEngine/go/audit/DataElementDiscoveryTest.scala
+++ b/src/test/scala/ai/privado/languageEngine/go/audit/DataElementDiscoveryTest.scala
@@ -1,6 +1,6 @@
 package ai.privado.languageEngine.go.audit
 
-import ai.privado.audit.{DataElementDiscovery, DataElementDiscoveryJS}
+import ai.privado.audit.{DataElementDiscovery, DataElementDiscoveryUtils}
 import ai.privado.languageEngine.go.audit.TestData.AuditTestClassData
 import ai.privado.languageEngine.go.tagger.collection.CollectionTagger
 import ai.privado.languageEngine.go.tagger.source.IdentifierTagger
@@ -30,7 +30,7 @@ class DataElementDiscoveryTest extends DataElementDiscoveryTestBase {
 
   "DataElementDiscovery" should {
     "Test discovery of class name in codebase" in {
-      val classNameList = DataElementDiscoveryJS.getSourceUsingRules(Try(cpg))
+      val classNameList = DataElementDiscoveryUtils.getSourceUsingRules(Try(cpg))
 
       classNameList.size shouldBe 4
       classNameList should contain("entity.User")
@@ -39,19 +39,10 @@ class DataElementDiscoveryTest extends DataElementDiscoveryTestBase {
       classNameList should not contain ("nonExistent.Type")
     }
 
-    "Test discovery of class Name in package from class name" in {
-      val classList = List("entity.User", "entity.Account")
-
-      val discoveryList = DataElementDiscovery.extractClassFromPackage(Try(cpg), classList.toSet)
-      discoveryList.size shouldBe 4
-      discoveryList should contain("entity.User")
-      discoveryList should contain("entity.Account")
-    }
-
     "Test class member variable" in {
       val classList = List("entity.User", "entity.Account")
 
-      val memberMap = DataElementDiscovery.getMemberUsingClassName(Try(cpg), classList.toSet)
+      val memberMap = DataElementDiscoveryUtils.getMemberUsingClassName(Try(cpg), classList.toSet)
 
       val classMemberMap = new mutable.HashMap[String, List[Member]]()
 
@@ -77,7 +68,7 @@ class DataElementDiscoveryTest extends DataElementDiscoveryTestBase {
       val endpointMap                    = new mutable.HashMap[String, String]()
       val methodNameMap                  = new mutable.HashMap[String, String]()
       val memberLineNumberAndTypeMapping = mutable.HashMap[String, (String, String)]()
-      val workbookList                   = DataElementDiscoveryJS.processDataElementDiscovery(Try(cpg), taggerCache)
+      val workbookList = DataElementDiscovery.processDataElementDiscovery(Try(cpg), taggerCache, false)
 
       workbookList.foreach(row => {
         classNameList += row.head
@@ -123,12 +114,12 @@ class DataElementDiscoveryTest extends DataElementDiscoveryTestBase {
     }
 
     "Test file score " in {
-      DataElementDiscoveryJS.getFileScoreJS("User.go", Try(cpg)) shouldBe "1.5"
+      DataElementDiscovery.getFileScoreJS("User.go", Try(cpg)) shouldBe "1.5"
     }
 
     "filter the class having no member" in {
       val classList = List("nonExistent.Type", "entity.Address")
-      val memberMap = DataElementDiscovery.getMemberUsingClassName(Try(cpg), classList.toSet)
+      val memberMap = DataElementDiscoveryUtils.getMemberUsingClassName(Try(cpg), classList.toSet)
 
       memberMap.size shouldBe 1
       memberMap.headOption.get._1.fullName should equal("entity.Address")

--- a/src/test/scala/ai/privado/languageEngine/java/audit/DataElementDiscoveryTest.scala
+++ b/src/test/scala/ai/privado/languageEngine/java/audit/DataElementDiscoveryTest.scala
@@ -4,6 +4,7 @@ import ai.privado.languageEngine.java.audit.TestData.AuditTestClassData
 import ai.privado.languageEngine.java.tagger.collection.CollectionTagger
 import ai.privado.languageEngine.java.tagger.source.*
 import io.shiftleft.codepropertygraph.generated.nodes.Member
+import ai.privado.model.Language
 
 import scala.collection.mutable
 import scala.util.Try
@@ -65,7 +66,7 @@ class DataElementDiscoveryTest extends DataElementDiscoveryTestBase {
     "Test class member variable" in {
       val classList = List("com.test.privado.Entity.User", "com.test.privado.Entity.Account")
 
-      val memberMap = DataElementDiscoveryUtils.getMemberUsingClassName(Try(cpg), classList.toSet)
+      val memberMap = DataElementDiscoveryUtils.getMemberUsingClassName(Try(cpg), classList.toSet, Language.JAVA)
 
       val classMemberMap = new mutable.HashMap[String, List[Member]]()
 
@@ -176,7 +177,7 @@ class DataElementDiscoveryTest extends DataElementDiscoveryTestBase {
 
     "filter the class having no member" in {
       val classList = List("com.test.privado.Controller.UserController", "com.test.privado.Entity.Address")
-      val memberMap = DataElementDiscoveryUtils.getMemberUsingClassName(Try(cpg), classList.toSet)
+      val memberMap = DataElementDiscoveryUtils.getMemberUsingClassName(Try(cpg), classList.toSet, Language.JAVA)
 
       memberMap.size shouldBe 1
       memberMap.headOption.get._1.fullName should equal("com.test.privado.Entity.Address")

--- a/src/test/scala/ai/privado/languageEngine/java/audit/DataElementDiscoveryTest.scala
+++ b/src/test/scala/ai/privado/languageEngine/java/audit/DataElementDiscoveryTest.scala
@@ -1,5 +1,5 @@
 package ai.privado.languageEngine.java.audit
-import ai.privado.audit.DataElementDiscovery
+import ai.privado.audit.{DataElementDiscoveryJava, DataElementDiscoveryUtils}
 import ai.privado.languageEngine.java.audit.TestData.AuditTestClassData
 import ai.privado.languageEngine.java.tagger.collection.CollectionTagger
 import ai.privado.languageEngine.java.tagger.source.*
@@ -34,7 +34,7 @@ class DataElementDiscoveryTest extends DataElementDiscoveryTestBase {
 
   "DataElementDiscovery" should {
     "Test discovery of class name in codebase" in {
-      val classNameList = DataElementDiscovery.getSourceUsingRules(Try(cpg))
+      val classNameList = DataElementDiscoveryJava.getSourceUsingRules(Try(cpg))
 
       classNameList.size shouldBe 4
       classNameList should contain("com.test.privado.Entity.User")
@@ -50,7 +50,7 @@ class DataElementDiscoveryTest extends DataElementDiscoveryTestBase {
     "Test discovery of class Name in package from class name" in {
       val classList = List("com.test.privado.Entity.User", "com.test.privado.Entity.Account")
 
-      val discoveryList = DataElementDiscovery.extractClassFromPackage(Try(cpg), classList.toSet)
+      val discoveryList = DataElementDiscoveryJava.extractClassFromPackage(Try(cpg), classList.toSet)
       discoveryList.size shouldBe 5
       discoveryList should contain("com.test.privado.Entity.User")
       discoveryList should contain("com.test.privado.Entity.Account")
@@ -65,7 +65,7 @@ class DataElementDiscoveryTest extends DataElementDiscoveryTestBase {
     "Test class member variable" in {
       val classList = List("com.test.privado.Entity.User", "com.test.privado.Entity.Account")
 
-      val memberMap = DataElementDiscovery.getMemberUsingClassName(Try(cpg), classList.toSet)
+      val memberMap = DataElementDiscoveryUtils.getMemberUsingClassName(Try(cpg), classList.toSet)
 
       val classMemberMap = new mutable.HashMap[String, List[Member]]()
 
@@ -83,7 +83,7 @@ class DataElementDiscoveryTest extends DataElementDiscoveryTestBase {
     }
 
     "Test Collection discovery" in {
-      val collectionList = DataElementDiscovery.getCollectionInputList(Try(cpg))
+      val collectionList = DataElementDiscoveryJava.getCollectionInputList(Try(cpg))
       collectionList should contain("com.test.privado.Entity.User")
       collectionList should not contain ("com.test.privado.Entity.Account")
       collectionList should not contain ("com.test.privado.Entity.Salary")
@@ -104,7 +104,7 @@ class DataElementDiscoveryTest extends DataElementDiscoveryTestBase {
       val methodNameMap                  = new mutable.HashMap[String, String]()
       val memberLineNumberAndTypeMapping = mutable.HashMap[String, (String, String)]()
       val uniqueIdentifiers              = mutable.ArrayBuffer[String]()
-      val workbookList                   = DataElementDiscovery.processDataElementDiscovery(Try(cpg), taggerCache)
+      val workbookList                   = DataElementDiscoveryJava.processDataElementDiscovery(Try(cpg), taggerCache)
 
       workbookList.foreach(row => {
         classNameList += row.head
@@ -120,8 +120,8 @@ class DataElementDiscoveryTest extends DataElementDiscoveryTestBase {
         uniqueIdentifiers += row(11)
       })
 
-      memberLineNumberAndTypeMapping("firstName") shouldBe (/* line number */ "5", "Member")
-      memberLineNumberAndTypeMapping("accountNo") shouldBe (/* line number */ "5", "Member")
+      memberLineNumberAndTypeMapping("firstName") shouldBe (/* line number */ "8", "Identifier")
+      memberLineNumberAndTypeMapping("accountNo") shouldBe (/* line number */ "7", "Identifier")
       memberLineNumberAndTypeMapping("invoiceNo") shouldBe (/* line number */ "6", "Member")
       memberLineNumberAndTypeMapping("payment") shouldBe (/* line number */ "11", "Member")
       memberLineNumberAndTypeMapping.contains("nonExistentField") shouldBe false
@@ -166,17 +166,17 @@ class DataElementDiscoveryTest extends DataElementDiscoveryTestBase {
     }
 
     "Test file score " in {
-      var score = DataElementDiscovery.getFileScore("User.java", Try(cpg))
+      var score = DataElementDiscoveryJava.getFileScore("User.java", Try(cpg))
       score shouldBe "2.0"
 
-      score = DataElementDiscovery.getFileScore("Salary.java", Try(cpg))
+      score = DataElementDiscoveryJava.getFileScore("Salary.java", Try(cpg))
       score shouldBe "0.0"
 
     }
 
     "filter the class having no member" in {
       val classList = List("com.test.privado.Controller.UserController", "com.test.privado.Entity.Address")
-      val memberMap = DataElementDiscovery.getMemberUsingClassName(Try(cpg), classList.toSet)
+      val memberMap = DataElementDiscoveryUtils.getMemberUsingClassName(Try(cpg), classList.toSet)
 
       memberMap.size shouldBe 1
       memberMap.headOption.get._1.fullName should equal("com.test.privado.Entity.Address")

--- a/src/test/scala/ai/privado/languageEngine/python/audit/DataElementDiscoveryTest.scala
+++ b/src/test/scala/ai/privado/languageEngine/python/audit/DataElementDiscoveryTest.scala
@@ -5,6 +5,7 @@ import ai.privado.languageEngine.python.audit.TestData.AuditTestClassData
 import ai.privado.languageEngine.python.tagger.collection.CollectionTagger
 import ai.privado.languageEngine.python.tagger.source.IdentifierTagger
 import io.shiftleft.codepropertygraph.generated.nodes.Member
+import ai.privado.model.Language
 
 import scala.collection.mutable
 import scala.util.Try
@@ -41,7 +42,7 @@ class DataElementDiscoveryTest extends DataElementDiscoveryTestBase {
     "Test class member variable" in {
       val classList = List("User.py:<module>.User", "Account.py:<module>.Account")
 
-      val memberMap = DataElementDiscoveryUtils.getMemberUsingClassName(Try(cpg), classList.toSet)
+      val memberMap = DataElementDiscoveryUtils.getMemberUsingClassName(Try(cpg), classList.toSet, Language.PYTHON)
 
       val classMemberMap = new mutable.HashMap[String, List[Member]]()
 
@@ -71,7 +72,7 @@ class DataElementDiscoveryTest extends DataElementDiscoveryTestBase {
       val endpointMap                    = new mutable.HashMap[String, String]()
       val methodNameMap                  = new mutable.HashMap[String, String]()
       val memberLineNumberAndTypeMapping = mutable.HashMap[String, (String, String)]()
-      val workbookList                   = DataElementDiscovery.processDataElementDiscovery(Try(cpg), taggerCache)
+      val workbookList = DataElementDiscovery.processDataElementDiscovery(Try(cpg), taggerCache, Language.PYTHON)
 
       workbookList.foreach(row => {
         classNameList += row.head
@@ -110,15 +111,13 @@ class DataElementDiscoveryTest extends DataElementDiscoveryTestBase {
       memberList should contain("houseNo")
       memberList should not contain ("nonExistentMember")
 
-      fileScoreList should contain("1.5")
-
       // validate source Rule ID in result
       sourceRuleIdMap("firstName") should equal("Data.Sensitive.FirstName")
     }
 
     "filter the class having no member" in {
       val classList = List("NonExistent.py:<module>.NonExistent", "Address.py:<module>.Address")
-      val memberMap = DataElementDiscoveryUtils.getMemberUsingClassName(Try(cpg), classList.toSet)
+      val memberMap = DataElementDiscoveryUtils.getMemberUsingClassName(Try(cpg), classList.toSet, Language.PYTHON)
 
       memberMap.size shouldBe 1
       memberMap.headOption.get._1.fullName should equal("Address.py:<module>.Address")

--- a/src/test/scala/ai/privado/languageEngine/python/audit/DataElementDiscoveryTest.scala
+++ b/src/test/scala/ai/privado/languageEngine/python/audit/DataElementDiscoveryTest.scala
@@ -1,6 +1,6 @@
 package ai.privado.languageEngine.python.audit
 
-import ai.privado.audit.{DataElementDiscovery, DataElementDiscoveryJS}
+import ai.privado.audit.{DataElementDiscovery, DataElementDiscoveryUtils}
 import ai.privado.languageEngine.python.audit.TestData.AuditTestClassData
 import ai.privado.languageEngine.python.tagger.collection.CollectionTagger
 import ai.privado.languageEngine.python.tagger.source.IdentifierTagger
@@ -30,7 +30,7 @@ class DataElementDiscoveryTest extends DataElementDiscoveryTestBase {
 
   "DataElementDiscovery" should {
     "Test discovery of class name in codebase" in {
-      val classNameList = DataElementDiscoveryJS.getSourceUsingRules(Try(cpg))
+      val classNameList = DataElementDiscoveryUtils.getSourceUsingRules(Try(cpg))
 
       classNameList should contain("User.py:<module>.User")
       classNameList should contain("Account.py:<module>.Account")
@@ -38,18 +38,10 @@ class DataElementDiscoveryTest extends DataElementDiscoveryTestBase {
       classNameList should not contain ("NonExistent.py:<module>.NonExistent")
     }
 
-    "Test discovery of class Name in package from class name" in {
-      val classList = List("User.py:<module>.User", "Account.py:<module>.Account")
-
-      val discoveryList = DataElementDiscovery.extractClassFromPackage(Try(cpg), classList.toSet)
-      discoveryList should contain("User.py:<module>.User")
-      discoveryList should contain("Account.py:<module>.Account")
-    }
-
     "Test class member variable" in {
       val classList = List("User.py:<module>.User", "Account.py:<module>.Account")
 
-      val memberMap = DataElementDiscovery.getMemberUsingClassName(Try(cpg), classList.toSet)
+      val memberMap = DataElementDiscoveryUtils.getMemberUsingClassName(Try(cpg), classList.toSet)
 
       val classMemberMap = new mutable.HashMap[String, List[Member]]()
 
@@ -60,14 +52,14 @@ class DataElementDiscoveryTest extends DataElementDiscoveryTestBase {
       classMemberMap.keys.toList should contain("User.py:<module>.User")
 
       // __init__, field, getter, setter
-      classMemberMap("User.py:<module>.User").size shouldBe 4
-      classMemberMap("User.py:<module>.User").last.name should equal("setFirstName")
+      classMemberMap("User.py:<module>.User").size shouldBe 1
+      classMemberMap("User.py:<module>.User").last.name should equal("firstName")
 
       classMemberMap.keys.toList should contain("Account.py:<module>.Account")
 
       // __init__, field, setter
-      classMemberMap("Account.py:<module>.Account").size shouldBe 3
-      classMemberMap("Account.py:<module>.Account").last.name should equal("setAccountNo")
+      classMemberMap("Account.py:<module>.Account").size shouldBe 1
+      classMemberMap("Account.py:<module>.Account").last.name should equal("accountNo")
     }
 
     "Test final discovery result" in {
@@ -79,7 +71,7 @@ class DataElementDiscoveryTest extends DataElementDiscoveryTestBase {
       val endpointMap                    = new mutable.HashMap[String, String]()
       val methodNameMap                  = new mutable.HashMap[String, String]()
       val memberLineNumberAndTypeMapping = mutable.HashMap[String, (String, String)]()
-      val workbookList                   = DataElementDiscoveryJS.processDataElementDiscovery(Try(cpg), taggerCache)
+      val workbookList                   = DataElementDiscovery.processDataElementDiscovery(Try(cpg), taggerCache)
 
       workbookList.foreach(row => {
         classNameList += row.head
@@ -98,12 +90,12 @@ class DataElementDiscoveryTest extends DataElementDiscoveryTestBase {
         if (!methodNameMap.contains(row.head)) methodNameMap.put(row.head, row(9))
       })
 
-      memberLineNumberAndTypeMapping("firstName") shouldBe (/* line number */ "4", "Member")
-      memberLineNumberAndTypeMapping("fName") shouldBe (/* line number */ "4", "Identifier")
-      memberLineNumberAndTypeMapping("accountNo") shouldBe (/* line number */ "4", "Member")
-      memberLineNumberAndTypeMapping("fName") shouldBe (/* line number */ "4", "Identifier")
-      memberLineNumberAndTypeMapping("houseNo") shouldBe (/* line number */ "4", "Member")
-      memberLineNumberAndTypeMapping("hNo") shouldBe (/* line number */ "4", "Identifier")
+      memberLineNumberAndTypeMapping("firstName") shouldBe (/* line number */ "10", "FieldIdentifier")
+      memberLineNumberAndTypeMapping("fName") shouldBe (/* line number */ "9", "Identifier")
+      memberLineNumberAndTypeMapping("accountNo") shouldBe (/* line number */ "7", "FieldIdentifier")
+      memberLineNumberAndTypeMapping("fName") shouldBe (/* line number */ "9", "Identifier")
+      memberLineNumberAndTypeMapping("houseNo") shouldBe (/* line number */ "7", "FieldIdentifier")
+      memberLineNumberAndTypeMapping("hNo") shouldBe (/* line number */ "6", "Identifier")
       memberLineNumberAndTypeMapping.contains("nonExistentField") shouldBe false
 
       // Validate class name in result
@@ -124,13 +116,9 @@ class DataElementDiscoveryTest extends DataElementDiscoveryTestBase {
       sourceRuleIdMap("firstName") should equal("Data.Sensitive.FirstName")
     }
 
-    "Test file score " in {
-      DataElementDiscoveryJS.getFileScoreJS("User.py", Try(cpg)) shouldBe "1.5"
-    }
-
     "filter the class having no member" in {
       val classList = List("NonExistent.py:<module>.NonExistent", "Address.py:<module>.Address")
-      val memberMap = DataElementDiscovery.getMemberUsingClassName(Try(cpg), classList.toSet)
+      val memberMap = DataElementDiscoveryUtils.getMemberUsingClassName(Try(cpg), classList.toSet)
 
       memberMap.size shouldBe 1
       memberMap.headOption.get._1.fullName should equal("Address.py:<module>.Address")


### PR DESCRIPTION
- For each language what support tobe  added mentioned in doc: https://privado-ai.atlassian.net/wiki/spaces/arc/pages/979009551/DED+Audit+Report+Data
- Add support for the Csharp, PHP, Ruby, Golang & Python
- Moved the common utilities in DataElementDiscoveryUtils
- Created single functions getIdentifiers, getFieldAccessIdentifier, getMemberUsingClassName to add support for those inline
- Added some common filters & language specific filters to remove noise from audit sources.
- Also, handled possibel error comes due to invalid regex pattern in **XX.typeFullName**