### PR TITLE
update validation for inference rule

### DIFF
--- a/src/main/resources/ai/privado/rulevalidator/schema/inferences.json
+++ b/src/main/resources/ai/privado/rulevalidator/schema/inferences.json
@@ -55,7 +55,7 @@
               "code",
               "method_full_name"
             ],
-            "pattern": "^(code|method_full_name|method_full_name_with_literal|method_full_name_with_property_name)$"
+            "pattern": "^(code|method_full_name|method_full_name_with_literal|method_full_name_with_property_name|endpoint_domain_with_literal|endpoint_domain_with_property_name)$"
           },
           "domains": {
             "$id": "#root/inferences/items/domains",

--- a/src/main/scala/ai/privado/entrypoint/DynamicRuleMerger.scala
+++ b/src/main/scala/ai/privado/entrypoint/DynamicRuleMerger.scala
@@ -1,6 +1,6 @@
 package ai.privado.entrypoint
 
-import ai.privado.model.{ConfigAndRules, FilterProperty, RuleInfo}
+import ai.privado.model.{ConfigAndRules, Constants, FilterProperty, RuleInfo}
 import org.slf4j.LoggerFactory
 
 import scala.collection.mutable
@@ -19,12 +19,12 @@ trait DynamicRuleMerger {
 
       val internalRuleMap = mutable.Map(
         internalSinkRules.map(rule =>
-          ((rule.domains.headOption.getOrElse(List.empty), rule.name, rule.filterProperty), rule)
+          ((rule.domains.headOption.getOrElse(Constants.Unknown), rule.name, rule.filterProperty), rule)
         )*
       )
 
       externalSinkRules.foreach { externalRule =>
-        val externalDomain         = externalRule.domains.headOption.getOrElse(List.empty)
+        val externalDomain         = externalRule.domains.headOption.getOrElse(Constants.Unknown)
         val externalRuleName       = externalRule.name
         val externalFilterProperty = externalRule.filterProperty
 
@@ -38,7 +38,11 @@ trait DynamicRuleMerger {
           case Some(_, _, _, matchingRule: RuleInfo) =>
             val updatedRule = matchingRule.copy(patterns = matchingRule.patterns ++ externalRule.patterns)
             internalRuleMap.update(
-              (matchingRule.domains.headOption.getOrElse(List.empty), matchingRule.name, matchingRule.filterProperty),
+              (
+                matchingRule.domains.headOption.getOrElse(Constants.Unknown),
+                matchingRule.name,
+                matchingRule.filterProperty
+              ),
               updatedRule
             )
           case _ =>

--- a/src/main/scala/ai/privado/entrypoint/DynamicRuleMerger.scala
+++ b/src/main/scala/ai/privado/entrypoint/DynamicRuleMerger.scala
@@ -18,13 +18,11 @@ trait DynamicRuleMerger {
     try {
 
       val internalRuleMap = mutable.Map(
-        internalSinkRules.map(rule =>
-          ((rule.domains.headOption.getOrElse(List.empty), rule.name, rule.filterProperty), rule)
-        )*
+        internalSinkRules.map(rule => ((rule.domains.headOption.get, rule.name, rule.filterProperty), rule))*
       )
 
       externalSinkRules.foreach { externalRule =>
-        val externalDomain         = externalRule.domains.headOption.getOrElse(List.empty)
+        val externalDomain         = externalRule.domains.headOption.get
         val externalRuleName       = externalRule.name
         val externalFilterProperty = externalRule.filterProperty
 
@@ -38,7 +36,7 @@ trait DynamicRuleMerger {
           case Some(_, _, _, matchingRule: RuleInfo) =>
             val updatedRule = matchingRule.copy(patterns = matchingRule.patterns ++ externalRule.patterns)
             internalRuleMap.update(
-              (matchingRule.domains.headOption.getOrElse(List.empty), matchingRule.name, matchingRule.filterProperty),
+              (matchingRule.domains.headOption.get, matchingRule.name, matchingRule.filterProperty),
               updatedRule
             )
           case _ =>

--- a/src/main/scala/ai/privado/entrypoint/DynamicRuleMerger.scala
+++ b/src/main/scala/ai/privado/entrypoint/DynamicRuleMerger.scala
@@ -1,6 +1,6 @@
 package ai.privado.entrypoint
 
-import ai.privado.model.{ConfigAndRules, Constants, FilterProperty, RuleInfo}
+import ai.privado.model.{ConfigAndRules, FilterProperty, RuleInfo}
 import org.slf4j.LoggerFactory
 
 import scala.collection.mutable
@@ -19,12 +19,12 @@ trait DynamicRuleMerger {
 
       val internalRuleMap = mutable.Map(
         internalSinkRules.map(rule =>
-          ((rule.domains.headOption.getOrElse(Constants.Unknown), rule.name, rule.filterProperty), rule)
+          ((rule.domains.headOption.getOrElse(List.empty), rule.name, rule.filterProperty), rule)
         )*
       )
 
       externalSinkRules.foreach { externalRule =>
-        val externalDomain         = externalRule.domains.headOption.getOrElse(Constants.Unknown)
+        val externalDomain         = externalRule.domains.headOption.getOrElse(List.empty)
         val externalRuleName       = externalRule.name
         val externalFilterProperty = externalRule.filterProperty
 
@@ -38,11 +38,7 @@ trait DynamicRuleMerger {
           case Some(_, _, _, matchingRule: RuleInfo) =>
             val updatedRule = matchingRule.copy(patterns = matchingRule.patterns ++ externalRule.patterns)
             internalRuleMap.update(
-              (
-                matchingRule.domains.headOption.getOrElse(Constants.Unknown),
-                matchingRule.name,
-                matchingRule.filterProperty
-              ),
+              (matchingRule.domains.headOption.getOrElse(List.empty), matchingRule.name, matchingRule.filterProperty),
               updatedRule
             )
           case _ =>

--- a/src/main/scala/ai/privado/entrypoint/DynamicRuleMerger.scala
+++ b/src/main/scala/ai/privado/entrypoint/DynamicRuleMerger.scala
@@ -18,11 +18,13 @@ trait DynamicRuleMerger {
     try {
 
       val internalRuleMap = mutable.Map(
-        internalSinkRules.map(rule => ((rule.domains.headOption.get, rule.name, rule.filterProperty), rule))*
+        internalSinkRules.map(rule =>
+          ((rule.domains.headOption.getOrElse(List.empty), rule.name, rule.filterProperty), rule)
+        )*
       )
 
       externalSinkRules.foreach { externalRule =>
-        val externalDomain         = externalRule.domains.headOption.get
+        val externalDomain         = externalRule.domains.headOption.getOrElse(List.empty)
         val externalRuleName       = externalRule.name
         val externalFilterProperty = externalRule.filterProperty
 
@@ -36,7 +38,7 @@ trait DynamicRuleMerger {
           case Some(_, _, _, matchingRule: RuleInfo) =>
             val updatedRule = matchingRule.copy(patterns = matchingRule.patterns ++ externalRule.patterns)
             internalRuleMap.update(
-              (matchingRule.domains.headOption.get, matchingRule.name, matchingRule.filterProperty),
+              (matchingRule.domains.headOption.getOrElse(List.empty), matchingRule.name, matchingRule.filterProperty),
               updatedRule
             )
           case _ =>

--- a/src/main/scala/ai/privado/model/PrivadoTag.scala
+++ b/src/main/scala/ai/privado/model/PrivadoTag.scala
@@ -254,6 +254,8 @@ object ConfigRuleType extends Enumeration {
 }
 
 object FilterProperty extends Enumeration {
+  // TODO When we update the Filter Property also update the validation regex at
+  // src/main/resources/ai/privado/rulevalidator/schema/inferences.json
   type FilterProperty = Value
   val METHOD_FULL_NAME: model.FilterProperty.Value = Value("method_full_name")
   val CODE: model.FilterProperty.Value             = Value("code")


### PR DESCRIPTION
The PR adds patch for
- Rule validation on inferences to support passing rules for endpoint_domain_with_literal and endpoint_domain_with_property_name
- domain.headOption.get can result into error for rules having empty domains and needs to be handled- Reverting this change as it is causing issue in comparison report, @ankit-privado Needs to look into why this is happening - ThirdParties.SDK.Google.Firebase in Java comparison report
