### PR TITLE
skip running dataflow passes in metadata scan

### DIFF
--- a/src/main/scala/ai/privado/entrypoint/CommandParser.scala
+++ b/src/main/scala/ai/privado/entrypoint/CommandParser.scala
@@ -47,6 +47,7 @@ case class PrivadoInput(
   disableReadDataflow: Boolean = false,
   enableAPIDisplay: Boolean = false,
   enableLambdaFlows: Boolean = false,
+  disableDataflowPass: Boolean = false,
   enableAPIByParameter: Boolean = false,
   ignoreExcludeRules: Boolean = false,
   ignoreSinkSkipRules: Boolean = false,

--- a/src/main/scala/ai/privado/languageEngine/base/processor/BaseProcessor.scala
+++ b/src/main/scala/ai/privado/languageEngine/base/processor/BaseProcessor.scala
@@ -111,10 +111,13 @@ abstract class BaseProcessor(
   def applyOverridenPasses(cpg: Cpg): Unit = List()
 
   def applyDataflowAndPostProcessingPasses(cpg: Cpg): Unit = {
-    logger.info("Applying data flow overlay")
-    val context = new LayerCreatorContext(cpg)
-    val options = new OssDataFlowOptions()
-    new OssDataFlow(options).run(context)
+    if (privadoInput.disableDataflowPass) logger.info("Skipping data flow overlay")
+    else {
+      logger.info("Applying data flow overlay")
+      val context = new LayerCreatorContext(cpg)
+      val options = new OssDataFlowOptions()
+      new OssDataFlow(options).run(context)
+    }
     if (privadoInput.enableLambdaFlows)
       new ExperimentalLambdaDataFlowSupportPass(cpg).createAndApply()
     logger.info("=====================")

--- a/src/main/scala/ai/privado/languageEngine/javascript/processor/JavascriptBaseCPGProcessor.scala
+++ b/src/main/scala/ai/privado/languageEngine/javascript/processor/JavascriptBaseCPGProcessor.scala
@@ -39,7 +39,7 @@ class JavascriptBaseCPGProcessor(
   fileLinkingMetadata: FileLinkingMetadata = new FileLinkingMetadata()
 ) extends JavascriptProcessor(
       ruleCache,
-      privadoInput,
+      privadoInput.copy(disableDataflowPass = true),
       sourceRepoLocation,
       dataFlowCache,
       auditCache,


### PR DESCRIPTION
For metadata scan we just need the Base CPG, so no need to run Dataflow passes