### PR TITLE
PHP: Migrate older test suites to newer ones

### DIFF
--- a/src/test/scala/ai/privado/languageEngine/php/tagger/source/FieldIdentifierTaggingTests.scala
+++ b/src/test/scala/ai/privado/languageEngine/php/tagger/source/FieldIdentifierTaggingTests.scala
@@ -22,14 +22,19 @@
  */
 package ai.privado.languageEngine.php.tagger.source
 
-import ai.privado.languageEngine.php.PhpTestBase
+import ai.privado.cache.RuleCache
 import ai.privado.model.*
+import ai.privado.rule.RuleInfoTestData
+import ai.privado.testfixtures.PhpFrontendTestSuite
 import io.shiftleft.semanticcpg.language.*
 
-class FieldIdentifierTaggingTests extends PhpTestBase {
+class FieldIdentifierTaggingTests extends PhpFrontendTestSuite {
+  val configAndRules: ConfigAndRules = ConfigAndRules(sources = RuleInfoTestData.sourceRule)
+  val ruleCache: RuleCache           = new RuleCache().setRule(configAndRules)
+
   "Field access in code" should {
-    "be tagged as part of identifier tagger" in {
-      val (cpg, _) = code("""
+    val cpg = code(
+      """
           |<?php
           |class Person {
           |  public $firstName;
@@ -44,8 +49,12 @@ class FieldIdentifierTaggingTests extends PhpTestBase {
           |  }
           |}
           |?>
-          |""".stripMargin)
+          |""".stripMargin,
+      "Test.php"
+    )
+      .withRuleCache(ruleCache)
 
+    "be tagged as part of identifier tagger" in {
       val List(firstNameField) = cpg.fieldAccess.l
       firstNameField.code shouldBe "$this->firstName"
       firstNameField.tag.nameExact(Constants.catLevelOne).value.l shouldBe List(CatLevelOne.SOURCES.name)

--- a/src/test/scala/ai/privado/languageEngine/php/tagger/source/FieldIdentifierTaggingTests.scala
+++ b/src/test/scala/ai/privado/languageEngine/php/tagger/source/FieldIdentifierTaggingTests.scala
@@ -22,16 +22,11 @@
  */
 package ai.privado.languageEngine.php.tagger.source
 
-import ai.privado.cache.RuleCache
 import ai.privado.model.*
-import ai.privado.rule.RuleInfoTestData
 import ai.privado.testfixtures.PhpFrontendTestSuite
 import io.shiftleft.semanticcpg.language.*
 
 class FieldIdentifierTaggingTests extends PhpFrontendTestSuite {
-  val configAndRules: ConfigAndRules = ConfigAndRules(sources = RuleInfoTestData.sourceRule)
-  val ruleCache: RuleCache           = new RuleCache().setRule(configAndRules)
-
   "Field access in code" should {
     val cpg = code(
       """
@@ -52,7 +47,6 @@ class FieldIdentifierTaggingTests extends PhpFrontendTestSuite {
           |""".stripMargin,
       "Test.php"
     )
-      .withRuleCache(ruleCache)
 
     "be tagged as part of identifier tagger" in {
       val List(firstNameField) = cpg.fieldAccess.l

--- a/src/test/scala/ai/privado/languageEngine/php/tagger/source/IdentifierTaggingTest.scala
+++ b/src/test/scala/ai/privado/languageEngine/php/tagger/source/IdentifierTaggingTest.scala
@@ -22,16 +22,11 @@
  */
 package ai.privado.languageEngine.php.tagger.source
 
-import ai.privado.cache.RuleCache
 import ai.privado.model.*
-import ai.privado.rule.RuleInfoTestData
 import ai.privado.testfixtures.PhpFrontendTestSuite
 import io.shiftleft.semanticcpg.language.*
 
 class IdentifierTaggingTest extends PhpFrontendTestSuite {
-  val configAndRules: ConfigAndRules = ConfigAndRules(sources = RuleInfoTestData.sourceRule)
-  val ruleCache: RuleCache           = new RuleCache().setRule(configAndRules)
-
   "Tagging derived sources" should {
     val cpg = code(
       """
@@ -60,7 +55,6 @@ class IdentifierTaggingTest extends PhpFrontendTestSuite {
         |""".stripMargin,
       "Test.php"
     )
-      .withRuleCache(ruleCache)
 
     "tag member in a structure" in {
       cpg.member("firstName").tag.nameExact(Constants.id).value.l shouldBe List("Data.Sensitive.FirstName")

--- a/src/test/scala/ai/privado/languageEngine/php/tagger/source/IdentifierTaggingTest.scala
+++ b/src/test/scala/ai/privado/languageEngine/php/tagger/source/IdentifierTaggingTest.scala
@@ -22,13 +22,19 @@
  */
 package ai.privado.languageEngine.php.tagger.source
 
-import ai.privado.languageEngine.php.PhpTestBase
+import ai.privado.cache.RuleCache
 import ai.privado.model.*
+import ai.privado.rule.RuleInfoTestData
+import ai.privado.testfixtures.PhpFrontendTestSuite
 import io.shiftleft.semanticcpg.language.*
 
-class IdentifierTaggingTest extends PhpTestBase {
+class IdentifierTaggingTest extends PhpFrontendTestSuite {
+  val configAndRules: ConfigAndRules = ConfigAndRules(sources = RuleInfoTestData.sourceRule)
+  val ruleCache: RuleCache           = new RuleCache().setRule(configAndRules)
+
   "Tagging derived sources" should {
-    val (cpg, _) = code("""
+    val cpg = code(
+      """
         |<?php
         |
         |  class User {
@@ -51,7 +57,10 @@ class IdentifierTaggingTest extends PhpTestBase {
         |  echo $user->firstName;
         |?>
         |
-        |""".stripMargin)
+        |""".stripMargin,
+      "Test.php"
+    )
+      .withRuleCache(ruleCache)
 
     "tag member in a structure" in {
       cpg.member("firstName").tag.nameExact(Constants.id).value.l shouldBe List("Data.Sensitive.FirstName")

--- a/src/test/scala/ai/privado/languageEngine/php/tagger/source/LiteralTaggingTests.scala
+++ b/src/test/scala/ai/privado/languageEngine/php/tagger/source/LiteralTaggingTests.scala
@@ -22,14 +22,19 @@
  */
 package ai.privado.languageEngine.php.tagger.source
 
-import ai.privado.languageEngine.php.PhpTestBase
+import ai.privado.cache.RuleCache
 import ai.privado.model.*
+import ai.privado.rule.RuleInfoTestData
+import ai.privado.testfixtures.PhpFrontendTestSuite
 import io.shiftleft.semanticcpg.language.*
 
-class LiteralTaggingTests extends PhpTestBase {
+class LiteralTaggingTests extends PhpFrontendTestSuite {
+  val configAndRules: ConfigAndRules = ConfigAndRules(sources = RuleInfoTestData.sourceRule)
+  val ruleCache: RuleCache           = new RuleCache().setRule(configAndRules)
+
   "Literals in code" should {
-    "be tagged as part of LiteralTagger" in {
-      val (cpg, _) = code("""
+    val cpg = code(
+      """
           |<?php
           |class Person {
           |  function initialize() {
@@ -40,8 +45,11 @@ class LiteralTaggingTests extends PhpTestBase {
           |  }
           |}
           |?>
-          |""".stripMargin)
+          |""".stripMargin,
+      "Test.php"
+    )
 
+    "be tagged as part of LiteralTagger" in {
       val literals = cpg.literal.l
       literals.last.code shouldBe "\"phone\""
       literals.last.tag.nameExact(Constants.catLevelOne).value.l shouldBe List(CatLevelOne.SOURCES.name)


### PR DESCRIPTION
PR refactors tests to use `*FrontendTestSuite`.