### PR TITLE
Upgrade `goastgen`

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -18,7 +18,7 @@ val circeYamlVersion    = "1.15.0"
 val circeGenericVersion = "0.14.7"
 val jacksonVersion      = "2.17.0"
 val mockitoVersion      = "1.17.14"
-val goAstGenVersion     = "0.14.0"
+val goAstGenVersion     = "0.18.0"
 val dotnetAstGenVersion = "0.34.0"
 
 lazy val schema         = Projects.schema


### PR DESCRIPTION
Upgraded to fix vulnerabilities introduced by go version 1.18. 
Refer commit on goastgen:  https://github.com/Privado-Inc/goastgen/commit/458e417717a9a09eb65c3695e02e6450c8f1405f