### PR TITLE
filter out already tagged api sinks

### DIFF
--- a/src/main/scala/ai/privado/languageEngine/java/tagger/sink/api/JavaAPITagger.scala
+++ b/src/main/scala/ai/privado/languageEngine/java/tagger/sink/api/JavaAPITagger.scala
@@ -102,22 +102,13 @@ class JavaAPITagger(
       APITaggerVersionJava.V2Tagger
   }
 
-  apis = apis
-    .whereNot(_.tag.nameExact(InternalTag.API_URL_MARKED.toString))
-    .whereNot(_.tag.nameExact(Constants.nodeType).valueExact(NodeType.API.toString))
-    .l
-
   val commonHttpPackages: String = ruleCache.getSystemConfigByKey(Constants.apiHttpLibraries)
   val grpcSinks = GRPCTaggerUtility
     .getGrpcSinks(cpg)
-    .whereNot(_.tag.nameExact(InternalTag.API_URL_MARKED.toString))
-    .whereNot(_.tag.nameExact(Constants.nodeType).valueExact(NodeType.API.toString))
     .l
   val soapSinks =
     SOAPTaggerUtility
       .getAPICallNodes(cpg)
-      .whereNot(_.tag.nameExact(InternalTag.API_URL_MARKED.toString))
-      .whereNot(_.tag.nameExact(Constants.nodeType).valueExact(NodeType.API.toString))
       .l
 
   override def generateParts(): Array[_ <: AnyRef] = {
@@ -155,14 +146,10 @@ class JavaAPITagger(
         )
       else
         List()
-    }.whereNot(_.tag.nameExact(InternalTag.API_URL_MARKED.toString))
-      .whereNot(_.tag.nameExact(Constants.nodeType).valueExact(NodeType.API.toString))
-      .l
+    }.l
 
     val markedAPISinks = cpg.call
       .where(_.tag.nameExact(InternalTag.API_SINK_MARKED.toString))
-      .whereNot(_.tag.nameExact(InternalTag.API_URL_MARKED.toString))
-      .whereNot(_.tag.nameExact(Constants.nodeType).valueExact(NodeType.API.toString))
       .l
 
     apiTaggerToUse match {

--- a/src/main/scala/ai/privado/languageEngine/javascript/tagger/sink/JSAPITagger.scala
+++ b/src/main/scala/ai/privado/languageEngine/javascript/tagger/sink/JSAPITagger.scala
@@ -26,7 +26,7 @@ package ai.privado.languageEngine.javascript.tagger.sink
 import ai.privado.cache.{AppCache, RuleCache}
 import ai.privado.dataflow.DuplicateFlowProcessor
 import ai.privado.entrypoint.{PrivadoInput, ScanProcessor}
-import ai.privado.model.{Constants, RuleInfo}
+import ai.privado.model.{Constants, InternalTag, NodeType, RuleInfo}
 import ai.privado.tagger.sink.APITagger
 
 import scala.collection.mutable.ListBuffer
@@ -56,6 +56,8 @@ class JSAPITagger(cpg: Cpg, ruleCache: RuleCache, privadoInput: PrivadoInput, ap
     .name(APISINKS_REGEX)
     .methodFullNameNot(COMMON_IGNORED_SINKS_REGEX)
     .where(_.or(_.code(commonHttpPackages), _.methodFullName(commonHttpPackages)))
+    .whereNot(_.tag.nameExact(InternalTag.API_URL_MARKED.toString))
+    .whereNot(_.tag.nameExact(Constants.nodeType).valueExact(NodeType.API.toString))
     .l
 
   override def runOnPart(builder: DiffGraphBuilder, ruleInfo: RuleInfo): Unit = {

--- a/src/main/scala/ai/privado/languageEngine/javascript/tagger/sink/JSAPITagger.scala
+++ b/src/main/scala/ai/privado/languageEngine/javascript/tagger/sink/JSAPITagger.scala
@@ -56,8 +56,6 @@ class JSAPITagger(cpg: Cpg, ruleCache: RuleCache, privadoInput: PrivadoInput, ap
     .name(APISINKS_REGEX)
     .methodFullNameNot(COMMON_IGNORED_SINKS_REGEX)
     .where(_.or(_.code(commonHttpPackages), _.methodFullName(commonHttpPackages)))
-    .whereNot(_.tag.nameExact(InternalTag.API_URL_MARKED.toString))
-    .whereNot(_.tag.nameExact(Constants.nodeType).valueExact(NodeType.API.toString))
     .l
 
   override def runOnPart(builder: DiffGraphBuilder, ruleInfo: RuleInfo): Unit = {

--- a/src/main/scala/ai/privado/languageEngine/php/tagger/sink/APITagger.scala
+++ b/src/main/scala/ai/privado/languageEngine/php/tagger/sink/APITagger.scala
@@ -3,7 +3,6 @@ package ai.privado.languageEngine.php.tagger.sink
 import ai.privado.cache.{AppCache, RuleCache}
 import ai.privado.entrypoint.{PrivadoInput, ScanProcessor}
 import ai.privado.languageEngine.java.language.{NodeStarters, StepsForProperty}
-import ai.privado.languageEngine.java.semantic.JavaSemanticGenerator
 import ai.privado.metric.MetricHandler
 import ai.privado.model.{Constants, InternalTag, NodeType, RuleInfo}
 import ai.privado.tagger.PrivadoParallelCpgPass
@@ -17,7 +16,6 @@ import io.shiftleft.semanticcpg.language.*
 import org.slf4j.LoggerFactory
 
 import scala.jdk.CollectionConverters.CollectionHasAsScala
-import java.util.Calendar
 
 class APITagger(cpg: Cpg, ruleCache: RuleCache, privadoInput: PrivadoInput, appCache: AppCache)
     extends PrivadoParallelCpgPass[RuleInfo](cpg) {
@@ -37,8 +35,6 @@ class APITagger(cpg: Cpg, ruleCache: RuleCache, privadoInput: PrivadoInput, appC
 
   val httpApis: List[Call] = (apis ++ constructors)
     .or(_.methodFullName(commonHttpPackages), _.filter(_.dynamicTypeHintFullName.exists(_.matches(commonHttpPackages))))
-    .whereNot(_.tag.nameExact(InternalTag.API_URL_MARKED.toString))
-    .whereNot(_.tag.nameExact(Constants.nodeType).valueExact(NodeType.API.toString))
     .l
 
   // Support to use `identifier` in API's

--- a/src/main/scala/ai/privado/languageEngine/php/tagger/sink/APITagger.scala
+++ b/src/main/scala/ai/privado/languageEngine/php/tagger/sink/APITagger.scala
@@ -5,7 +5,7 @@ import ai.privado.entrypoint.{PrivadoInput, ScanProcessor}
 import ai.privado.languageEngine.java.language.{NodeStarters, StepsForProperty}
 import ai.privado.languageEngine.java.semantic.JavaSemanticGenerator
 import ai.privado.metric.MetricHandler
-import ai.privado.model.{Constants, NodeType, RuleInfo}
+import ai.privado.model.{Constants, InternalTag, NodeType, RuleInfo}
 import ai.privado.tagger.PrivadoParallelCpgPass
 import ai.privado.tagger.utility.APITaggerUtility.sinkTagger
 import ai.privado.utility.Utilities
@@ -37,6 +37,8 @@ class APITagger(cpg: Cpg, ruleCache: RuleCache, privadoInput: PrivadoInput, appC
 
   val httpApis: List[Call] = (apis ++ constructors)
     .or(_.methodFullName(commonHttpPackages), _.filter(_.dynamicTypeHintFullName.exists(_.matches(commonHttpPackages))))
+    .whereNot(_.tag.nameExact(InternalTag.API_URL_MARKED.toString))
+    .whereNot(_.tag.nameExact(Constants.nodeType).valueExact(NodeType.API.toString))
     .l
 
   // Support to use `identifier` in API's

--- a/src/main/scala/ai/privado/languageEngine/python/tagger/sink/PythonAPITagger.scala
+++ b/src/main/scala/ai/privado/languageEngine/python/tagger/sink/PythonAPITagger.scala
@@ -53,8 +53,6 @@ class PythonAPITagger(
 
   val apis = cacheCall
     .name(APISINKS_REGEX)
-    .whereNot(_.tag.nameExact(InternalTag.API_URL_MARKED.toString))
-    .whereNot(_.tag.nameExact(Constants.nodeType).valueExact(NodeType.API.toString))
     .l
 
   MetricHandler.metricsData("apiTaggerVersion") = Json.fromString("Common HTTP Libraries Used")

--- a/src/main/scala/ai/privado/languageEngine/python/tagger/sink/PythonAPITagger.scala
+++ b/src/main/scala/ai/privado/languageEngine/python/tagger/sink/PythonAPITagger.scala
@@ -27,7 +27,7 @@ import ai.privado.entrypoint.{PrivadoInput, ScanProcessor}
 import ai.privado.languageEngine.java.language.{NodeStarters, StepsForProperty}
 import ai.privado.languageEngine.java.semantic.JavaSemanticGenerator
 import ai.privado.metric.MetricHandler
-import ai.privado.model.{Constants, Language, NodeType, RuleInfo}
+import ai.privado.model.{Constants, InternalTag, Language, NodeType, RuleInfo}
 import ai.privado.tagger.PrivadoParallelCpgPass
 import ai.privado.tagger.utility.APITaggerUtility.sinkTagger
 import ai.privado.utility.{StatsRecorder, Utilities}
@@ -51,7 +51,11 @@ class PythonAPITagger(
 
   lazy val APISINKS_REGEX = ruleCache.getSystemConfigByKey(Constants.apiSinks)
 
-  val apis = cacheCall.name(APISINKS_REGEX).l
+  val apis = cacheCall
+    .name(APISINKS_REGEX)
+    .whereNot(_.tag.nameExact(InternalTag.API_URL_MARKED.toString))
+    .whereNot(_.tag.nameExact(Constants.nodeType).valueExact(NodeType.API.toString))
+    .l
 
   MetricHandler.metricsData("apiTaggerVersion") = Json.fromString("Common HTTP Libraries Used")
 

--- a/src/main/scala/ai/privado/languageEngine/ruby/tagger/sink/APITagger.scala
+++ b/src/main/scala/ai/privado/languageEngine/ruby/tagger/sink/APITagger.scala
@@ -5,7 +5,7 @@ import ai.privado.entrypoint.{PrivadoInput, ScanProcessor}
 import ai.privado.languageEngine.java.language.{NodeStarters, StepsForProperty}
 import ai.privado.languageEngine.java.semantic.JavaSemanticGenerator
 import ai.privado.metric.MetricHandler
-import ai.privado.model.{Constants, NodeType, RuleInfo}
+import ai.privado.model.{Constants, InternalTag, NodeType, RuleInfo}
 import ai.privado.tagger.PrivadoParallelCpgPass
 import ai.privado.tagger.utility.APITaggerUtility.sinkTagger
 import ai.privado.utility.{StatsRecorder, Utilities}
@@ -39,11 +39,15 @@ class APITagger(
 
   val httpApis: List[Call] = apis
     .or(_.methodFullName(commonHttpPackages), _.filter(_.dynamicTypeHintFullName.exists(_.matches(commonHttpPackages))))
+    .whereNot(_.tag.nameExact(InternalTag.API_URL_MARKED.toString))
+    .whereNot(_.tag.nameExact(Constants.nodeType).valueExact(NodeType.API.toString))
     .l
 
   val clientLikeApis: List[Call] = cacheCall
     .code("(?i).*(client|connection).*[.](get|post|delete|put|patch).*")
     .name("get|post|post_json|delete|put|patch")
+    .whereNot(_.tag.nameExact(InternalTag.API_URL_MARKED.toString))
+    .whereNot(_.tag.nameExact(Constants.nodeType).valueExact(NodeType.API.toString))
     .l
 
   // Support to use `identifier` in API's

--- a/src/main/scala/ai/privado/languageEngine/ruby/tagger/sink/APITagger.scala
+++ b/src/main/scala/ai/privado/languageEngine/ruby/tagger/sink/APITagger.scala
@@ -39,15 +39,11 @@ class APITagger(
 
   val httpApis: List[Call] = apis
     .or(_.methodFullName(commonHttpPackages), _.filter(_.dynamicTypeHintFullName.exists(_.matches(commonHttpPackages))))
-    .whereNot(_.tag.nameExact(InternalTag.API_URL_MARKED.toString))
-    .whereNot(_.tag.nameExact(Constants.nodeType).valueExact(NodeType.API.toString))
     .l
 
   val clientLikeApis: List[Call] = cacheCall
     .code("(?i).*(client|connection).*[.](get|post|delete|put|patch).*")
     .name("get|post|post_json|delete|put|patch")
-    .whereNot(_.tag.nameExact(InternalTag.API_URL_MARKED.toString))
-    .whereNot(_.tag.nameExact(Constants.nodeType).valueExact(NodeType.API.toString))
     .l
 
   // Support to use `identifier` in API's

--- a/src/main/scala/ai/privado/tagger/sink/APITagger.scala
+++ b/src/main/scala/ai/privado/tagger/sink/APITagger.scala
@@ -27,7 +27,7 @@ import ai.privado.cache.{AppCache, RuleCache}
 import ai.privado.entrypoint.{PrivadoInput, ScanProcessor}
 import ai.privado.languageEngine.java.language.{NodeStarters, StepsForProperty}
 import ai.privado.languageEngine.java.semantic.JavaSemanticGenerator
-import ai.privado.model.{CatLevelOne, Constants, Language, NodeType, RuleInfo}
+import ai.privado.model.{CatLevelOne, Constants, InternalTag, Language, NodeType, RuleInfo}
 import ai.privado.tagger.PrivadoParallelCpgPass
 import ai.privado.tagger.utility.APITaggerUtility.{SERVICE_URL_REGEX_PATTERN, sinkTagger}
 import ai.privado.utility.Utilities
@@ -50,6 +50,7 @@ class APITagger(cpg: Cpg, ruleCache: RuleCache, privadoInput: PrivadoInput, appC
     .name(APISINKS_REGEX)
     .methodFullNameNot(COMMON_IGNORED_SINKS_REGEX)
     .methodFullName(commonHttpPackages)
+    .whereNot(_.tag.nameExact(InternalTag.API_URL_MARKED.toString))
     .whereNot(_.tag.nameExact(Constants.nodeType).valueExact(NodeType.API.toString))
     .l
 

--- a/src/main/scala/ai/privado/tagger/sink/APITagger.scala
+++ b/src/main/scala/ai/privado/tagger/sink/APITagger.scala
@@ -34,7 +34,6 @@ import ai.privado.utility.Utilities
 import io.joern.dataflowengineoss.queryengine.{EngineConfig, EngineContext}
 import io.shiftleft.codepropertygraph.generated.Cpg
 import io.shiftleft.semanticcpg.language.*
-import io.joern.dataflowengineoss.DefaultSemantics
 
 class APITagger(cpg: Cpg, ruleCache: RuleCache, privadoInput: PrivadoInput, appCache: AppCache)
     extends PrivadoParallelCpgPass[RuleInfo](cpg) {
@@ -50,8 +49,6 @@ class APITagger(cpg: Cpg, ruleCache: RuleCache, privadoInput: PrivadoInput, appC
     .name(APISINKS_REGEX)
     .methodFullNameNot(COMMON_IGNORED_SINKS_REGEX)
     .methodFullName(commonHttpPackages)
-    .whereNot(_.tag.nameExact(InternalTag.API_URL_MARKED.toString))
-    .whereNot(_.tag.nameExact(Constants.nodeType).valueExact(NodeType.API.toString))
     .l
 
   implicit val engineContext: EngineContext =

--- a/src/main/scala/ai/privado/tagger/utility/APITaggerUtility.scala
+++ b/src/main/scala/ai/privado/tagger/utility/APITaggerUtility.scala
@@ -153,19 +153,6 @@ object APITaggerUtility {
     apiUrlNode: Any
   ): Unit = {
     // TODO Optimise this by adding a cache mechanism
-    val flatMapList = ruleCache.getRule.inferences
-      .filter(_.catLevelTwo.equals(Constants.apiEndpoint))
-      .filter(_.domains.nonEmpty)
-      .flatMap { ruleInfo =>
-        ruleInfo.filterProperty match {
-          case FilterProperty.ENDPOINT_DOMAIN_WITH_LITERAL if domain.matches(ruleInfo.combinedRulePattern) =>
-            Some(ruleInfo.domains.head)
-          case FilterProperty.ENDPOINT_DOMAIN_WITH_PROPERTY_NAME
-              if domain.matches(ruleInfo.combinedRulePattern) && cpg.property.name(ruleInfo.domains.head).nonEmpty =>
-            Some(cpg.property.name(ruleInfo.domains.head).value.head)
-          case _ => None
-        }
-      }
     ruleCache.getRule.inferences
       .filter(_.catLevelTwo.equals(Constants.apiEndpoint))
       .filter(_.domains.nonEmpty)

--- a/src/test/scala/ai/privado/tagger/TaggerValidator.scala
+++ b/src/test/scala/ai/privado/tagger/TaggerValidator.scala
@@ -1,0 +1,23 @@
+package ai.privado.tagger
+
+import ai.privado.model.Constants
+import io.shiftleft.codepropertygraph.generated.nodes.Call
+import org.scalatest.Assertion
+import org.scalatest.matchers.should.Matchers
+import io.shiftleft.semanticcpg.language.*
+
+/** Use this trait for all the basic tagging related validation
+  */
+trait TaggerValidator extends Matchers {
+
+  /** Asserts if the given callNode has given values, default tag name is Id
+    *
+    * @param callNode
+    *   \- Expected API call node
+    * @return
+    */
+  def assertCallByTag(callNode: Call, values: List[String], name: String = Constants.id): Assertion = {
+    callNode.tag.nameExact(name).value.l shouldBe values
+  }
+
+}

--- a/src/test/scala/ai/privado/tagger/sink/LeakageValidator.scala
+++ b/src/test/scala/ai/privado/tagger/sink/LeakageValidator.scala
@@ -1,13 +1,17 @@
 package ai.privado.tagger.sink
 
 import ai.privado.model.{CatLevelOne, Constants}
+import ai.privado.tagger.TaggerValidator
 import io.shiftleft.codepropertygraph.generated.nodes.AstNode
 import io.shiftleft.semanticcpg.language.*
 import org.scalatest.{Assertion, FixtureContext, Succeeded}
 import org.scalatest.matchers.should.Matchers
-import scala.util.{Try, Success, Failure}
 
-trait LeakageValidator extends Matchers {
+import scala.util.{Failure, Success, Try}
+
+/** Use this trait for all the Leakage related validation
+  */
+trait LeakageValidator extends Matchers with TaggerValidator {
 
   def assertLeakageSink(leakageSink: AstNode): Assertion = {
     leakageSink.tag.nameExact(Constants.catLevelOne).valueExact(CatLevelOne.SINKS.name).size shouldBe 1

--- a/src/test/scala/ai/privado/tagger/sink/api/APIValidator.scala
+++ b/src/test/scala/ai/privado/tagger/sink/api/APIValidator.scala
@@ -1,12 +1,15 @@
 package ai.privado.tagger.sink.api
 
 import ai.privado.model.{CatLevelOne, Constants, NodeType, SystemConfig}
+import ai.privado.tagger.TaggerValidator
 import io.shiftleft.codepropertygraph.generated.nodes.Call
 import io.shiftleft.semanticcpg.language.*
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.Assertion
 
-trait APIValidator extends Matchers {
+/** Use this trait for all the API related validation
+  */
+trait APIValidator extends Matchers with TaggerValidator {
 
   // Keeping these rules here as there are mostly used with API Validation
   val apiIdentifier    = SystemConfig(Constants.apiIdentifier, "(?i).*url")


### PR DESCRIPTION
Context - We run inference tagger to tag API, and after than we run a API Tagger.
API's already tagged by inference, shouldn't process with API Tagger, so we have added a filtering in `sinkTagger` utility which was currently only applied for Java. But as we have opened up the inference tagger for other language as well, having it at a common place is ideal.