### PR TITLE
refactor and make sure to use the trait as base for all ApiSinkTagger

### DIFF
--- a/src/main/scala/ai/privado/languageEngine/csharp/tagger/sink/CSharpAPISinkTagger.scala
+++ b/src/main/scala/ai/privado/languageEngine/csharp/tagger/sink/CSharpAPISinkTagger.scala
@@ -2,7 +2,7 @@ package ai.privado.languageEngine.csharp.tagger.sink
 
 import ai.privado.cache.{AppCache, RuleCache}
 import ai.privado.entrypoint.PrivadoInput
-import ai.privado.tagger.sink.api.APISinkTagger
+import ai.privado.tagger.sink.api.{APISinkByMethodFullNameTagger, APISinkTagger}
 import ai.privado.utility.StatsRecorder
 import io.shiftleft.codepropertygraph.generated.Cpg
 
@@ -17,7 +17,7 @@ object CSharpAPISinkTagger extends APISinkTagger {
   ): Unit = {
 
     super.applyTagger(cpg, ruleCache, privadoInput, appCache, statsRecorder)
-
+    new APISinkByMethodFullNameTagger(cpg, ruleCache).createAndApply()
     new CSharpAPITagger(cpg, ruleCache, privadoInput, appCache).createAndApply()
   }
 

--- a/src/main/scala/ai/privado/languageEngine/go/tagger/sink/GoAPISinkTagger.scala
+++ b/src/main/scala/ai/privado/languageEngine/go/tagger/sink/GoAPISinkTagger.scala
@@ -2,7 +2,7 @@ package ai.privado.languageEngine.go.tagger.sink
 
 import ai.privado.cache.{AppCache, RuleCache}
 import ai.privado.entrypoint.PrivadoInput
-import ai.privado.tagger.sink.api.APISinkTagger
+import ai.privado.tagger.sink.api.{APISinkByMethodFullNameTagger, APISinkTagger}
 import ai.privado.utility.StatsRecorder
 import io.shiftleft.codepropertygraph.generated.Cpg
 
@@ -17,7 +17,7 @@ object GoAPISinkTagger extends APISinkTagger {
   ): Unit = {
 
     super.applyTagger(cpg, ruleCache, privadoInput, appCache, statsRecorder)
-
+    new APISinkByMethodFullNameTagger(cpg, ruleCache).createAndApply()
     new GoAPITagger(cpg, ruleCache, privadoInput, appCache).createAndApply()
   }
 

--- a/src/main/scala/ai/privado/languageEngine/javascript/tagger/PrivadoTagger.scala
+++ b/src/main/scala/ai/privado/languageEngine/javascript/tagger/PrivadoTagger.scala
@@ -29,7 +29,12 @@ import ai.privado.feeder.PermissionSourceRule
 import ai.privado.languageEngine.javascript.config.JSDBConfigTagger
 import ai.privado.languageEngine.javascript.passes.read.GraphqlQueryParserPass
 import ai.privado.languageEngine.javascript.tagger.collection.CollectionTagger
-import ai.privado.languageEngine.javascript.tagger.sink.{GraphqlAPITagger, JSAPITagger, RegularSinkTagger}
+import ai.privado.languageEngine.javascript.tagger.sink.{
+  GraphqlAPITagger,
+  JSAPISinkTagger,
+  JSAPITagger,
+  RegularSinkTagger
+}
 import ai.privado.languageEngine.javascript.tagger.source.{IdentifierTagger, LiteralTagger}
 import ai.privado.tagger.PrivadoBaseTagger
 import ai.privado.tagger.collection.WebFormsCollectionTagger
@@ -66,9 +71,7 @@ class PrivadoTagger(cpg: Cpg) extends PrivadoBaseTagger {
 
     new RegularSinkTagger(cpg, ruleCache, databaseDetailsCache).createAndApply()
 
-    new JSAPITagger(cpg, ruleCache, privadoInput = privadoInputConfig, appCache = appCache).createAndApply()
-
-    new GraphqlAPITagger(cpg, ruleCache).createAndApply()
+    JSAPISinkTagger.applyTagger(cpg, ruleCache, privadoInputConfig, appCache, statsRecorder)
 
     new GraphqlQueryParserPass(cpg, ruleCache, taggerCache).createAndApply()
 

--- a/src/main/scala/ai/privado/languageEngine/javascript/tagger/sink/JSAPISinkTagger.scala
+++ b/src/main/scala/ai/privado/languageEngine/javascript/tagger/sink/JSAPISinkTagger.scala
@@ -1,4 +1,4 @@
-package ai.privado.languageEngine.java.tagger.sink.api
+package ai.privado.languageEngine.javascript.tagger.sink
 
 import ai.privado.cache.{AppCache, RuleCache}
 import ai.privado.entrypoint.PrivadoInput
@@ -6,12 +6,8 @@ import ai.privado.tagger.sink.api.{APISinkByMethodFullNameTagger, APISinkTagger}
 import ai.privado.utility.StatsRecorder
 import io.shiftleft.codepropertygraph.generated.Cpg
 
-object JavaAPISinkTagger extends APISinkTagger {
+object JSAPISinkTagger extends APISinkTagger {
 
-  /** Wrapper method to tag all the api taggers
-    * @param cpg
-    * @param ruleCache
-    */
   override def applyTagger(
     cpg: Cpg,
     ruleCache: RuleCache,
@@ -21,16 +17,13 @@ object JavaAPISinkTagger extends APISinkTagger {
   ): Unit = {
 
     super.applyTagger(cpg, ruleCache, privadoInput, appCache, statsRecorder)
-    new JavaAPIRetrofitTagger(cpg, ruleCache).createAndApply()
-
-    if (privadoInput.enableAPIByParameter) {
-      new JavaAPISinkByParameterMarkByAnnotationTagger(cpg, ruleCache).createAndApply()
-      new JavaAPISinkByParameterTagger(cpg, ruleCache).createAndApply()
-    }
 
     new APISinkByMethodFullNameTagger(cpg, ruleCache).createAndApply()
 
-    new JavaAPITagger(cpg, ruleCache, privadoInput, appCache, statsRecorder).createAndApply()
+    new JSAPITagger(cpg, ruleCache, privadoInput = privadoInput, appCache = appCache).createAndApply()
+
+    new GraphqlAPITagger(cpg, ruleCache).createAndApply()
+
   }
 
 }

--- a/src/main/scala/ai/privado/languageEngine/php/tagger/PrivadoTagger.scala
+++ b/src/main/scala/ai/privado/languageEngine/php/tagger/PrivadoTagger.scala
@@ -29,7 +29,7 @@ import ai.privado.languageEngine.php.tagger.collection.MethodFullNameCollectionT
 import ai.privado.languageEngine.php.tagger.collection.AnnotationsCollectionTagger
 import ai.privado.languageEngine.php.tagger.collection.ConfigCollectionTagger
 import ai.privado.languageEngine.php.tagger.source.IdentifierTagger
-import ai.privado.languageEngine.php.tagger.sink.APITagger
+import ai.privado.languageEngine.php.tagger.sink.{APITagger, PhpAPISinkTagger}
 import ai.privado.tagger.PrivadoBaseTagger
 import ai.privado.tagger.sink.RegularSinkTagger
 import ai.privado.tagger.source.{DEDTagger, LiteralTagger}
@@ -61,7 +61,8 @@ class PrivadoTagger(cpg: Cpg) extends PrivadoBaseTagger {
     new AnnotationsCollectionTagger(cpg, rules).createAndApply()
     new ConfigCollectionTagger(cpg, rules, privadoInputConfig.sourceLocation.headOption.getOrElse("")).createAndApply()
     new MethodFullNameCollectionTagger(cpg, rules).createAndApply()
-    new APITagger(cpg, rules, privadoInput = privadoInputConfig, appCache = appCache).createAndApply()
+
+    PhpAPISinkTagger.applyTagger(cpg, rules, privadoInputConfig, appCache, statsRecorder)
 
     logger.info("Finished tagging")
     cpg.tag

--- a/src/main/scala/ai/privado/languageEngine/php/tagger/sink/PhpAPISinkTagger.scala
+++ b/src/main/scala/ai/privado/languageEngine/php/tagger/sink/PhpAPISinkTagger.scala
@@ -1,4 +1,4 @@
-package ai.privado.languageEngine.java.tagger.sink.api
+package ai.privado.languageEngine.php.tagger.sink
 
 import ai.privado.cache.{AppCache, RuleCache}
 import ai.privado.entrypoint.PrivadoInput
@@ -6,12 +6,8 @@ import ai.privado.tagger.sink.api.{APISinkByMethodFullNameTagger, APISinkTagger}
 import ai.privado.utility.StatsRecorder
 import io.shiftleft.codepropertygraph.generated.Cpg
 
-object JavaAPISinkTagger extends APISinkTagger {
+object PhpAPISinkTagger extends APISinkTagger {
 
-  /** Wrapper method to tag all the api taggers
-    * @param cpg
-    * @param ruleCache
-    */
   override def applyTagger(
     cpg: Cpg,
     ruleCache: RuleCache,
@@ -21,16 +17,9 @@ object JavaAPISinkTagger extends APISinkTagger {
   ): Unit = {
 
     super.applyTagger(cpg, ruleCache, privadoInput, appCache, statsRecorder)
-    new JavaAPIRetrofitTagger(cpg, ruleCache).createAndApply()
-
-    if (privadoInput.enableAPIByParameter) {
-      new JavaAPISinkByParameterMarkByAnnotationTagger(cpg, ruleCache).createAndApply()
-      new JavaAPISinkByParameterTagger(cpg, ruleCache).createAndApply()
-    }
 
     new APISinkByMethodFullNameTagger(cpg, ruleCache).createAndApply()
-
-    new JavaAPITagger(cpg, ruleCache, privadoInput, appCache, statsRecorder).createAndApply()
+    new APITagger(cpg, ruleCache, privadoInput = privadoInput, appCache = appCache).createAndApply()
   }
 
 }

--- a/src/main/scala/ai/privado/languageEngine/python/tagger/PrivadoTagger.scala
+++ b/src/main/scala/ai/privado/languageEngine/python/tagger/PrivadoTagger.scala
@@ -6,7 +6,12 @@ import ai.privado.languageEngine.python.config.PythonDBConfigTagger
 import ai.privado.languageEngine.python.feeder.StorageInheritRule
 import ai.privado.languageEngine.python.passes.read.DatabaseReadPass
 import ai.privado.languageEngine.python.tagger.collection.CollectionTagger
-import ai.privado.languageEngine.python.tagger.sink.{AirflowOperatorSinkTagger, InheritMethodTagger, PythonAPITagger}
+import ai.privado.languageEngine.python.tagger.sink.{
+  AirflowOperatorSinkTagger,
+  InheritMethodTagger,
+  PythonAPISinkTagger,
+  PythonAPITagger
+}
 import ai.privado.languageEngine.python.tagger.source.{IdentifierTagger, LiteralTagger}
 import ai.privado.tagger.PrivadoBaseTagger
 import ai.privado.tagger.collection.WebFormsCollectionTagger
@@ -42,7 +47,7 @@ class PrivadoTagger(cpg: Cpg) extends PrivadoBaseTagger {
 
     new SqlQueryTagger(cpg, ruleCache).createAndApply()
 
-    new PythonAPITagger(cpg, ruleCache, privadoInput = privadoInputConfig, appCache, statsRecorder).createAndApply()
+    PythonAPISinkTagger.applyTagger(cpg, ruleCache, privadoInputConfig, appCache, statsRecorder)
 
     new PythonDBConfigTagger(cpg, databaseDetailsCache).createAndApply()
 

--- a/src/main/scala/ai/privado/languageEngine/python/tagger/sink/PythonAPISinkTagger.scala
+++ b/src/main/scala/ai/privado/languageEngine/python/tagger/sink/PythonAPISinkTagger.scala
@@ -1,4 +1,4 @@
-package ai.privado.languageEngine.java.tagger.sink.api
+package ai.privado.languageEngine.python.tagger.sink
 
 import ai.privado.cache.{AppCache, RuleCache}
 import ai.privado.entrypoint.PrivadoInput
@@ -6,12 +6,8 @@ import ai.privado.tagger.sink.api.{APISinkByMethodFullNameTagger, APISinkTagger}
 import ai.privado.utility.StatsRecorder
 import io.shiftleft.codepropertygraph.generated.Cpg
 
-object JavaAPISinkTagger extends APISinkTagger {
+object PythonAPISinkTagger extends APISinkTagger {
 
-  /** Wrapper method to tag all the api taggers
-    * @param cpg
-    * @param ruleCache
-    */
   override def applyTagger(
     cpg: Cpg,
     ruleCache: RuleCache,
@@ -21,16 +17,9 @@ object JavaAPISinkTagger extends APISinkTagger {
   ): Unit = {
 
     super.applyTagger(cpg, ruleCache, privadoInput, appCache, statsRecorder)
-    new JavaAPIRetrofitTagger(cpg, ruleCache).createAndApply()
-
-    if (privadoInput.enableAPIByParameter) {
-      new JavaAPISinkByParameterMarkByAnnotationTagger(cpg, ruleCache).createAndApply()
-      new JavaAPISinkByParameterTagger(cpg, ruleCache).createAndApply()
-    }
 
     new APISinkByMethodFullNameTagger(cpg, ruleCache).createAndApply()
-
-    new JavaAPITagger(cpg, ruleCache, privadoInput, appCache, statsRecorder).createAndApply()
+    new PythonAPITagger(cpg, ruleCache, privadoInput = privadoInput, appCache, statsRecorder).createAndApply()
   }
 
 }

--- a/src/main/scala/ai/privado/languageEngine/ruby/tagger/PrivadoTagger.scala
+++ b/src/main/scala/ai/privado/languageEngine/ruby/tagger/PrivadoTagger.scala
@@ -28,19 +28,20 @@ import ai.privado.entrypoint.{PrivadoInput, ScanProcessor}
 import ai.privado.languageEngine.ruby.tagger.collection.CollectionTagger
 import ai.privado.languageEngine.ruby.config.RubyDBConfigTagger
 import ai.privado.languageEngine.ruby.feeder.{LeakageRule, StorageInheritRule}
-import ai.privado.languageEngine.ruby.tagger.collection.CollectionTagger
 import ai.privado.languageEngine.ruby.tagger.monolith.MonolithTagger
-import ai.privado.languageEngine.ruby.tagger.sink.{APITagger, InheritMethodTagger, LeakageTagger, RegularSinkTagger}
+import ai.privado.languageEngine.ruby.tagger.sink.{
+  InheritMethodTagger,
+  LeakageTagger,
+  RegularSinkTagger,
+  RubyAPISinkTagger
+}
+import ai.privado.languageEngine.ruby.tagger.schema.{RubyMongoSchemaMapper, RubyMongoSchemaTagger}
 import ai.privado.languageEngine.ruby.tagger.source.{
   IdentifierDerivedTagger,
   IdentifierTagger,
   RubyLiteralDerivedTagger,
   RubyLiteralTagger
 }
-import ai.privado.languageEngine.ruby.feeder.{LeakageRule, StorageInheritRule}
-import ai.privado.languageEngine.ruby.tagger.monolith.MonolithTagger
-import ai.privado.languageEngine.ruby.tagger.schema.{RubyMongoSchemaMapper, RubyMongoSchemaTagger}
-import ai.privado.languageEngine.ruby.tagger.sink.{APITagger, InheritMethodTagger, LeakageTagger, RegularSinkTagger}
 import ai.privado.tagger.PrivadoBaseTagger
 import ai.privado.tagger.source.{DEDTagger, LiteralTagger, SqlQueryTagger}
 import ai.privado.utility.StatsRecorder
@@ -49,8 +50,6 @@ import io.shiftleft.codepropertygraph.generated.nodes.Tag
 import io.shiftleft.semanticcpg.language.*
 import org.slf4j.LoggerFactory
 import overflowdb.traversal.Traversal
-
-import java.util.Calendar
 
 class PrivadoTagger(cpg: Cpg) extends PrivadoBaseTagger {
   private val logger = LoggerFactory.getLogger(this.getClass)
@@ -73,7 +72,8 @@ class PrivadoTagger(cpg: Cpg) extends PrivadoBaseTagger {
     new SqlQueryTagger(cpg, ruleCache).createAndApply()
     new IdentifierDerivedTagger(cpg, ruleCache).createAndApply()
     new RegularSinkTagger(cpg, ruleCache).createAndApply()
-    new APITagger(cpg, ruleCache, privadoInput = privadoInputConfig, appCache, statsRecorder).createAndApply()
+
+    RubyAPISinkTagger.applyTagger(cpg, ruleCache, privadoInputConfig, appCache, statsRecorder)
 
     val collectionTagger = new CollectionTagger(cpg, ruleCache)
     collectionTagger.createAndApply()

--- a/src/main/scala/ai/privado/languageEngine/ruby/tagger/sink/RubyAPISinkTagger.scala
+++ b/src/main/scala/ai/privado/languageEngine/ruby/tagger/sink/RubyAPISinkTagger.scala
@@ -1,4 +1,4 @@
-package ai.privado.languageEngine.java.tagger.sink.api
+package ai.privado.languageEngine.ruby.tagger.sink
 
 import ai.privado.cache.{AppCache, RuleCache}
 import ai.privado.entrypoint.PrivadoInput
@@ -6,12 +6,8 @@ import ai.privado.tagger.sink.api.{APISinkByMethodFullNameTagger, APISinkTagger}
 import ai.privado.utility.StatsRecorder
 import io.shiftleft.codepropertygraph.generated.Cpg
 
-object JavaAPISinkTagger extends APISinkTagger {
+object RubyAPISinkTagger extends APISinkTagger {
 
-  /** Wrapper method to tag all the api taggers
-    * @param cpg
-    * @param ruleCache
-    */
   override def applyTagger(
     cpg: Cpg,
     ruleCache: RuleCache,
@@ -21,16 +17,9 @@ object JavaAPISinkTagger extends APISinkTagger {
   ): Unit = {
 
     super.applyTagger(cpg, ruleCache, privadoInput, appCache, statsRecorder)
-    new JavaAPIRetrofitTagger(cpg, ruleCache).createAndApply()
-
-    if (privadoInput.enableAPIByParameter) {
-      new JavaAPISinkByParameterMarkByAnnotationTagger(cpg, ruleCache).createAndApply()
-      new JavaAPISinkByParameterTagger(cpg, ruleCache).createAndApply()
-    }
 
     new APISinkByMethodFullNameTagger(cpg, ruleCache).createAndApply()
-
-    new JavaAPITagger(cpg, ruleCache, privadoInput, appCache, statsRecorder).createAndApply()
+    new APITagger(cpg, ruleCache, privadoInput = privadoInput, appCache, statsRecorder).createAndApply()
   }
 
 }

--- a/src/main/scala/ai/privado/tagger/sink/api/APISinkByMethodFullNameTagger.scala
+++ b/src/main/scala/ai/privado/tagger/sink/api/APISinkByMethodFullNameTagger.scala
@@ -1,17 +1,17 @@
-package ai.privado.languageEngine.java.tagger.sink.api
+package ai.privado.tagger.sink.api
 
 import ai.privado.cache.RuleCache
 import ai.privado.model.{Constants, InternalTag}
 import ai.privado.tagger.{PrivadoParallelCpgPass, PrivadoSimpleCpgPass}
-import io.shiftleft.codepropertygraph.generated.{Cpg, Operators}
-import io.shiftleft.codepropertygraph.generated.nodes.Call
-import io.shiftleft.semanticcpg.language.*
 import ai.privado.utility.Utilities.{addRuleTags, storeForTag}
+import io.shiftleft.codepropertygraph.generated.nodes.Call
+import io.shiftleft.codepropertygraph.generated.{Cpg, Operators}
+import io.shiftleft.semanticcpg.language.*
 
 import scala.jdk.CollectionConverters.CollectionHasAsScala
 import scala.language.postfixOps
 
-class JavaAPISinkByMethodFullNameTagger(cpg: Cpg, ruleCache: RuleCache) extends PrivadoSimpleCpgPass(cpg) {
+class APISinkByMethodFullNameTagger(cpg: Cpg, ruleCache: RuleCache) extends PrivadoSimpleCpgPass(cpg) {
 
   private val apiMethodFullNameRegex = ruleCache.getSystemConfigByKey(Constants.apiMethodFullNames)
 


### PR DESCRIPTION
The PR adds
- support of adding inference API rules across languages
- support for taking API sink via methodFullName regex
- Refactor to make this available across