### PR TITLE
add support for metadata command

### DIFF
--- a/src/main/scala/ai/privado/entrypoint/CommandParser.scala
+++ b/src/main/scala/ai/privado/entrypoint/CommandParser.scala
@@ -22,6 +22,7 @@
 
 package ai.privado.entrypoint
 
+import ai.privado.entrypoint
 import ai.privado.metric.MetricHandler
 import ai.privado.model.Language
 import io.circe.syntax.EncoderOps
@@ -64,7 +65,12 @@ case class PrivadoInput(
 )
 
 object CommandConstants {
-  val SCAN                                         = "scan"
+  val SCAN        = "scan"
+  val VALIDATE    = "validate"
+  val UPLOAD      = "upload"
+  val UPLOAD_ABBR = "u"
+  val METADATA    = "metadata"
+
   val INTERNAL_CONFIG                              = "internal-config"
   val INTERNAL_CONFIG_ABBR                         = "ic"
   val EXTERNAL_CONFIG                              = "external-config"
@@ -93,11 +99,8 @@ object CommandConstants {
   val ENABLE_API_BY_PARAMETER_ABBR                 = "eabyp"
   val IGNORE_EXCLUDE_RULES                         = "ignore-exclude-rules"
   val IGNORE_EXCLUDE_RULES_ABBR                    = "ier"
-  val UPLOAD                                       = "upload"
-  val UPLOAD_ABBR                                  = "u"
   val SKIP_UPLOAD                                  = "skip-upload"
   val SKIP_UPLOAD_ABBR                             = "su"
-  val VALIDATE                                     = "validate"
   val UNRESOLVED_REPORT                            = "unresolved_report"
   val UNRESOLVED_REPORT_ABBR                       = "ur"
   val TEST_OUTPUT                                  = "test-output"
@@ -126,7 +129,8 @@ object CommandParser {
     Map(
       CommandConstants.SCAN     -> ScanProcessor,
       CommandConstants.UPLOAD   -> UploadProcessor,
-      CommandConstants.VALIDATE -> RuleValidator
+      CommandConstants.VALIDATE -> RuleValidator,
+      CommandConstants.METADATA -> MetadataProcessor
     )
   def parse(args: Array[String]): Option[CommandProcessor] = {
     val builder = OParser.builder[PrivadoInput]
@@ -316,6 +320,20 @@ object CommandParser {
           .required()
           .action((_, c) => c.copy(cmd = c.cmd + CommandConstants.UPLOAD))
           .text("Uploads the result file to Privado.ai UI dashboard.")
+          .children(
+            arg[String]("<Source directory>")
+              .required()
+              .action((x, c) => c.copy(sourceLocation = c.sourceLocation + x))
+              .text("Source code location"),
+            checkConfig(c =>
+              if (c.cmd.isEmpty) failure("")
+              else success
+            )
+          ),
+        cmd(CommandConstants.METADATA)
+          .required()
+          .action((_, c) => c.copy(cmd = c.cmd + CommandConstants.METADATA))
+          .text("Generate metadata for the repository")
           .children(
             arg[String]("<Source directory>")
               .required()

--- a/src/main/scala/ai/privado/entrypoint/MetadataProcessor.scala
+++ b/src/main/scala/ai/privado/entrypoint/MetadataProcessor.scala
@@ -1,0 +1,26 @@
+package ai.privado.entrypoint
+
+import ai.privado.cache.AppCache
+import ai.privado.metadata.SystemInfo
+import ai.privado.model.Constants
+
+import scala.util.{Failure, Success, Try}
+
+object MetadataProcessor extends CommandProcessor {
+
+  override def process(appCache: AppCache): Either[String, Unit] = {
+
+    def generateMetadata(): SystemInfo = {
+      val systemInfo = SystemInfo.getInfo
+      SystemInfo.dumpInfoToFile(config.sourceLocation.head, Constants.systemInfoFileName, systemInfo)
+      systemInfo
+    }
+
+    Try(generateMetadata()) match
+      case Failure(exception) =>
+        println(s"Exception when processing metadata command : ${exception.toString}")
+        Left(exception.toString)
+      case Success(systemInfo) => Right(systemInfo)
+  }
+
+}

--- a/src/main/scala/ai/privado/entrypoint/ScanProcessor.scala
+++ b/src/main/scala/ai/privado/entrypoint/ScanProcessor.scala
@@ -32,6 +32,7 @@ import ai.privado.languageEngine.kotlin.processor.KotlinProcessor
 import ai.privado.languageEngine.php.processor.PhpProcessor
 import ai.privado.languageEngine.python.processor.PythonProcessor
 import ai.privado.languageEngine.ruby.processor.RubyProcessor
+import ai.privado.metadata.SystemInfo
 import ai.privado.metric.MetricHandler
 import ai.privado.model.*
 import ai.privado.model.Language.{Language, UNKNOWN}
@@ -328,6 +329,7 @@ object ScanProcessor extends CommandProcessor {
     if (!File(config.sourceLocation.head).isWritable) {
       println(s"Warning: Privado doesn't have write permission on give repo location - ${config.sourceLocation.head}")
     }
+    SystemInfo.getInfo
     processCpg(appCache)
   }
 

--- a/src/main/scala/ai/privado/metadata/SystemInfo.scala
+++ b/src/main/scala/ai/privado/metadata/SystemInfo.scala
@@ -1,0 +1,81 @@
+package ai.privado.metadata
+
+import ai.privado.model.Constants.outputDirectoryName
+import better.files.File
+import io.circe.{Decoder, Encoder}
+import io.circe.generic.semiauto.{deriveDecoder, deriveEncoder}
+import io.circe.syntax.EncoderOps
+import SystemInfoEncoderDecoder.*
+
+import java.nio.file.{Files, Paths}
+
+object SystemInfo {
+
+  def getInfo: SystemInfo = {
+    import java.lang.management._
+
+    // Operating System Information
+    val osBean: OperatingSystemMXBean = ManagementFactory.getOperatingSystemMXBean
+    val operatingSystemInfo =
+      OperatingSystemInfo(osBean.getName, osBean.getVersion, osBean.getArch, osBean.getAvailableProcessors)
+
+    // Memory Information
+    import com.sun.management.OperatingSystemMXBean
+    val memoryOSBean = ManagementFactory.getPlatformMXBean(classOf[com.sun.management.OperatingSystemMXBean])
+    // Convert bytes to gigabytes for readability
+    val systemMemoryInfo = SystemMemoryInfo(
+      convertBytesToGB(memoryOSBean.getTotalMemorySize),
+      convertBytesToGB(memoryOSBean.getTotalSwapSpaceSize)
+    )
+
+    // Get the file store for the current path
+    val fileStore = Files.getFileStore(Paths.get("").toAbsolutePath)
+    val systemDiskInfo = SystemDiskInfo(
+      fileStore.name(),
+      convertBytesToGB(fileStore.getTotalSpace),
+      convertBytesToGB(fileStore.getUnallocatedSpace)
+    )
+
+    val systemInfo = SystemInfo(operatingSystemInfo, systemMemoryInfo, systemDiskInfo)
+    println("Printing system Info")
+    println(systemInfo.asJson.toString)
+    systemInfo
+  }
+
+  def dumpInfoToFile(repoPath: String, outputFileName: String, systemInfo: SystemInfo): File = {
+    val outputDirectory = File(s"$repoPath/$outputDirectoryName").createDirectoryIfNotExists()
+    val f               = File(s"$repoPath/$outputDirectoryName/$outputFileName")
+    f.write(systemInfo.asJson.toString)
+    f
+  }
+
+  private def convertBytesToGB(size: Long) = size / (1024 * 1024 * 1024)
+}
+
+case class SystemInfo(
+  operatingSystemInfo: OperatingSystemInfo,
+  systemMemoryInfo: SystemMemoryInfo,
+  systemDiskInfo: SystemDiskInfo
+)
+
+case class OperatingSystemInfo(name: String, version: String, architecture: String, processorCount: Int)
+
+case class SystemMemoryInfo(memorySizeInGB: Long, swapSizeInGB: Long)
+
+case class SystemDiskInfo(fileStoreName: String, totalSpaceInGB: Long, freeSpaceInGB: Long)
+
+object SystemInfoEncoderDecoder {
+
+  implicit val systemInfoDecoder: Decoder[SystemInfo] = deriveDecoder[SystemInfo]
+  implicit val systemInfoEncoder: Encoder[SystemInfo] = deriveEncoder[SystemInfo]
+
+  implicit val operatingSystemInfoDecoder: Decoder[OperatingSystemInfo] = deriveDecoder[OperatingSystemInfo]
+  implicit val operatingSystemInfoEncoder: Encoder[OperatingSystemInfo] = deriveEncoder[OperatingSystemInfo]
+
+  implicit val systemMemoryInfoDecoder: Decoder[SystemMemoryInfo] = deriveDecoder[SystemMemoryInfo]
+  implicit val systemMemoryInfoEncoder: Encoder[SystemMemoryInfo] = deriveEncoder[SystemMemoryInfo]
+
+  implicit val systemDiskInfoDecoder: Decoder[SystemDiskInfo] = deriveDecoder[SystemDiskInfo]
+  implicit val systemDiskInfoEncoder: Encoder[SystemDiskInfo] = deriveEncoder[SystemDiskInfo]
+
+}

--- a/src/main/scala/ai/privado/model/Constants.scala
+++ b/src/main/scala/ai/privado/model/Constants.scala
@@ -131,6 +131,7 @@ object Constants {
   val egressUrlsFromCode            = "egressUrlsFromCode"
   val httpEndPointBasePaths         = "httpEndPointBasePaths"
   val outputFileName                = "privado.json"
+  val systemInfoFileName            = "systemInfo.json"
   val outputDirectoryName           = ".privado"
   val generatedConfigFolderName     = ".privado/config"
   val outputIntermediateFileName    = "intermediate.json"


### PR DESCRIPTION
The PR introduces a new command `metadata`, which captures system level information and dumps the info in `.privado/systemInfo.json`

```

{
  "operatingSystemInfo" : {
    "name" : "Mac OS X",
    "version" : "14.3",
    "architecture" : "aarch64",
    "processorCount" : 11
  },
  "systemMemoryInfo" : {
    "memorySizeInGB" : 18,
    "swapSizeInGB" : 2
  },
  "systemDiskInfo" : {
    "fileStoreName" : "/dev/disk3s5",
    "totalSpaceInGB" : 460,
    "freeSpaceInGB" : 253
  }
}

```

