### PR TITLE
Changes for surfacing dependency information under sink processing section.

### DIFF
--- a/schema/src/main/scala/CpgExtSchema.scala
+++ b/schema/src/main/scala/CpgExtSchema.scala
@@ -147,7 +147,7 @@ class CpgExtSchema(builder: SchemaBuilder, cpgSchema: CpgSchema) {
     .addProperty(artifactId)
     .addProperty(configVersion)
 
-  val dependency = builder
+  val moduleDependency = builder
     .addNodeType(CpgSchemaConstants.MODULE_DEPENDENCY_NODE_NAME)
     .addProperty(groupId)
     .addProperty(artifactId)
@@ -159,10 +159,10 @@ class CpgExtSchema(builder: SchemaBuilder, cpgSchema: CpgSchema) {
   val dependencyModuleEdge = builder
     .addEdgeType(CpgSchemaConstants.DEPENDENCY_MODULE_EDGE_NAME)
 
-  module.addOutEdge(edge = dependencies, inNode = dependency)
+  module.addOutEdge(edge = dependencies, inNode = moduleDependency)
   module.addOutEdge(edge = sourceFile, inNode = file)
-  dependency.addOutEdge(edge = sourceFile, inNode = file)
-  dependency.addOutEdge(edge = dependencyModuleEdge, inNode = module)
+  moduleDependency.addOutEdge(edge = sourceFile, inNode = file)
+  moduleDependency.addOutEdge(edge = dependencyModuleEdge, inNode = module)
 
   templateDOM.addOutEdge(edge = sourceFile, inNode = file)
 
@@ -228,6 +228,10 @@ class CpgExtSchema(builder: SchemaBuilder, cpgSchema: CpgSchema) {
   private val derivedSourceEdge  = builder.addEdgeType(CpgSchemaConstants.DERIVED_SOURCE_EDGE_NAME)
   astNode.addOutEdge(edge = originalSourceEdge, inNode = astNode)
   astNode.addOutEdge(edge = derivedSourceEdge, inNode = astNode)
+
+  // Extend Dependency Node
+  dependency.addOutEdge(edge = sourceFile, inNode = file)
+  dependency.extendz(astNode)
 }
 
 object CpgExtSchema {

--- a/schema/src/main/scala/CpgExtSchema.scala
+++ b/schema/src/main/scala/CpgExtSchema.scala
@@ -231,6 +231,7 @@ class CpgExtSchema(builder: SchemaBuilder, cpgSchema: CpgSchema) {
 
   // Extend Dependency Node
   dependency.addOutEdge(edge = sourceFile, inNode = file)
+  dependency.addOutEdge(edge = taggedBy, inNode = tag)
   dependency.extendz(astNode)
 }
 

--- a/schema/src/main/scala/CpgExtSchema.scala
+++ b/schema/src/main/scala/CpgExtSchema.scala
@@ -164,6 +164,12 @@ class CpgExtSchema(builder: SchemaBuilder, cpgSchema: CpgSchema) {
   moduleDependency.addOutEdge(edge = sourceFile, inNode = file)
   moduleDependency.addOutEdge(edge = dependencyModuleEdge, inNode = module)
 
+  // Extend Dependency Node
+  dependency.addOutEdge(edge = sourceFile, inNode = file)
+  dependency.addOutEdge(edge = taggedBy, inNode = tag)
+  dependency.extendz(astNode)
+
+  // Extend teamplateDOM node
   templateDOM.addOutEdge(edge = sourceFile, inNode = file)
 
   // Nodes and edges for Android res/layout/*.xml files and
@@ -229,10 +235,6 @@ class CpgExtSchema(builder: SchemaBuilder, cpgSchema: CpgSchema) {
   astNode.addOutEdge(edge = originalSourceEdge, inNode = astNode)
   astNode.addOutEdge(edge = derivedSourceEdge, inNode = astNode)
 
-  // Extend Dependency Node
-  dependency.addOutEdge(edge = sourceFile, inNode = file)
-  dependency.addOutEdge(edge = taggedBy, inNode = tag)
-  dependency.extendz(astNode)
 }
 
 object CpgExtSchema {

--- a/src/main/scala/ai/privado/entrypoint/CommandParser.scala
+++ b/src/main/scala/ai/privado/entrypoint/CommandParser.scala
@@ -158,7 +158,7 @@ object CommandParser {
     Map(
       CommandConstants.SCAN     -> ScanProcessor,
       CommandConstants.UPLOAD   -> UploadProcessor,
-      CommandConstants.VALIDATE -> RuleValidator,
+      CommandConstants.VALIDATE -> RuleValidatorProcessor,
       CommandConstants.METADATA -> MetadataProcessor
     )
   def parse(args: Array[String], statsRecorder: StatsRecorder): Option[CommandProcessor] = {

--- a/src/main/scala/ai/privado/entrypoint/MetadataProcessor.scala
+++ b/src/main/scala/ai/privado/entrypoint/MetadataProcessor.scala
@@ -1,25 +1,17 @@
 package ai.privado.entrypoint
 
-import ai.privado.cache.{
-  AppCache,
-  AuditCache,
-  DataFlowCache,
-  DatabaseDetailsCache,
-  FileLinkingMetadata,
-  PropertyFilterCache,
-  S3DatabaseDetailsCache
-}
+import ai.privado.cache.*
+import ai.privado.entrypoint.MetadataProcessor.statsRecorder
+import ai.privado.inputprocessor.RuleProcessor
 import ai.privado.languageEngine.javascript.processor.JavascriptBaseCPGProcessor
 import ai.privado.languageEngine.python.processor.PythonBaseCPGProcessor
 import ai.privado.metadata.SystemInfo
 import ai.privado.metric.MetricHandler
-import ai.privado.model.Constants
-import ai.privado.model.Language.UNKNOWN
 import ai.privado.model.*
+import ai.privado.model.Language.UNKNOWN
 import better.files.File
 import io.circe.Json
 import io.joern.console.cpgcreation.guessLanguage
-import ai.privado.entrypoint.MetadataProcessor.statsRecorder
 
 import scala.util.{Failure, Success, Try}
 

--- a/src/main/scala/ai/privado/entrypoint/RuleValidatorProcessor.scala
+++ b/src/main/scala/ai/privado/entrypoint/RuleValidatorProcessor.scala
@@ -6,7 +6,7 @@ import ai.privado.rulevalidator.YamlFileValidator
 import better.files.File
 import org.slf4j.LoggerFactory
 
-object RuleValidator extends CommandProcessor {
+object RuleValidatorProcessor extends CommandProcessor {
 
   private val logger = LoggerFactory.getLogger(this.getClass)
 

--- a/src/main/scala/ai/privado/entrypoint/ScanProcessor.scala
+++ b/src/main/scala/ai/privado/entrypoint/ScanProcessor.scala
@@ -47,7 +47,6 @@ import io.joern.x2cpg.SourceFiles
 import org.slf4j.LoggerFactory
 import privado_core.BuildInfo
 
-import java.io.File as JFile
 import scala.sys.exit
 import scala.util.Try
 
@@ -100,9 +99,7 @@ object ScanProcessor extends CommandProcessor with RuleProcessor with Dependency
     MetricHandler.metricsData("language") = Json.fromString(languageDetected.toString)
     val dependencies: List[DependencyInfo] = config.externalConfigPath.headOption match {
       case Some(externalConfigPath) =>
-        parseDependencyInfo(
-          List(externalConfigPath, "config", "dependencyInfo", "dependencyinfo.json").mkString(JFile.separator)
-        )
+        parseDependencyInfo(generateDependencyInfoJsonPath(externalConfigPath))
       case None => List()
     }
     languageDetected match {

--- a/src/main/scala/ai/privado/entrypoint/ScanProcessor.scala
+++ b/src/main/scala/ai/privado/entrypoint/ScanProcessor.scala
@@ -24,6 +24,7 @@ package ai.privado.entrypoint
 
 import ai.privado.cache.*
 import ai.privado.entrypoint.ScanProcessor.statsRecorder
+import ai.privado.inputprocessor.RuleProcessor
 import ai.privado.languageEngine.c.processor.CProcessor
 import ai.privado.languageEngine.csharp.processor.CSharpProcessor
 import ai.privado.languageEngine.default.processor.DefaultProcessor
@@ -47,7 +48,7 @@ import org.slf4j.LoggerFactory
 import privado_core.BuildInfo
 
 import scala.sys.exit
-import scala.util.{Try}
+import scala.util.Try
 
 object ScanProcessor extends CommandProcessor with RuleProcessor {
   private val logger = LoggerFactory.getLogger(this.getClass)

--- a/src/main/scala/ai/privado/entrypoint/ScanProcessor.scala
+++ b/src/main/scala/ai/privado/entrypoint/ScanProcessor.scala
@@ -126,7 +126,8 @@ object ScanProcessor extends CommandProcessor with RuleProcessor with Dependency
             statsRecorder = statsRecorder,
             databaseDetailsCache = databaseDetailsCache,
             propertyFilterCache = propertyFilterCache,
-            fileLinkingMetadata = fileLinkingMetadata
+            fileLinkingMetadata = fileLinkingMetadata,
+            dependencies = dependencies
           ).processCpg()
         else
           KotlinProcessor(
@@ -140,7 +141,8 @@ object ScanProcessor extends CommandProcessor with RuleProcessor with Dependency
             statsRecorder = statsRecorder,
             databaseDetailsCache = databaseDetailsCache,
             propertyFilterCache = propertyFilterCache,
-            fileLinkingMetadata = fileLinkingMetadata
+            fileLinkingMetadata = fileLinkingMetadata,
+            dependencies = dependencies
           ).processCpg()
       case Language.JAVASCRIPT =>
         statsRecorder.justLogMessage("Detected language 'JavaScript'")
@@ -155,7 +157,8 @@ object ScanProcessor extends CommandProcessor with RuleProcessor with Dependency
           statsRecorder = statsRecorder,
           databaseDetailsCache = databaseDetailsCache,
           propertyFilterCache = propertyFilterCache,
-          fileLinkingMetadata = fileLinkingMetadata
+          fileLinkingMetadata = fileLinkingMetadata,
+          dependencies = dependencies
         ).processCpg()
       case Language.PYTHON =>
         statsRecorder.justLogMessage("Detected language 'Python'")
@@ -170,7 +173,8 @@ object ScanProcessor extends CommandProcessor with RuleProcessor with Dependency
           propertyFilterCache = propertyFilterCache,
           databaseDetailsCache = databaseDetailsCache,
           statsRecorder = statsRecorder,
-          fileLinkingMetadata = fileLinkingMetadata
+          fileLinkingMetadata = fileLinkingMetadata,
+          dependencies = dependencies
         ).processCpg()
       case Language.RUBY =>
         statsRecorder.justLogMessage("Detected language 'Ruby'")
@@ -184,7 +188,8 @@ object ScanProcessor extends CommandProcessor with RuleProcessor with Dependency
           appCache,
           propertyFilterCache = propertyFilterCache,
           statsRecorder = statsRecorder,
-          fileLinkingMetadata = fileLinkingMetadata
+          fileLinkingMetadata = fileLinkingMetadata,
+          dependencies = dependencies
         ).processCpg()
       case Language.GO =>
         statsRecorder.justLogMessage("Detected language 'Go'")
@@ -199,7 +204,8 @@ object ScanProcessor extends CommandProcessor with RuleProcessor with Dependency
           propertyFilterCache = propertyFilterCache,
           statsRecorder = statsRecorder,
           databaseDetailsCache = databaseDetailsCache,
-          fileLinkingMetadata = fileLinkingMetadata
+          fileLinkingMetadata = fileLinkingMetadata,
+          dependencies = dependencies
         ).processCpg()
       case Language.KOTLIN =>
         statsRecorder.justLogMessage("Detected language 'Kotlin'")
@@ -214,7 +220,8 @@ object ScanProcessor extends CommandProcessor with RuleProcessor with Dependency
           statsRecorder = statsRecorder,
           databaseDetailsCache = databaseDetailsCache,
           propertyFilterCache = propertyFilterCache,
-          fileLinkingMetadata = fileLinkingMetadata
+          fileLinkingMetadata = fileLinkingMetadata,
+          dependencies = dependencies
         ).processCpg()
       case Language.CSHARP =>
         statsRecorder.justLogMessage("Detected language 'C#'")
@@ -229,7 +236,8 @@ object ScanProcessor extends CommandProcessor with RuleProcessor with Dependency
           statsRecorder = statsRecorder,
           databaseDetailsCache = databaseDetailsCache,
           propertyFilterCache = propertyFilterCache,
-          fileLinkingMetadata = fileLinkingMetadata
+          fileLinkingMetadata = fileLinkingMetadata,
+          dependencies = dependencies
         ).processCpg()
       case Language.PHP =>
         statsRecorder.justLogMessage("Detected language 'PHP'")
@@ -244,7 +252,8 @@ object ScanProcessor extends CommandProcessor with RuleProcessor with Dependency
           statsRecorder = statsRecorder,
           databaseDetailsCache = databaseDetailsCache,
           propertyFilterCache = propertyFilterCache,
-          fileLinkingMetadata = fileLinkingMetadata
+          fileLinkingMetadata = fileLinkingMetadata,
+          dependencies = dependencies
         )
           .processCpg()
       case Language.C =>

--- a/src/main/scala/ai/privado/exporter/SinkExporter.scala
+++ b/src/main/scala/ai/privado/exporter/SinkExporter.scala
@@ -145,7 +145,7 @@ class SinkExporter(
           .where(filterSink)
           .l ++ cpg.argument.isFieldIdentifier.where(filterSink).l ++ cpg.method.where(filterSink).l ++ cpg.dbNode
           .where(filterSink)
-          .l ++ cpg.highTouchSink.where(filterSink).l
+          .l ++ cpg.highTouchSink.where(filterSink).l ++ cpg.dependency.where(filterSink).l
     ExporterUtility.filterNodeBasedOnRepoItemTagName(sinks, repoItemTagName)
   }
 

--- a/src/main/scala/ai/privado/inputprocessor/DependencyTaggingProcessor.scala
+++ b/src/main/scala/ai/privado/inputprocessor/DependencyTaggingProcessor.scala
@@ -10,6 +10,7 @@ case class DependencyInfo(
   groupId: String,
   dependencyName: String,
   version: String,
+  code: String,
   ruleId: String,
   ruleName: String,
   ruleDomains: List[String],

--- a/src/main/scala/ai/privado/inputprocessor/DependencyTaggingProcessor.scala
+++ b/src/main/scala/ai/privado/inputprocessor/DependencyTaggingProcessor.scala
@@ -1,0 +1,36 @@
+package ai.privado.inputprocessor
+
+import org.slf4j.LoggerFactory
+import upickle.default.*
+
+import java.nio.file.{Files, Paths}
+import scala.util.{Failure, Success, Try}
+
+case class DependencyInfo(
+  groupId: String,
+  dependencyName: String,
+  version: String,
+  ruleId: String,
+  ruleName: String,
+  ruleDomains: List[String],
+  ruleTags: List[String],
+  lineNumber: Int,
+  filePath: String
+)
+
+object DependencyInfo {
+  implicit val reader: Reader[DependencyInfo] = macroR[DependencyInfo]
+}
+class DependencyTaggingProcessor {
+  private val logger = LoggerFactory.getLogger(this.getClass)
+
+  def parse(filePath: String): List[DependencyInfo] = {
+    // Manually provide a reader for List[DependencyInfo]
+    Try(read[List[DependencyInfo]](new String(Files.readAllBytes(Paths.get(filePath))))) match {
+      case Success(dependencies) => dependencies
+      case Failure(exception) =>
+        logger.error(s"Error while parsing $filePath : ", exception)
+        List()
+    }
+  }
+}

--- a/src/main/scala/ai/privado/inputprocessor/DependencyTaggingProcessor.scala
+++ b/src/main/scala/ai/privado/inputprocessor/DependencyTaggingProcessor.scala
@@ -16,15 +16,19 @@ case class DependencyInfo(
   ruleTags: List[String],
   lineNumber: Int,
   filePath: String
-)
+) {
+  def getFullDependencyName(): String = {
+    if groupId.isEmpty then dependencyName else s"$groupId.$dependencyName"
+  }
+}
 
 object DependencyInfo {
   implicit val reader: Reader[DependencyInfo] = macroR[DependencyInfo]
 }
-class DependencyTaggingProcessor {
+trait DependencyTaggingProcessor {
   private val logger = LoggerFactory.getLogger(this.getClass)
 
-  def parse(filePath: String): List[DependencyInfo] = {
+  def parseDependencyInfo(filePath: String): List[DependencyInfo] = {
     // Manually provide a reader for List[DependencyInfo]
     Try(read[List[DependencyInfo]](new String(Files.readAllBytes(Paths.get(filePath))))) match {
       case Success(dependencies) => dependencies

--- a/src/main/scala/ai/privado/inputprocessor/DependencyTaggingProcessor.scala
+++ b/src/main/scala/ai/privado/inputprocessor/DependencyTaggingProcessor.scala
@@ -3,9 +3,9 @@ package ai.privado.inputprocessor
 import org.slf4j.LoggerFactory
 import upickle.default.*
 
+import java.io.File as JFile
 import java.nio.file.{Files, Paths}
 import scala.util.{Failure, Success, Try}
-
 case class DependencyInfo(
   groupId: String,
   dependencyName: String,
@@ -29,6 +29,8 @@ object DependencyInfo {
 trait DependencyTaggingProcessor {
   private val logger = LoggerFactory.getLogger(this.getClass)
 
+  def generateDependencyInfoJsonPath(externalConfigPath: String): String =
+    List(externalConfigPath, "config", "dependencyInfo", "dependencyinfo.json").mkString(JFile.separator)
   def parseDependencyInfo(filePath: String): List[DependencyInfo] = {
     // Manually provide a reader for List[DependencyInfo]
     Try(read[List[DependencyInfo]](new String(Files.readAllBytes(Paths.get(filePath))))) match {

--- a/src/main/scala/ai/privado/inputprocessor/DynamicRuleMerger.scala
+++ b/src/main/scala/ai/privado/inputprocessor/DynamicRuleMerger.scala
@@ -1,11 +1,10 @@
-package ai.privado.entrypoint
+package ai.privado.inputprocessor
 
 import ai.privado.model.{ConfigAndRules, FilterProperty, RuleInfo}
 import org.slf4j.LoggerFactory
 
 import scala.collection.mutable
-import scala.collection.mutable.Map
-import scala.collection.mutable.ListBuffer
+import scala.collection.mutable.{ListBuffer, Map}
 
 trait DynamicRuleMerger {
 

--- a/src/main/scala/ai/privado/inputprocessor/RuleProcessor.scala
+++ b/src/main/scala/ai/privado/inputprocessor/RuleProcessor.scala
@@ -1,19 +1,20 @@
-package ai.privado.entrypoint
+package ai.privado.inputprocessor
 
 import ai.privado.cache.{AppCache, RuleCache}
+import ai.privado.entrypoint.PrivadoInput
 import ai.privado.metric.MetricHandler
 import ai.privado.model.*
 import ai.privado.model.Language.Language
 import ai.privado.rulevalidator.YamlFileValidator
 import ai.privado.utility.StatsRecorder
+import ai.privado.utility.Utilities.{isValidDEDRule, isValidRule}
 import better.files.File
+import io.circe.Json
+import io.circe.yaml.parser
 import org.slf4j.LoggerFactory
 
 import scala.collection.parallel.CollectionConverters.ImmutableIterableIsParallelizable
 import scala.sys.exit
-import io.circe.yaml.parser
-import ai.privado.utility.Utilities.{isValidDEDRule, isValidRule}
-import io.circe.Json
 
 trait RuleProcessor extends DynamicRuleMerger {
 

--- a/src/main/scala/ai/privado/languageEngine/base/processor/BaseProcessor.scala
+++ b/src/main/scala/ai/privado/languageEngine/base/processor/BaseProcessor.scala
@@ -5,22 +5,19 @@ import ai.privado.cache.*
 import ai.privado.dataflow.Dataflow
 import ai.privado.entrypoint.PrivadoInput
 import ai.privado.exporter.{ExcelExporter, JSONExporter}
+import ai.privado.inputprocessor.DependencyInfo
 import ai.privado.languageEngine.java.cache.ModuleCache
-import ai.privado.languageEngine.java.passes.config.{JavaPropertyLinkerPass, ModuleFilePass}
+import ai.privado.languageEngine.java.passes.config.ModuleFilePass
 import ai.privado.languageEngine.java.passes.module.{DependenciesCategoryPass, DependenciesNodePass}
 import ai.privado.metric.MetricHandler
 import ai.privado.model.Constants.*
 import ai.privado.model.Language.Language
 import ai.privado.model.{CpgWithOutputMap, Language}
 import ai.privado.passes.ExperimentalLambdaDataFlowSupportPass
-import ai.privado.semantic.language.*
-import ai.privado.tagger.PrivadoParallelCpgPass
-import ai.privado.utility.{PropertyParserPass, StatsRecorder, UnresolvedReportUtility}
+import ai.privado.utility.{StatsRecorder, UnresolvedReportUtility}
 import io.circe.Json
 import io.joern.dataflowengineoss.language.Path
 import io.joern.dataflowengineoss.layers.dataflows.{OssDataFlow, OssDataFlowOptions}
-import io.joern.javasrc2cpg.Config
-import io.joern.x2cpg.X2CpgConfig
 import io.shiftleft.codepropertygraph.generated.Cpg
 import io.shiftleft.codepropertygraph.generated.nodes.ModuleDependency
 import io.shiftleft.passes.CpgPassBase
@@ -28,10 +25,10 @@ import io.shiftleft.semanticcpg.language.*
 import io.shiftleft.semanticcpg.layers.LayerCreatorContext
 import org.slf4j.{Logger, LoggerFactory}
 
-import java.util.Calendar
 import scala.collection.mutable
 import scala.collection.mutable.ListBuffer
 import scala.util.{Failure, Success, Try}
+
 abstract class BaseProcessor(
   ruleCache: RuleCache,
   privadoInput: PrivadoInput,
@@ -45,7 +42,8 @@ abstract class BaseProcessor(
   returnClosedCpg: Boolean,
   databaseDetailsCache: DatabaseDetailsCache,
   propertyFilterCache: PropertyFilterCache = new PropertyFilterCache(),
-  fileLinkingMetadata: FileLinkingMetadata = new FileLinkingMetadata()
+  fileLinkingMetadata: FileLinkingMetadata = new FileLinkingMetadata(),
+  dependencies: List[DependencyInfo] = List()
 ) {
 
   val logger: Logger = LoggerFactory.getLogger(getClass)
@@ -151,6 +149,7 @@ abstract class BaseProcessor(
     result
   }
 
+  def applyDependencyInfo(cpg: Cpg): Unit                        = {}
   def runPrivadoTagger(cpg: Cpg, taggerCache: TaggerCache): Unit = ???
 
   protected def applyFinalExport(

--- a/src/main/scala/ai/privado/languageEngine/base/processor/BaseProcessor.scala
+++ b/src/main/scala/ai/privado/languageEngine/base/processor/BaseProcessor.scala
@@ -13,7 +13,8 @@ import ai.privado.metric.MetricHandler
 import ai.privado.model.Constants.*
 import ai.privado.model.Language.Language
 import ai.privado.model.{CpgWithOutputMap, Language}
-import ai.privado.passes.ExperimentalLambdaDataFlowSupportPass
+import ai.privado.passes.{DependencyNodePass, ExperimentalLambdaDataFlowSupportPass}
+import ai.privado.tagger.sink.DependencyNodeTagger
 import ai.privado.utility.{StatsRecorder, UnresolvedReportUtility}
 import io.circe.Json
 import io.joern.dataflowengineoss.language.Path
@@ -100,7 +101,7 @@ abstract class BaseProcessor(
     * @param cpg
     * @return
     */
-  def applyPrivadoPasses(cpg: Cpg): List[CpgPassBase] = List()
+  def applyPrivadoPasses(cpg: Cpg): List[CpgPassBase] = List(DependencyNodePass(cpg, dependencies, sourceRepoLocation))
 
   /** Method to apply Dataflow pass
     * @param cpg
@@ -149,8 +150,9 @@ abstract class BaseProcessor(
     result
   }
 
-  def applyDependencyInfo(cpg: Cpg): Unit                        = {}
-  def runPrivadoTagger(cpg: Cpg, taggerCache: TaggerCache): Unit = ???
+  def runPrivadoTagger(cpg: Cpg, taggerCache: TaggerCache): Unit = {
+    DependencyNodeTagger(cpg, dependencies, ruleCache).createAndApply()
+  }
 
   protected def applyFinalExport(
     cpg: Cpg,

--- a/src/main/scala/ai/privado/languageEngine/csharp/processor/CSharpProcessor.scala
+++ b/src/main/scala/ai/privado/languageEngine/csharp/processor/CSharpProcessor.scala
@@ -26,6 +26,7 @@ package ai.privado.languageEngine.csharp.processor
 import ai.privado.cache.*
 import ai.privado.entrypoint.*
 import ai.privado.entrypoint.ScanProcessor.config
+import ai.privado.inputprocessor.DependencyInfo
 import ai.privado.languageEngine.base.processor.BaseProcessor
 import ai.privado.languageEngine.csharp.semantic.Language.tagger
 import ai.privado.model.Constants.*
@@ -53,7 +54,8 @@ class CSharpProcessor(
   returnClosedCpg: Boolean = true,
   databaseDetailsCache: DatabaseDetailsCache = new DatabaseDetailsCache(),
   propertyFilterCache: PropertyFilterCache = new PropertyFilterCache(),
-  fileLinkingMetadata: FileLinkingMetadata = new FileLinkingMetadata()
+  fileLinkingMetadata: FileLinkingMetadata = new FileLinkingMetadata(),
+  dependencies: List[DependencyInfo]
 ) extends BaseProcessor(
       ruleCache,
       privadoInput,
@@ -67,15 +69,17 @@ class CSharpProcessor(
       returnClosedCpg,
       databaseDetailsCache,
       propertyFilterCache,
-      fileLinkingMetadata
+      fileLinkingMetadata,
+      dependencies
     ) {
   private val logger = LoggerFactory.getLogger(getClass)
 
   override def applyPrivadoPasses(cpg: Cpg): List[CpgPassBase] = {
-    List[CpgPassBase]()
+    super.applyPrivadoPasses(cpg)
   }
 
   override def runPrivadoTagger(cpg: Cpg, taggerCache: TaggerCache): Unit = {
+    super.runPrivadoTagger(cpg, taggerCache)
     cpg.runTagger(
       ruleCache,
       taggerCache,

--- a/src/main/scala/ai/privado/languageEngine/csharp/processor/CSharpProcessor.scala
+++ b/src/main/scala/ai/privado/languageEngine/csharp/processor/CSharpProcessor.scala
@@ -23,40 +23,23 @@
 
 package ai.privado.languageEngine.csharp.processor
 
-import ai.privado.audit.AuditReportEntryPoint
 import ai.privado.cache.*
-import ai.privado.dataflow.Dataflow
 import ai.privado.entrypoint.*
 import ai.privado.entrypoint.ScanProcessor.config
-import ai.privado.entrypoint.ScanProcessor
-import ai.privado.exporter.{ExcelExporter, JSONExporter}
 import ai.privado.languageEngine.base.processor.BaseProcessor
 import ai.privado.languageEngine.csharp.semantic.Language.tagger
-import ai.privado.languageEngine.java.passes.config.JavaPropertyLinkerPass
-import ai.privado.metric.MetricHandler
 import ai.privado.model.Constants.*
-import ai.privado.model.Language.Language
-import ai.privado.model.{CatLevelOne, Constants, CpgWithOutputMap, Language}
-import ai.privado.passes.*
-import ai.privado.semantic.language.*
+import ai.privado.model.{Constants, CpgWithOutputMap, Language}
+import ai.privado.utility.StatsRecorder
 import ai.privado.utility.Utilities.createCpgFolder
-import ai.privado.utility.{PropertyParserPass, StatsRecorder}
-import better.files.File
-import io.circe.Json
 import io.joern.csharpsrc2cpg.*
-import io.joern.dataflowengineoss.language.Path
-import io.joern.dataflowengineoss.layers.dataflows.{OssDataFlow, OssDataFlowOptions}
 import io.joern.x2cpg.X2Cpg
 import io.shiftleft.codepropertygraph
 import io.shiftleft.codepropertygraph.generated.Cpg
 import io.shiftleft.passes.CpgPassBase
-import io.shiftleft.semanticcpg.language.*
-import io.shiftleft.semanticcpg.layers.LayerCreatorContext
 import org.slf4j.LoggerFactory
 
-import java.util.Calendar
-import scala.collection.mutable.ListBuffer
-import scala.util.{Failure, Success, Try}
+import scala.util.Try
 
 class CSharpProcessor(
   ruleCache: RuleCache,

--- a/src/main/scala/ai/privado/languageEngine/go/processor/GoProcessor.scala
+++ b/src/main/scala/ai/privado/languageEngine/go/processor/GoProcessor.scala
@@ -3,20 +3,20 @@ package ai.privado.languageEngine.go.processor
 import ai.privado.audit.AuditReportEntryPoint
 import ai.privado.cache.*
 import ai.privado.dataflow.Dataflow
-import ai.privado.entrypoint.ScanProcessor.config
 import ai.privado.entrypoint.PrivadoInput
+import ai.privado.entrypoint.ScanProcessor.config
 import ai.privado.languageEngine.base.processor.BaseProcessor
 import ai.privado.languageEngine.go.passes.SQLQueryParser
 import ai.privado.languageEngine.go.passes.config.GoYamlLinkerPass
 import ai.privado.languageEngine.go.passes.orm.ORMParserPass
 import ai.privado.languageEngine.go.semantic.Language.tagger
-import ai.privado.semantic.*
 import ai.privado.model.Constants.*
 import ai.privado.model.{CatLevelOne, Constants, CpgWithOutputMap, Language}
 import ai.privado.passes.*
+import ai.privado.semantic.*
 import ai.privado.semantic.language.*
+import ai.privado.utility.StatsRecorder
 import ai.privado.utility.Utilities.createCpgFolder
-import ai.privado.utility.{PropertyParserPass, StatsRecorder}
 import io.joern.gosrc2cpg.{Config, GoSrc2Cpg}
 import io.joern.x2cpg.X2Cpg
 import io.joern.x2cpg.X2Cpg.applyDefaultOverlays

--- a/src/main/scala/ai/privado/languageEngine/go/processor/GoProcessor.scala
+++ b/src/main/scala/ai/privado/languageEngine/go/processor/GoProcessor.scala
@@ -1,20 +1,17 @@
 package ai.privado.languageEngine.go.processor
 
-import ai.privado.audit.AuditReportEntryPoint
 import ai.privado.cache.*
-import ai.privado.dataflow.Dataflow
 import ai.privado.entrypoint.PrivadoInput
-import ai.privado.entrypoint.ScanProcessor.config
+import ai.privado.inputprocessor.DependencyInfo
 import ai.privado.languageEngine.base.processor.BaseProcessor
 import ai.privado.languageEngine.go.passes.SQLQueryParser
 import ai.privado.languageEngine.go.passes.config.GoYamlLinkerPass
 import ai.privado.languageEngine.go.passes.orm.ORMParserPass
 import ai.privado.languageEngine.go.semantic.Language.tagger
 import ai.privado.model.Constants.*
-import ai.privado.model.{CatLevelOne, Constants, CpgWithOutputMap, Language}
+import ai.privado.model.{Constants, CpgWithOutputMap, Language}
 import ai.privado.passes.*
 import ai.privado.semantic.*
-import ai.privado.semantic.language.*
 import ai.privado.utility.StatsRecorder
 import ai.privado.utility.Utilities.createCpgFolder
 import io.joern.gosrc2cpg.{Config, GoSrc2Cpg}
@@ -23,7 +20,6 @@ import io.joern.x2cpg.X2Cpg.applyDefaultOverlays
 import io.shiftleft.codepropertygraph
 import io.shiftleft.codepropertygraph.generated.Cpg
 import io.shiftleft.passes.CpgPassBase
-import io.shiftleft.semanticcpg.language.*
 import org.slf4j.LoggerFactory
 
 class GoProcessor(
@@ -38,7 +34,8 @@ class GoProcessor(
   returnClosedCpg: Boolean = true,
   databaseDetailsCache: DatabaseDetailsCache = new DatabaseDetailsCache(),
   propertyFilterCache: PropertyFilterCache = new PropertyFilterCache(),
-  fileLinkingMetadata: FileLinkingMetadata = new FileLinkingMetadata()
+  fileLinkingMetadata: FileLinkingMetadata = new FileLinkingMetadata(),
+  dependencies: List[DependencyInfo]
 ) extends BaseProcessor(
       ruleCache,
       privadoInput,
@@ -52,12 +49,13 @@ class GoProcessor(
       returnClosedCpg,
       databaseDetailsCache,
       propertyFilterCache,
-      fileLinkingMetadata
+      fileLinkingMetadata,
+      dependencies
     ) {
   private val logger = LoggerFactory.getLogger(getClass)
 
   override def applyPrivadoPasses(cpg: Cpg): List[CpgPassBase] = {
-    List(
+    super.applyPrivadoPasses(cpg) ++ List(
       {
         if (privadoInput.assetDiscovery)
           new JsonPropertyParserPass(cpg, s"$sourceRepoLocation/${Constants.generatedConfigFolderName}")
@@ -72,6 +70,7 @@ class GoProcessor(
   }
 
   override def runPrivadoTagger(cpg: Cpg, taggerCache: TaggerCache): Unit = {
+    super.runPrivadoTagger(cpg, taggerCache)
     cpg.runTagger(
       ruleCache,
       taggerCache,

--- a/src/main/scala/ai/privado/languageEngine/java/processor/JavaProcessor.scala
+++ b/src/main/scala/ai/privado/languageEngine/java/processor/JavaProcessor.scala
@@ -41,7 +41,7 @@ import ai.privado.passes.*
 import ai.privado.semantic.language.*
 import ai.privado.tagger.PrivadoParallelCpgPass
 import ai.privado.utility.Utilities.createCpgFolder
-import ai.privado.utility.{PropertyParserPass, StatsRecorder, UnresolvedReportUtility}
+import ai.privado.utility.{StatsRecorder, UnresolvedReportUtility}
 import better.files.File
 import io.circe.Json
 import io.joern.dataflowengineoss.layers.dataflows.{OssDataFlow, OssDataFlowOptions}

--- a/src/main/scala/ai/privado/languageEngine/java/processor/JavaProcessor.scala
+++ b/src/main/scala/ai/privado/languageEngine/java/processor/JavaProcessor.scala
@@ -23,42 +23,30 @@
 
 package ai.privado.languageEngine.java.processor
 
-import ai.privado.audit.{AuditReportEntryPoint, DependencyReport}
 import ai.privado.cache.*
 import ai.privado.entrypoint.PrivadoInput
-import ai.privado.exporter.{ExcelExporter, JSONExporter}
+import ai.privado.inputprocessor.DependencyInfo
 import ai.privado.languageEngine.base.processor.BaseProcessor
-import ai.privado.languageEngine.java.cache.ModuleCache
-import ai.privado.languageEngine.java.passes.config.{JavaPropertyLinkerPass, JavaYamlLinkerPass, ModuleFilePass}
+import ai.privado.languageEngine.java.passes.config.{JavaPropertyLinkerPass, JavaYamlLinkerPass}
 import ai.privado.languageEngine.java.passes.methodFullName.LoggerLombokPass
-import ai.privado.languageEngine.java.passes.module.{DependenciesCategoryPass, DependenciesNodePass}
 import ai.privado.languageEngine.java.semantic.Language.*
-import ai.privado.metric.MetricHandler
 import ai.privado.model.Constants.*
-import ai.privado.model.Language.Language
-import ai.privado.model.{CatLevelOne, Constants, CpgWithOutputMap, Language}
+import ai.privado.model.{Constants, CpgWithOutputMap, Language}
 import ai.privado.passes.*
-import ai.privado.semantic.language.*
 import ai.privado.tagger.PrivadoParallelCpgPass
+import ai.privado.utility.StatsRecorder
 import ai.privado.utility.Utilities.createCpgFolder
-import ai.privado.utility.{StatsRecorder, UnresolvedReportUtility}
 import better.files.File
-import io.circe.Json
-import io.joern.dataflowengineoss.layers.dataflows.{OssDataFlow, OssDataFlowOptions}
 import io.joern.javasrc2cpg.{Config, JavaSrc2Cpg}
 import io.joern.x2cpg.X2Cpg.applyDefaultOverlays
 import io.joern.x2cpg.utils.ExternalCommand
 import io.joern.x2cpg.utils.dependency.DependencyResolver
+import io.shiftleft.codepropertygraph.generated.Cpg
 import io.shiftleft.codepropertygraph.generated.nodes.JavaProperty
-import io.shiftleft.codepropertygraph.generated.{Cpg, Languages}
 import io.shiftleft.passes.CpgPassBase
-import io.shiftleft.semanticcpg.language.*
-import io.shiftleft.semanticcpg.layers.LayerCreatorContext
 import org.slf4j.{Logger, LoggerFactory}
 
 import java.nio.file.Paths
-import java.util.Calendar
-import scala.collection.mutable.ListBuffer
 import scala.util.{Failure, Success, Try}
 
 class JavaProcessor(
@@ -73,7 +61,8 @@ class JavaProcessor(
   returnClosedCpg: Boolean = true,
   databaseDetailsCache: DatabaseDetailsCache = new DatabaseDetailsCache(),
   propertyFilterCache: PropertyFilterCache = new PropertyFilterCache(),
-  fileLinkingMetadata: FileLinkingMetadata = new FileLinkingMetadata()
+  fileLinkingMetadata: FileLinkingMetadata = new FileLinkingMetadata(),
+  dependencies: List[DependencyInfo]
 ) extends BaseProcessor(
       ruleCache,
       privadoInput,
@@ -87,14 +76,15 @@ class JavaProcessor(
       returnClosedCpg,
       databaseDetailsCache,
       propertyFilterCache,
-      fileLinkingMetadata
+      fileLinkingMetadata,
+      dependencies
     ) {
 
   override val logger: Logger = LoggerFactory.getLogger(getClass)
   private var cpgconfig       = Config()
 
   override def applyPrivadoPasses(cpg: Cpg): List[CpgPassBase] = {
-    List({
+    super.applyPrivadoPasses(cpg) ++ List({
       if (privadoInput.assetDiscovery)
         new JsonPropertyParserPass(cpg, s"$sourceRepoLocation/${Constants.generatedConfigFolderName}")
       else
@@ -110,7 +100,8 @@ class JavaProcessor(
       )
   }
 
-  override def runPrivadoTagger(cpg: Cpg, taggerCache: TaggerCache): Unit =
+  override def runPrivadoTagger(cpg: Cpg, taggerCache: TaggerCache): Unit = {
+    super.runPrivadoTagger(cpg, taggerCache)
     cpg.runTagger(
       ruleCache,
       taggerCache,
@@ -122,6 +113,7 @@ class JavaProcessor(
       statsRecorder,
       fileLinkingMetadata
     )
+  }
 
   override def processCpg(): Either[String, CpgWithOutputMap] = {
     val excludeFileRegex = ruleCache.getExclusionRegex

--- a/src/main/scala/ai/privado/languageEngine/javascript/processor/JavascriptBaseCPGProcessor.scala
+++ b/src/main/scala/ai/privado/languageEngine/javascript/processor/JavascriptBaseCPGProcessor.scala
@@ -12,6 +12,7 @@ import ai.privado.cache.{
   TaggerCache
 }
 import ai.privado.entrypoint.PrivadoInput
+import ai.privado.inputprocessor.DependencyInfo
 import ai.privado.metric.MetricHandler
 import ai.privado.model.Constants.{cpgOutputFileName, outputDirectoryName}
 import ai.privado.model.CpgWithOutputMap
@@ -49,7 +50,8 @@ class JavascriptBaseCPGProcessor(
       returnClosedCpg,
       databaseDetailsCache,
       propertyFilterCache,
-      fileLinkingMetadata
+      fileLinkingMetadata,
+      List()
     ) {
 
   override val logger: Logger = LoggerFactory.getLogger(this.getClass)

--- a/src/main/scala/ai/privado/languageEngine/javascript/processor/JavascriptProcessor.scala
+++ b/src/main/scala/ai/privado/languageEngine/javascript/processor/JavascriptProcessor.scala
@@ -38,7 +38,7 @@ import ai.privado.model.{CatLevelOne, Constants, CpgWithOutputMap, Language}
 import ai.privado.passes.*
 import ai.privado.semantic.language.*
 import ai.privado.utility.Utilities.createCpgFolder
-import ai.privado.utility.{PropertyParserPass, StatsRecorder, UnresolvedReportUtility}
+import ai.privado.utility.{StatsRecorder, UnresolvedReportUtility}
 import better.files.File
 import io.joern.jssrc2cpg.{Config, JsSrc2Cpg}
 import io.joern.x2cpg.X2Cpg.applyDefaultOverlays

--- a/src/main/scala/ai/privado/languageEngine/kotlin/processor/KotlinProcessor.scala
+++ b/src/main/scala/ai/privado/languageEngine/kotlin/processor/KotlinProcessor.scala
@@ -1,17 +1,7 @@
 package ai.privado.languageEngine.kotlin.processor
 
 import ai.privado.audit.{AuditReportEntryPoint, DependencyReport}
-import ai.privado.cache.{
-  AppCache,
-  AuditCache,
-  DataFlowCache,
-  DatabaseDetailsCache,
-  FileLinkingMetadata,
-  PropertyFilterCache,
-  RuleCache,
-  S3DatabaseDetailsCache,
-  TaggerCache
-}
+import ai.privado.cache.*
 import ai.privado.entrypoint.PrivadoInput
 import ai.privado.exporter.{ExcelExporter, JSONExporter}
 import ai.privado.languageEngine.base.processor.BaseProcessor
@@ -26,7 +16,7 @@ import ai.privado.model.{CatLevelOne, Constants, CpgWithOutputMap, Language}
 import ai.privado.passes.*
 import ai.privado.semantic.language.*
 import ai.privado.utility.Utilities.createCpgFolder
-import ai.privado.utility.{PropertyParserPass, StatsRecorder, UnresolvedReportUtility}
+import ai.privado.utility.{StatsRecorder, UnresolvedReportUtility}
 import better.files.File
 import io.circe.Json
 import io.joern.dataflowengineoss.layers.dataflows.{OssDataFlow, OssDataFlowOptions}

--- a/src/main/scala/ai/privado/languageEngine/kotlin/processor/KotlinProcessor.scala
+++ b/src/main/scala/ai/privado/languageEngine/kotlin/processor/KotlinProcessor.scala
@@ -1,40 +1,22 @@
 package ai.privado.languageEngine.kotlin.processor
 
-import ai.privado.audit.{AuditReportEntryPoint, DependencyReport}
 import ai.privado.cache.*
 import ai.privado.entrypoint.PrivadoInput
-import ai.privado.exporter.{ExcelExporter, JSONExporter}
+import ai.privado.inputprocessor.DependencyInfo
 import ai.privado.languageEngine.base.processor.BaseProcessor
-import ai.privado.languageEngine.java.cache.ModuleCache
-import ai.privado.languageEngine.java.passes.config.{JavaPropertyLinkerPass, ModuleFilePass}
-import ai.privado.languageEngine.java.passes.module.{DependenciesCategoryPass, DependenciesNodePass}
+import ai.privado.languageEngine.java.passes.config.JavaPropertyLinkerPass
 import ai.privado.languageEngine.kotlin.semantic.Language.*
-import ai.privado.metric.MetricHandler
 import ai.privado.model.Constants.*
-import ai.privado.model.Language.Language
-import ai.privado.model.{CatLevelOne, Constants, CpgWithOutputMap, Language}
+import ai.privado.model.{Constants, CpgWithOutputMap, Language}
 import ai.privado.passes.*
-import ai.privado.semantic.language.*
+import ai.privado.utility.StatsRecorder
 import ai.privado.utility.Utilities.createCpgFolder
-import ai.privado.utility.{StatsRecorder, UnresolvedReportUtility}
-import better.files.File
-import io.circe.Json
-import io.joern.dataflowengineoss.layers.dataflows.{OssDataFlow, OssDataFlowOptions}
 import io.joern.kotlin2cpg.{Config, Kotlin2Cpg}
 import io.joern.x2cpg.X2Cpg
-import io.joern.x2cpg.passes.base.AstLinkerPass
-import io.joern.x2cpg.passes.callgraph.NaiveCallLinker
 import io.shiftleft.codepropertygraph
 import io.shiftleft.codepropertygraph.generated.Cpg
 import io.shiftleft.passes.CpgPassBase
-import io.shiftleft.semanticcpg.language.*
-import io.shiftleft.semanticcpg.layers.LayerCreatorContext
 import org.slf4j.LoggerFactory
-
-import java.nio.file.Paths
-import java.util.Calendar
-import scala.collection.mutable.ListBuffer
-import scala.util.{Failure, Success, Try}
 class KotlinProcessor(
   ruleCache: RuleCache,
   privadoInput: PrivadoInput,
@@ -47,7 +29,8 @@ class KotlinProcessor(
   returnClosedCpg: Boolean = true,
   databaseDetailsCache: DatabaseDetailsCache = new DatabaseDetailsCache(),
   propertyFilterCache: PropertyFilterCache = PropertyFilterCache(),
-  fileLinkingMetadata: FileLinkingMetadata = new FileLinkingMetadata()
+  fileLinkingMetadata: FileLinkingMetadata = new FileLinkingMetadata(),
+  dependencies: List[DependencyInfo]
 ) extends BaseProcessor(
       ruleCache,
       privadoInput,
@@ -61,13 +44,14 @@ class KotlinProcessor(
       returnClosedCpg,
       databaseDetailsCache,
       propertyFilterCache,
-      fileLinkingMetadata
+      fileLinkingMetadata,
+      dependencies
     ) {
   override val logger   = LoggerFactory.getLogger(getClass)
   private var cpgconfig = Config()
 
   override def applyPrivadoPasses(cpg: Cpg): List[CpgPassBase] = {
-    List({
+    super.applyPrivadoPasses(cpg) ++ List({
       if (privadoInput.assetDiscovery)
         new JsonPropertyParserPass(cpg, s"$sourceRepoLocation/${Constants.generatedConfigFolderName}")
       else
@@ -89,7 +73,8 @@ class KotlinProcessor(
     statsRecorder.endLastStage()
   }
 
-  override def runPrivadoTagger(cpg: Cpg, taggerCache: TaggerCache): Unit =
+  override def runPrivadoTagger(cpg: Cpg, taggerCache: TaggerCache): Unit = {
+    super.runPrivadoTagger(cpg, taggerCache)
     cpg.runTagger(
       ruleCache,
       taggerCache,
@@ -100,6 +85,7 @@ class KotlinProcessor(
       statsRecorder,
       fileLinkingMetadata
     )
+  }
 
   override def processCpg(): Either[String, CpgWithOutputMap] = {
 

--- a/src/main/scala/ai/privado/languageEngine/php/processor/PhpProcessor.scala
+++ b/src/main/scala/ai/privado/languageEngine/php/processor/PhpProcessor.scala
@@ -24,19 +24,16 @@
 package ai.privado.languageEngine.php.processor
 
 import ai.privado.cache.*
-import ai.privado.entrypoint.ScanProcessor.config
 import ai.privado.entrypoint.PrivadoInput
+import ai.privado.inputprocessor.DependencyInfo
 import ai.privado.languageEngine.base.processor.BaseProcessor
 import ai.privado.languageEngine.php.semantic.Language.tagger
 import ai.privado.model.Constants.*
 import ai.privado.model.{CpgWithOutputMap, Language}
-import ai.privado.model.Language.Language
-import ai.privado.model.{CpgWithOutputMap, Language}
 import ai.privado.utility.StatsRecorder
 import ai.privado.utility.Utilities.createCpgFolder
-import io.circe.Json
 import io.joern.php2cpg.{Config, Php2Cpg}
-import io.joern.x2cpg.X2Cpg.{applyDefaultOverlays, newEmptyCpg}
+import io.joern.x2cpg.X2Cpg.applyDefaultOverlays
 import io.shiftleft.codepropertygraph.generated.Cpg
 import io.shiftleft.passes.CpgPassBase
 import org.slf4j.{Logger, LoggerFactory}
@@ -44,7 +41,6 @@ import org.slf4j.{Logger, LoggerFactory}
 import java.io.File
 import java.nio.file.Paths
 import java.util.Calendar
-import scala.util.Try
 
 class PhpProcessor(
   ruleCache: RuleCache,
@@ -58,7 +54,8 @@ class PhpProcessor(
   returnClosedCpg: Boolean = true,
   databaseDetailsCache: DatabaseDetailsCache = new DatabaseDetailsCache(),
   propertyFilterCache: PropertyFilterCache = new PropertyFilterCache(),
-  fileLinkingMetadata: FileLinkingMetadata = new FileLinkingMetadata()
+  fileLinkingMetadata: FileLinkingMetadata = new FileLinkingMetadata(),
+  dependencies: List[DependencyInfo]
 ) extends BaseProcessor(
       ruleCache,
       privadoInput,
@@ -72,14 +69,16 @@ class PhpProcessor(
       returnClosedCpg,
       databaseDetailsCache,
       propertyFilterCache,
-      fileLinkingMetadata
+      fileLinkingMetadata,
+      dependencies
     ) {
 
   override val logger: Logger = LoggerFactory.getLogger(this.getClass)
 
-  override def applyPrivadoPasses(cpg: Cpg): List[CpgPassBase] = List[CpgPassBase]()
+  override def applyPrivadoPasses(cpg: Cpg): List[CpgPassBase] = super.applyPrivadoPasses(cpg)
 
-  override def runPrivadoTagger(cpg: Cpg, taggerCache: TaggerCache): Unit =
+  override def runPrivadoTagger(cpg: Cpg, taggerCache: TaggerCache): Unit = {
+    super.runPrivadoTagger(cpg, taggerCache)
     cpg.runTagger(
       ruleCache,
       taggerCache,
@@ -90,6 +89,7 @@ class PhpProcessor(
       statsRecorder,
       fileLinkingMetadata
     )
+  }
 
   override def applyDataflowAndPostProcessingPasses(cpg: Cpg): Unit = {
     super.applyDataflowAndPostProcessingPasses(cpg)

--- a/src/main/scala/ai/privado/languageEngine/python/processor/PythonBaseCPGProcessor.scala
+++ b/src/main/scala/ai/privado/languageEngine/python/processor/PythonBaseCPGProcessor.scala
@@ -1,16 +1,6 @@
 package ai.privado.languageEngine.python.processor
 
-import ai.privado.cache.{
-  AppCache,
-  AuditCache,
-  DataFlowCache,
-  DatabaseDetailsCache,
-  FileLinkingMetadata,
-  PropertyFilterCache,
-  RuleCache,
-  S3DatabaseDetailsCache,
-  TaggerCache
-}
+import ai.privado.cache.*
 import ai.privado.entrypoint.PrivadoInput
 import ai.privado.metric.MetricHandler
 import ai.privado.model.Constants.{cpgOutputFileName, outputDirectoryName}
@@ -49,7 +39,8 @@ class PythonBaseCPGProcessor(
       returnClosedCpg,
       databaseDetailsCache,
       propertyFilterCache,
-      fileLinkingMetadata
+      fileLinkingMetadata,
+      List()
     ) {
 
   override val logger: Logger = LoggerFactory.getLogger(this.getClass)

--- a/src/main/scala/ai/privado/languageEngine/python/processor/PythonProcessor.scala
+++ b/src/main/scala/ai/privado/languageEngine/python/processor/PythonProcessor.scala
@@ -2,6 +2,7 @@ package ai.privado.languageEngine.python.processor
 
 import ai.privado.cache.*
 import ai.privado.entrypoint.PrivadoInput
+import ai.privado.inputprocessor.DependencyInfo
 import ai.privado.languageEngine.base.processor.BaseProcessor
 import ai.privado.languageEngine.python.config.PythonConfigPropertyPass
 import ai.privado.languageEngine.python.metadata.FileLinkingMetadataPassPython
@@ -37,7 +38,8 @@ class PythonProcessor(
   returnClosedCpg: Boolean = true,
   databaseDetailsCache: DatabaseDetailsCache = new DatabaseDetailsCache(),
   propertyFilterCache: PropertyFilterCache = new PropertyFilterCache(),
-  fileLinkingMetadata: FileLinkingMetadata = new FileLinkingMetadata()
+  fileLinkingMetadata: FileLinkingMetadata = new FileLinkingMetadata(),
+  dependencies: List[DependencyInfo]
 ) extends BaseProcessor(
       ruleCache,
       privadoInput,
@@ -51,13 +53,14 @@ class PythonProcessor(
       returnClosedCpg,
       databaseDetailsCache,
       propertyFilterCache,
-      fileLinkingMetadata
+      fileLinkingMetadata,
+      dependencies
     ) {
 
   override val logger = LoggerFactory.getLogger(getClass)
 
   override def applyPrivadoPasses(cpg: Cpg): List[CpgPassBase] = {
-    List(
+    super.applyPrivadoPasses(cpg) ++ List(
       new HTMLParserPass(cpg, sourceRepoLocation, ruleCache, privadoInputConfig = privadoInput), {
         if (privadoInput.assetDiscovery) {
           new JsonPropertyParserPass(cpg, s"$sourceRepoLocation/${Constants.generatedConfigFolderName}")
@@ -74,6 +77,7 @@ class PythonProcessor(
   }
 
   override def runPrivadoTagger(cpg: Cpg, taggerCache: TaggerCache): Unit = {
+    super.runPrivadoTagger(cpg, taggerCache)
     cpg.runTagger(
       ruleCache,
       taggerCache,

--- a/src/main/scala/ai/privado/languageEngine/python/processor/PythonProcessor.scala
+++ b/src/main/scala/ai/privado/languageEngine/python/processor/PythonProcessor.scala
@@ -1,20 +1,18 @@
 package ai.privado.languageEngine.python.processor
 
-import ai.privado.entrypoint.PrivadoInput
 import ai.privado.cache.*
+import ai.privado.entrypoint.PrivadoInput
 import ai.privado.languageEngine.base.processor.BaseProcessor
 import ai.privado.languageEngine.python.config.PythonConfigPropertyPass
 import ai.privado.languageEngine.python.metadata.FileLinkingMetadataPassPython
 import ai.privado.languageEngine.python.passes.PrivadoPythonTypeHintCallLinker
 import ai.privado.languageEngine.python.passes.config.PythonPropertyLinkerPass
 import ai.privado.languageEngine.python.semantic.Language.*
-import ai.privado.languageEngine.python.tagger.PythonS3Tagger
 import ai.privado.model.Constants.*
 import ai.privado.model.{Constants, CpgWithOutputMap, Language}
 import ai.privado.passes.*
-import ai.privado.semantic.language.*
+import ai.privado.utility.StatsRecorder
 import ai.privado.utility.Utilities.createCpgFolder
-import ai.privado.utility.{PropertyParserPass, StatsRecorder}
 import better.files.File
 import io.joern.pysrc2cpg.*
 import io.joern.x2cpg.X2Cpg.applyDefaultOverlays
@@ -23,7 +21,6 @@ import io.joern.x2cpg.passes.callgraph.NaiveCallLinker
 import io.shiftleft.codepropertygraph
 import io.shiftleft.codepropertygraph.generated.Cpg
 import io.shiftleft.passes.CpgPassBase
-import io.shiftleft.semanticcpg.language.*
 import org.slf4j.LoggerFactory
 
 import java.nio.file.Paths

--- a/src/main/scala/ai/privado/languageEngine/ruby/processor/RubyProcessor.scala
+++ b/src/main/scala/ai/privado/languageEngine/ruby/processor/RubyProcessor.scala
@@ -25,22 +25,23 @@ package ai.privado.languageEngine.ruby.processor
 
 import ai.privado.audit.{AuditReportEntryPoint, DEDSourceDiscovery}
 import ai.privado.cache.*
+import ai.privado.dataflow.Dataflow
 import ai.privado.entrypoint.ScanProcessor.config
 import ai.privado.entrypoint.{PrivadoInput, ScanProcessor}
-import ai.privado.exporter.{ExcelExporter, JSONExporter}
 import ai.privado.exporter.monolith.MonolithExporter
+import ai.privado.exporter.{ExcelExporter, JSONExporter}
+import ai.privado.languageEngine.base.processor.BaseProcessor
 import ai.privado.languageEngine.ruby.passes.*
 import ai.privado.languageEngine.ruby.passes.config.RubyPropertyLinkerPass
 import ai.privado.languageEngine.ruby.passes.download.DownloadDependenciesPass
-import ai.privado.languageEngine.ruby.passes.*
 import ai.privado.languageEngine.ruby.semantic.Language.*
 import ai.privado.metric.MetricHandler
 import ai.privado.model.Constants.{cpgOutputFileName, outputAuditFileName, outputDirectoryName, outputFileName}
 import ai.privado.model.{CatLevelOne, Constants, CpgWithOutputMap, Language}
-import ai.privado.passes.{DBTParserPass, ExperimentalLambdaDataFlowSupportPass, JsonPropertyParserPass, SQLParser}
+import ai.privado.passes.*
 import ai.privado.semantic.language.*
 import ai.privado.utility.Utilities.createCpgFolder
-import ai.privado.utility.{PropertyParserPass, StatsRecorder, UnresolvedReportUtility}
+import ai.privado.utility.{StatsRecorder, UnresolvedReportUtility}
 import better.files.File
 import io.joern.dataflowengineoss.layers.dataflows.{OssDataFlow, OssDataFlowOptions}
 import io.joern.rubysrc2cpg.deprecated.astcreation.ResourceManagedParser
@@ -63,23 +64,20 @@ import io.joern.x2cpg.{SourceFiles, ValidationMode, X2Cpg, X2CpgConfig}
 import io.shiftleft.codepropertygraph
 import io.shiftleft.codepropertygraph.generated.nodes.*
 import io.shiftleft.codepropertygraph.generated.{Cpg, Languages, Operators}
+import io.shiftleft.passes.CpgPassBase
 import io.shiftleft.semanticcpg.language.*
 import io.shiftleft.semanticcpg.layers.{LayerCreator, LayerCreatorContext}
 import org.slf4j.LoggerFactory
 import overflowdb.BatchedUpdate.DiffGraphBuilder
-import ai.privado.dataflow.Dataflow
-import ai.privado.cache.*
-import ai.privado.languageEngine.base.processor.BaseProcessor
-import io.shiftleft.passes.CpgPassBase
 
 import java.util
 import java.util.Calendar
 import java.util.concurrent.{Callable, Executors}
 import scala.collection.mutable.ListBuffer
 import scala.concurrent.*
+import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration.DurationLong
 import scala.util.{Failure, Success, Try, Using}
-import scala.concurrent.ExecutionContext.Implicits.global
 
 class RubyProcessor(
   ruleCache: RuleCache,

--- a/src/main/scala/ai/privado/passes/DependencyNodePass.scala
+++ b/src/main/scala/ai/privado/passes/DependencyNodePass.scala
@@ -1,0 +1,33 @@
+package ai.privado.passes
+
+import ai.privado.inputprocessor.DependencyInfo
+import ai.privado.tagger.PrivadoSimpleCpgPass
+import ai.privado.utility.Utilities
+import io.shiftleft.codepropertygraph.generated.nodes.{NewDependency, NewFile}
+import io.shiftleft.codepropertygraph.generated.{Cpg, EdgeTypes}
+
+import scala.collection.mutable
+class DependencyNodePass(cpg: Cpg, dependencies: List[DependencyInfo], projectRoot: String)
+    extends PrivadoSimpleCpgPass(cpg)
+    with Utility {
+  val fileNodeMap: mutable.Map[String, NewFile] = mutable.Map[String, NewFile]()
+  def run(builder: DiffGraphBuilder): Unit = {
+    dependencies.foreach(dependency => {
+      val dep = NewDependency()
+        .name(dependency.getFullDependencyName())
+        .version(dependency.version)
+        .lineNumber(dependency.lineNumber)
+        .code(dependency.code)
+
+      val fileNode = fileNodeMap.get(dependency.filePath) match {
+        case Some(fileNode) => fileNode
+        case None =>
+          val fileNode = Utilities.addFileNode(dependency.filePath, builder)
+          fileNodeMap.put(dependency.filePath, fileNode)
+          fileNode
+      }
+      builder.addNode(dep)
+      builder.addEdge(dep, fileNode, EdgeTypes.SOURCE_FILE)
+    })
+  }
+}

--- a/src/main/scala/ai/privado/passes/DependencyNodePass.scala
+++ b/src/main/scala/ai/privado/passes/DependencyNodePass.scala
@@ -7,6 +7,16 @@ import io.shiftleft.codepropertygraph.generated.nodes.{NewDependency, NewFile}
 import io.shiftleft.codepropertygraph.generated.{Cpg, EdgeTypes}
 
 import scala.collection.mutable
+
+/** This pass is using single threaded CPG pass mechanism.
+  *   a. The contents to be processed are not going to be very huge as the list contains only the identified 3p
+  *      dependencies only. b. We need to create a file node. Which can be repeated across the multiple nodes. If we use
+  *      parallel mechanism. It will be difficult to handle that use case.
+  *
+  * @param cpg
+  * @param dependencies
+  * @param projectRoot
+  */
 class DependencyNodePass(cpg: Cpg, dependencies: List[DependencyInfo], projectRoot: String)
     extends PrivadoSimpleCpgPass(cpg)
     with Utility {

--- a/src/main/scala/ai/privado/passes/Utility.scala
+++ b/src/main/scala/ai/privado/passes/Utility.scala
@@ -1,0 +1,21 @@
+package ai.privado.passes
+
+import io.shiftleft.codepropertygraph.generated.nodes.NewFile
+import overflowdb.BatchedUpdate
+
+import java.nio.file.Path
+
+trait Utility {
+
+  def addFileNode(name: String, builder: BatchedUpdate.DiffGraphBuilder, projectRoot: String): NewFile = {
+    val relativeFileName = Path.of(projectRoot).relativize(Path.of(name)).toString
+    val fileNode         = NewFile().name(relativeFileName)
+    builder.addNode(fileNode)
+    fileNode
+  }
+
+  def combinedRulePattern(patterns: List[String]): String = {
+    patterns.mkString("(", "|", ")")
+  }
+
+}

--- a/src/main/scala/ai/privado/tagger/sink/DependencyNodeTagger.scala
+++ b/src/main/scala/ai/privado/tagger/sink/DependencyNodeTagger.scala
@@ -1,0 +1,34 @@
+package ai.privado.tagger.sink
+
+import ai.privado.cache.RuleCache
+import ai.privado.inputprocessor.DependencyInfo
+import ai.privado.passes.Utility
+import ai.privado.tagger.PrivadoSimpleCpgPass
+import ai.privado.utility.Utilities
+import io.shiftleft.codepropertygraph.generated.Cpg
+import io.shiftleft.semanticcpg.language.*
+import org.slf4j.LoggerFactory
+
+class DependencyNodeTagger(cpg: Cpg, dependencies: List[DependencyInfo], ruleCache: RuleCache)
+    extends PrivadoSimpleCpgPass(cpg)
+    with Utility {
+  private val logger = LoggerFactory.getLogger(this.getClass)
+  def run(builder: DiffGraphBuilder): Unit = {
+    dependencies.foreach(dependency => {
+      cpg.dependency
+        .nameExact(dependency.getFullDependencyName())
+        .where(_.file.nameExact(dependency.filePath))
+        .headOption match {
+        case Some(dep) =>
+          ruleCache.getRuleInfo(dependency.ruleId) match {
+            case Some(rule) => Utilities.addRuleTags(builder, dep, rule, ruleCache)
+            case None =>
+              logger.error(
+                s"Dynamic rule ${dependency.ruleId} is not found inside rule cache. It seems given rule is not passed"
+              )
+          }
+        case None =>
+      }
+    })
+  }
+}

--- a/src/test/scala/ai/privado/exporter/PropertyFilterExportTest.scala
+++ b/src/test/scala/ai/privado/exporter/PropertyFilterExportTest.scala
@@ -2,7 +2,7 @@ package ai.privado.exporter
 
 import ai.privado.cache.{PropertyFilterCache, RuleCache}
 import ai.privado.model.{ConfigAndRules, Language, SystemConfig}
-import ai.privado.utility.PropertyParserPass
+import ai.privado.passes.PropertyParserPass
 import better.files.File
 import io.joern.javasrc2cpg.{Config, JavaSrc2Cpg}
 import io.joern.x2cpg.X2Cpg.applyDefaultOverlays

--- a/src/test/scala/ai/privado/exporter/RepoConfigMetadataExporterTest.scala
+++ b/src/test/scala/ai/privado/exporter/RepoConfigMetadataExporterTest.scala
@@ -2,7 +2,7 @@ package ai.privado.exporter
 
 import ai.privado.cache.RuleCache
 import ai.privado.model.{ConfigAndRules, Language, SystemConfig}
-import ai.privado.utility.PropertyParserPass
+import ai.privado.passes.PropertyParserPass
 import better.files.File
 import io.joern.javasrc2cpg.{Config, JavaSrc2Cpg}
 import io.joern.x2cpg.X2Cpg.applyDefaultOverlays

--- a/src/test/scala/ai/privado/inputprocessor/DependencyTaggingProcessorTest.scala
+++ b/src/test/scala/ai/privado/inputprocessor/DependencyTaggingProcessorTest.scala
@@ -21,6 +21,7 @@ class DependencyTaggingProcessorTest
           |    "groupId": "com.privado.sample",
           |    "dependencyName": "Scanner",
           |    "version": "1.0",
+          |    "code" : "<artifactid>Scanner</artifactid>",
           |    "ruleId": "ThirdParties.SDK.Scanner",
           |    "ruleName": "Privado Scanner",
           |    "ruleDomains": [
@@ -38,6 +39,7 @@ class DependencyTaggingProcessorTest
             "com.privado.sample",
             "Scanner",
             "1.0",
+            "<artifactid>Scanner</artifactid>",
             "ThirdParties.SDK.Scanner",
             "Privado Scanner",
             List("scanner.privado.ai"),

--- a/src/test/scala/ai/privado/inputprocessor/DependencyTaggingProcessorTest.scala
+++ b/src/test/scala/ai/privado/inputprocessor/DependencyTaggingProcessorTest.scala
@@ -5,7 +5,11 @@ import org.scalatest.BeforeAndAfterAll
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
-class DependencyTaggingProcessorTest extends AnyWordSpec with Matchers with BeforeAndAfterAll {
+class DependencyTaggingProcessorTest
+    extends AnyWordSpec
+    with Matchers
+    with BeforeAndAfterAll
+    with DependencyTaggingProcessor {
 
   "Parsing test" should {
     "Working test" in {
@@ -28,7 +32,7 @@ class DependencyTaggingProcessorTest extends AnyWordSpec with Matchers with Befo
           |  }
           |]
           |""".stripMargin)
-        val dependencies: List[DependencyInfo] = DependencyTaggingProcessor().parse(tempFile.pathAsString)
+        val dependencies: List[DependencyInfo] = parseDependencyInfo(tempFile.pathAsString)
         dependencies shouldBe List(
           DependencyInfo(
             "com.privado.sample",
@@ -46,7 +50,7 @@ class DependencyTaggingProcessorTest extends AnyWordSpec with Matchers with Befo
     }
 
     "Graceful handling of error situation" in {
-      val dependencies: List[DependencyInfo] = DependencyTaggingProcessor().parse("path/nonexistingfile.json")
+      val dependencies: List[DependencyInfo] = parseDependencyInfo("path/nonexistingfile.json")
       dependencies shouldBe List()
     }
   }

--- a/src/test/scala/ai/privado/inputprocessor/DependencyTaggingProcessorTest.scala
+++ b/src/test/scala/ai/privado/inputprocessor/DependencyTaggingProcessorTest.scala
@@ -1,0 +1,54 @@
+package ai.privado.inputprocessor
+
+import better.files.*
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+class DependencyTaggingProcessorTest extends AnyWordSpec with Matchers with BeforeAndAfterAll {
+
+  "Parsing test" should {
+    "Working test" in {
+      File.usingTemporaryDirectory("deptest") { tmpDir =>
+        val tempFile = tmpDir / "java.json";
+        tempFile.writeText("""
+          |[
+          |  {
+          |    "groupId": "com.privado.sample",
+          |    "dependencyName": "Scanner",
+          |    "version": "1.0",
+          |    "ruleId": "ThirdParties.SDK.Scanner",
+          |    "ruleName": "Privado Scanner",
+          |    "ruleDomains": [
+          |      "scanner.privado.ai"
+          |    ],
+          |    "ruleTags": [],
+          |    "lineNumber": 10,
+          |    "filePath": "/path/pom.xml"
+          |  }
+          |]
+          |""".stripMargin)
+        val dependencies: List[DependencyInfo] = DependencyTaggingProcessor().parse(tempFile.pathAsString)
+        dependencies shouldBe List(
+          DependencyInfo(
+            "com.privado.sample",
+            "Scanner",
+            "1.0",
+            "ThirdParties.SDK.Scanner",
+            "Privado Scanner",
+            List("scanner.privado.ai"),
+            List(),
+            10,
+            "/path/pom.xml"
+          )
+        )
+      }
+    }
+
+    "Graceful handling of error situation" in {
+      val dependencies: List[DependencyInfo] = DependencyTaggingProcessor().parse("path/nonexistingfile.json")
+      dependencies shouldBe List()
+    }
+  }
+
+}

--- a/src/test/scala/ai/privado/inputprocessor/DynamicRuleMergerTest.scala
+++ b/src/test/scala/ai/privado/inputprocessor/DynamicRuleMergerTest.scala
@@ -1,4 +1,4 @@
-package ai.privado.entrypoint
+package ai.privado.inputprocessor
 
 import ai.privado.cache.RuleCache
 import ai.privado.model.{CatLevelOne, ConfigAndRules, Constants, FilterProperty, Language, NodeType, RuleInfo}

--- a/src/test/scala/ai/privado/languageEngine/go/passes/config/GoYamlLinkerPassTest.scala
+++ b/src/test/scala/ai/privado/languageEngine/go/passes/config/GoYamlLinkerPassTest.scala
@@ -4,28 +4,19 @@ import ai.privado.cache.{AppCache, FileLinkingMetadata, RuleCache, TaggerCache}
 import ai.privado.entrypoint.PrivadoInput
 import ai.privado.languageEngine.go.tagger.sink.GoAPITagger
 import ai.privado.languageEngine.go.tagger.source.IdentifierTagger
-import ai.privado.model.{
-  CatLevelOne,
-  ConfigAndRules,
-  Constants,
-  FilterProperty,
-  Language,
-  NodeType,
-  RuleInfo,
-  SystemConfig
-}
-import ai.privado.utility.PropertyParserPass
+import ai.privado.model.*
+import ai.privado.passes.PropertyParserPass
+import ai.privado.semantic.language.*
 import better.files.File
 import io.joern.dataflowengineoss.layers.dataflows.{OssDataFlow, OssDataFlowOptions}
 import io.joern.gosrc2cpg.{Config, GoSrc2Cpg}
 import io.joern.x2cpg.X2Cpg.applyDefaultOverlays
 import io.shiftleft.codepropertygraph.generated.Cpg
+import io.shiftleft.semanticcpg.language.*
 import io.shiftleft.semanticcpg.layers.LayerCreatorContext
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
-import io.shiftleft.semanticcpg.language.*
-import ai.privado.semantic.language.*
 
 abstract class GoYamlLinkerPassTest extends GoYamlFileLinkerPassTestBase {
   override val yamlFileContents: String = """

--- a/src/test/scala/ai/privado/languageEngine/java/passes/config/JavaYamlLinkerPassTest.scala
+++ b/src/test/scala/ai/privado/languageEngine/java/passes/config/JavaYamlLinkerPassTest.scala
@@ -2,11 +2,12 @@ package ai.privado.languageEngine.java.passes.config
 
 import ai.privado.cache.{AppCache, FileLinkingMetadata, RuleCache, TaggerCache}
 import ai.privado.entrypoint.PrivadoInput
-import ai.privado.semantic.language.*
 import ai.privado.languageEngine.java.tagger.sink.api.JavaAPITagger
 import ai.privado.languageEngine.java.tagger.source.*
 import ai.privado.model.*
-import ai.privado.utility.{PropertyParserPass, StatsRecorder}
+import ai.privado.passes.PropertyParserPass
+import ai.privado.semantic.language.*
+import ai.privado.utility.StatsRecorder
 import better.files.File
 import io.joern.dataflowengineoss.layers.dataflows.{OssDataFlow, OssDataFlowOptions}
 import io.joern.javasrc2cpg.{Config, JavaSrc2Cpg}

--- a/src/test/scala/ai/privado/languageEngine/java/passes/config/PropertiesFilePassTest.scala
+++ b/src/test/scala/ai/privado/languageEngine/java/passes/config/PropertiesFilePassTest.scala
@@ -25,21 +25,20 @@ package ai.privado.languageEngine.java.passes.config
 
 import ai.privado.cache.{AppCache, RuleCache}
 import ai.privado.entrypoint.PrivadoInput
+import ai.privado.exporter.HttpConnectionMetadataExporter
+import ai.privado.model.{Constants, Language}
+import ai.privado.passes.PropertyParserPass
 import ai.privado.semantic.language.*
-import ai.privado.model.Language
-import ai.privado.utility.PropertyParserPass
+import ai.privado.testfixtures.JavaFrontendTestSuite
 import better.files.File
 import io.joern.javasrc2cpg.{Config, JavaSrc2Cpg}
 import io.joern.x2cpg.X2Cpg.applyDefaultOverlays
 import io.shiftleft.codepropertygraph.generated.Cpg
-import io.shiftleft.codepropertygraph.generated.nodes.{AstNode, JavaProperty, Literal, Method, MethodParameterIn}
+import io.shiftleft.codepropertygraph.generated.nodes.*
 import io.shiftleft.semanticcpg.language.*
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
-import ai.privado.exporter.HttpConnectionMetadataExporter
-import ai.privado.testfixtures.JavaFrontendTestSuite
-import ai.privado.model.Constants
 
 class AnnotationTests extends JavaFrontendTestSuite {
   "ConfigFilePass" should {

--- a/src/test/scala/ai/privado/languageEngine/java/passes/config/PropertyPassFilterTest.scala
+++ b/src/test/scala/ai/privado/languageEngine/java/passes/config/PropertyPassFilterTest.scala
@@ -2,16 +2,16 @@ package ai.privado.languageEngine.java.passes.config
 
 import ai.privado.cache.{AppCache, RuleCache}
 import ai.privado.model.{ConfigAndRules, Language, SystemConfig}
-import ai.privado.utility.PropertyParserPass
+import ai.privado.passes.PropertyParserPass
+import ai.privado.semantic.language.*
 import better.files.File
 import io.joern.javasrc2cpg.{Config, JavaSrc2Cpg}
 import io.joern.x2cpg.X2Cpg.applyDefaultOverlays
 import io.shiftleft.codepropertygraph.generated.Cpg
+import io.shiftleft.semanticcpg.language.*
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
-import io.shiftleft.semanticcpg.language.*
-import ai.privado.semantic.language.*
 
 import scala.collection.mutable
 

--- a/src/test/scala/ai/privado/languageEngine/java/tagger/sink/DependencyTaggerTest.scala
+++ b/src/test/scala/ai/privado/languageEngine/java/tagger/sink/DependencyTaggerTest.scala
@@ -1,0 +1,124 @@
+package ai.privado.languageEngine.java.tagger.sink
+
+import ai.privado.cache.RuleCache
+import ai.privado.exporter.SinkExporterValidator
+import ai.privado.inputprocessor.DependencyInfo
+import ai.privado.model
+import ai.privado.model.*
+import ai.privado.model.exporter.{DataFlowSubCategoryPathExcerptModel, SinkProcessingModel}
+import ai.privado.testfixtures.JavaFrontendTestSuite
+
+class DependencyTaggerTest extends JavaFrontendTestSuite with SinkExporterValidator {
+
+  "Java pom.xml simple use case" should {
+    val dynamicRule = List(
+      RuleInfo(
+        "ThirdParties.SDK.twilio",
+        "twilio",
+        "Third Parties",
+        FilterProperty.METHOD_FULL_NAME,
+        Array("www.twilio.com"),
+        List(".*(com.twilio.sdk).*"),
+        false,
+        "",
+        Map(),
+        NodeType.REGULAR,
+        "",
+        CatLevelOne.SINKS,
+        "",
+        Language.JAVA,
+        Array()
+      )
+    )
+    val configAndRule = ConfigAndRules(sinks = dynamicRule)
+    val ruleCache     = RuleCache().setRule(configAndRule)
+    val twilioDep = List(
+      DependencyInfo(
+        "com.twilio.sdk",
+        "twilio",
+        "8.19.1",
+        "<artifactId>twilio</artifactId>",
+        "ThirdParties.SDK.twilio",
+        "Twilio",
+        List("www.twilio.com"),
+        List(),
+        32,
+        "pom.xml"
+      )
+    )
+    val cpg = code(
+      """
+        |<?xml version="1.0" encoding="UTF-8"?>
+        |<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        |	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+        |	<modelVersion>4.0.0</modelVersion>
+        |	<parent>
+        |		<groupId>org.springframework.boot</groupId>
+        |		<artifactId>spring-boot-starter-parent</artifactId>
+        |		<version>2.5.4</version>
+        |		<relativePath/> <!-- lookup parent from repository -->
+        |	</parent>
+        |	<groupId>com.atlan</groupId>
+        |	<artifactId>SMSService</artifactId>
+        |	<version>0.0.1-SNAPSHOT</version>
+        |	<name>SMSService</name>
+        |	<description>Demo project for Spring Boot</description>
+        |	<properties>
+        |		<java.version>1.8</java.version>
+        |		<spring-cloud.version>2020.0.3</spring-cloud.version>
+        |	</properties>
+        |	<dependencies>
+        | 		<dependency>
+        |			<groupId>mysql</groupId>
+        |			<artifactId>mysql-connector-java</artifactId>
+        |		</dependency>
+        |		<dependency>
+        |			<groupId>org.springframework.boot</groupId>
+        |			<artifactId>spring-boot-starter-web</artifactId>
+        |		</dependency>
+        |		<dependency>
+        |			<groupId>com.twilio.sdk</groupId>
+        |			<artifactId>twilio</artifactId>
+        |			<version>8.19.1</version>
+        |		</dependency>
+        |		<dependency>
+        |			<groupId>org.springframework.boot</groupId>
+        |			<artifactId>spring-boot-starter-test</artifactId>
+        |			<scope>test</scope>
+        |		</dependency>
+        |	</dependencies>
+        |	<build>
+        |		<plugins>
+        |			<plugin>
+        |				<groupId>org.springframework.boot</groupId>
+        |				<artifactId>spring-boot-maven-plugin</artifactId>
+        |			</plugin>
+        |		</plugins>
+        |	</build>
+        |</project>
+        |""".stripMargin,
+      "pom.xml"
+    ).withDependencies(twilioDep).withRuleCache(ruleCache)
+
+    "Twilio dependency should get added in processing section" in {
+      val sinkProcessing = getSinkProcessings(cpg.getPrivadoJson())
+      sinkProcessing shouldBe List(
+        SinkProcessingModel(
+          sinkId = "ThirdParties.SDK.twilio",
+          occurrences = List(
+            DataFlowSubCategoryPathExcerptModel(
+              sample = "<artifactId>twilio</artifactId>",
+              lineNumber = 32,
+              columnNumber = -1,
+              fileName = "pom.xml",
+              excerpt =
+                "\t\t\t<groupId>org.springframework.boot</groupId>\n\t\t\t<artifactId>spring-boot-starter-web</artifactId>\n\t\t</dependency>\n\t\t<dependency>\n\t\t\t<groupId>com.twilio.sdk</groupId>\n\t\t\t<artifactId>twilio</artifactId> /* <===  */ \n\t\t\t<version>8.19.1</version>\n\t\t</dependency>\n\t\t<dependency>\n\t\t\t<groupId>org.springframework.boot</groupId>\n\t\t\t<artifactId>spring-boot-starter-test</artifactId>",
+              arguments = None
+            )
+          )
+        )
+      )
+    }
+  }
+
+}

--- a/src/test/scala/ai/privado/languageEngine/java/tagger/sink/DependencyTaggerTest.scala
+++ b/src/test/scala/ai/privado/languageEngine/java/tagger/sink/DependencyTaggerTest.scala
@@ -8,6 +8,7 @@ import ai.privado.model.*
 import ai.privado.model.exporter.{DataFlowSubCategoryPathExcerptModel, SinkProcessingModel}
 import ai.privado.testfixtures.JavaFrontendTestSuite
 
+import java.io.File
 import scala.collection.mutable
 
 class DependencyTaggerTest extends JavaFrontendTestSuite with SinkExporterValidator {
@@ -184,4 +185,273 @@ class DependencyTaggerTest extends JavaFrontendTestSuite with SinkExporterValida
     }
   }
 
+  "Gradle tests" should {
+    val dynamicRule = List(
+      RuleInfo(
+        "ThirdParties.SDK.Google.Play.Services",
+        "Google Play Services",
+        "Third Parties",
+        FilterProperty.METHOD_FULL_NAME,
+        Array("developers.google.com"),
+        List("(?i).*com.google.android.gms.*"),
+        false,
+        "",
+        Map(),
+        NodeType.REGULAR,
+        "",
+        CatLevelOne.SINKS,
+        "",
+        Language.JAVA,
+        Array()
+      ),
+      RuleInfo(
+        "ThirdParties.SDK.Firebase.Authentication",
+        "Firebase Authentication",
+        "Third Parties",
+        FilterProperty.METHOD_FULL_NAME,
+        Array("firebase.google.com"),
+        List("(?i).*com.google.firebase.*"),
+        false,
+        "",
+        Map(),
+        NodeType.REGULAR,
+        "",
+        CatLevelOne.SINKS,
+        "",
+        Language.JAVA,
+        Array()
+      ),
+      RuleInfo(
+        "ThirdParties.SDK.Firebase",
+        "Firebase",
+        "Third Parties",
+        FilterProperty.METHOD_FULL_NAME,
+        Array("firebase.google.com"),
+        List("(?i).*com.google.firebase.*"),
+        false,
+        "",
+        Map(),
+        NodeType.REGULAR,
+        "",
+        CatLevelOne.SINKS,
+        "",
+        Language.JAVA,
+        Array()
+      )
+    )
+
+    val configAndRule = ConfigAndRules(sinks = dynamicRule)
+    val ruleCache     = RuleCache().setRule(configAndRule)
+    val twilioDep = List(
+      DependencyInfo(
+        "com.google.android.gms",
+        "play-services-auth",
+        "17.0.0",
+        "    implementation 'com.google.android.gms:play-services-auth:17.0.0'\n",
+        "ThirdParties.SDK.Google.Play.Services",
+        "Google Play Services",
+        List("developers.google.com"),
+        List(),
+        36,
+        "app/build.gradle"
+      ),
+      DependencyInfo(
+        "com.google.firebase",
+        "firebase-auth",
+        "19.0.0",
+        "    implementation 'com.google.firebase:firebase-auth:19.0.0'\n",
+        "ThirdParties.SDK.Firebase.Authentication",
+        "Firebase Authentication",
+        List("firebase.google.com"),
+        List(),
+        35,
+        "app/build.gradle"
+      ),
+      DependencyInfo(
+        "com.google.firebase",
+        "firebase-core",
+        "17.1.0",
+        "    implementation 'com.google.firebase:firebase-core:17.1.0'\n",
+        "ThirdParties.SDK.Firebase",
+        "Firebase",
+        List("firebase.google.com"),
+        List(),
+        32,
+        "app/build.gradle"
+      ),
+      DependencyInfo(
+        "com.google.gms",
+        "google-services",
+        "4.2.0",
+        "        classpath 'com.google.gms:google-services:4.2.0'\n",
+        "ThirdParties.SDK.Google.Play.Services",
+        "Google Play Services",
+        List("play.google.com"),
+        List(),
+        11,
+        "build.gradle"
+      )
+    )
+    val cpg = code(
+      """
+        |buildscript {
+        |    repositories {
+        |        google()
+        |        jcenter()
+        |        
+        |    }
+        |    dependencies {
+        |        classpath 'com.android.tools.build:gradle:3.5.3'
+        |        classpath 'com.google.gms:google-services:4.2.0'
+        |
+        |        // NOTE: Do not place your application dependencies here; they belong
+        |        // in the individual module build.gradle files
+        |    }
+        |}
+        |
+        |allprojects {
+        |    repositories {
+        |        google()
+        |        jcenter()
+        |        
+        |    }
+        |}
+        |
+        |task clean(type: Delete) {
+        |    delete rootProject.buildDir
+        |}
+        |""".stripMargin,
+      "build.gradle"
+    ).moreCode(
+      """
+        |apply plugin: 'com.android.application'
+        |apply plugin: 'com.google.gms.google-services'
+        |
+        |android {
+        |    compileSdkVersion 29
+        |    buildToolsVersion "29.0.1"
+        |    defaultConfig {
+        |        applicationId "com.example.edu"
+        |        minSdkVersion 22
+        |        targetSdkVersion 29
+        |        versionCode 1
+        |        versionName "1.0"
+        |        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+        |    }
+        |    buildTypes {
+        |        release {
+        |            minifyEnabled false
+        |            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+        |        }
+        |    }
+        |}
+        |
+        |dependencies {
+        |    implementation fileTree(dir: 'libs', include: ['*.jar'])
+        |    implementation 'androidx.appcompat:appcompat:1.0.2'
+        |    implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
+        |    implementation 'androidx.cardview:cardview:1.0.0'
+        |    implementation 'com.android.support:appcompat-v7:29.0.0'
+        |    implementation 'com.android.support:design:29.0.1'
+        |    implementation 'androidx.appcompat:appcompat:1.0.0'
+        |    implementation 'androidx.core:core:1.0.0'
+        |    implementation 'com.google.firebase:firebase-core:17.1.0'
+        |    implementation 'com.google.firebase:firebase-auth:19.0.0'
+        |    implementation 'com.google.firebase:firebase-database:19.0.0'
+        |    implementation 'com.google.firebase:firebase-auth:19.0.0'
+        |    implementation 'com.google.android.gms:play-services-auth:17.0.0'
+        |    implementation 'com.github.d-max:spots-dialog:1.1@aar'
+        |    implementation 'com.google.android.material:material:1.0.0'
+        |    implementation 'com.android.volley:volley:1.1.1'
+        |    implementation 'com.google.firebase:firebase-messaging:20.1.0'
+        |    implementation 'br.com.simplepass:loading-button-android:1.14.0'
+        |    implementation 'com.google.android.material:material:1.0.0'
+        |    implementation 'com.google.android.material:material:1.1.0-alpha09'
+        |    implementation 'com.google.firebase:firebase-storage:16.0.4'
+        |    implementation 'androidx.navigation:navigation-fragment:2.0.0'
+        |    implementation 'androidx.navigation:navigation-ui:2.0.0'
+        |    implementation 'androidx.lifecycle:lifecycle-extensions:2.0.0'
+        |
+        |    testImplementation 'junit:junit:4.12'
+        |    androidTestImplementation 'androidx.test:runner:1.2.0'
+        |    androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
+        |}
+        |""".stripMargin,
+      List("app", "build.gradle").mkString(File.separator)
+    ).withDependencies(twilioDep)
+      .withRuleCache(ruleCache)
+
+    "3p dependency should get added in processing section" in {
+      val outjson                                                = cpg.getPrivadoJson()
+      val sinkProcessing                                         = getSinkProcessings(outjson)
+      val sinkProceMap: mutable.Map[String, SinkProcessingModel] = mutable.Map[String, SinkProcessingModel]()
+      sinkProcessing.size shouldBe 3
+      sinkProcessing.foreach(sink => {
+        sinkProceMap.put(sink.sinkId, sink)
+      })
+
+      val playServices = sinkProceMap.get("ThirdParties.SDK.Google.Play.Services")
+      playServices shouldBe Some(
+        SinkProcessingModel(
+          sinkId = "ThirdParties.SDK.Google.Play.Services",
+          occurrences = List(
+            DataFlowSubCategoryPathExcerptModel(
+              sample = "        classpath 'com.google.gms:google-services:4.2.0'\n",
+              lineNumber = 11,
+              columnNumber = -1,
+              fileName = "build.gradle",
+              excerpt =
+                "        \n    }\n    dependencies {\n        classpath 'com.android.tools.build:gradle:3.5.3'\n        classpath 'com.google.gms:google-services:4.2.0'\n /* <===  */ \n        // NOTE: Do not place your application dependencies here; they belong\n        // in the individual module build.gradle files\n    }\n}\n",
+              arguments = None
+            ),
+            DataFlowSubCategoryPathExcerptModel(
+              sample = "    implementation 'com.google.android.gms:play-services-auth:17.0.0'\n",
+              lineNumber = 36,
+              columnNumber = -1,
+              fileName = "app/build.gradle",
+              excerpt =
+                "    implementation 'androidx.appcompat:appcompat:1.0.0'\n    implementation 'androidx.core:core:1.0.0'\n    implementation 'com.google.firebase:firebase-core:17.1.0'\n    implementation 'com.google.firebase:firebase-auth:19.0.0'\n    implementation 'com.google.firebase:firebase-database:19.0.0'\n    implementation 'com.google.firebase:firebase-auth:19.0.0' /* <===  */ \n    implementation 'com.google.android.gms:play-services-auth:17.0.0'\n    implementation 'com.github.d-max:spots-dialog:1.1@aar'\n    implementation 'com.google.android.material:material:1.0.0'\n    implementation 'com.android.volley:volley:1.1.1'\n    implementation 'com.google.firebase:firebase-messaging:20.1.0'",
+              arguments = None
+            )
+          )
+        )
+      )
+
+      val firebaseAuth = sinkProceMap.get("ThirdParties.SDK.Firebase.Authentication")
+      firebaseAuth shouldBe Some(
+        SinkProcessingModel(
+          sinkId = "ThirdParties.SDK.Firebase.Authentication",
+          occurrences = List(
+            DataFlowSubCategoryPathExcerptModel(
+              sample = "    implementation 'com.google.firebase:firebase-auth:19.0.0'\n",
+              lineNumber = 35,
+              columnNumber = -1,
+              fileName = "app/build.gradle",
+              excerpt =
+                "    implementation 'com.android.support:design:29.0.1'\n    implementation 'androidx.appcompat:appcompat:1.0.0'\n    implementation 'androidx.core:core:1.0.0'\n    implementation 'com.google.firebase:firebase-core:17.1.0'\n    implementation 'com.google.firebase:firebase-auth:19.0.0'\n    implementation 'com.google.firebase:firebase-database:19.0.0' /* <===  */ \n    implementation 'com.google.firebase:firebase-auth:19.0.0'\n    implementation 'com.google.android.gms:play-services-auth:17.0.0'\n    implementation 'com.github.d-max:spots-dialog:1.1@aar'\n    implementation 'com.google.android.material:material:1.0.0'\n    implementation 'com.android.volley:volley:1.1.1'",
+              arguments = None
+            )
+          )
+        )
+      )
+
+      val firebase = sinkProceMap.get("ThirdParties.SDK.Firebase")
+      firebase shouldBe Some(
+        SinkProcessingModel(
+          sinkId = "ThirdParties.SDK.Firebase",
+          occurrences = List(
+            DataFlowSubCategoryPathExcerptModel(
+              sample = "    implementation 'com.google.firebase:firebase-core:17.1.0'\n",
+              lineNumber = 32,
+              columnNumber = -1,
+              fileName = "app/build.gradle",
+              excerpt =
+                "    implementation 'androidx.constraintlayout:constraintlayout:1.1.3'\n    implementation 'androidx.cardview:cardview:1.0.0'\n    implementation 'com.android.support:appcompat-v7:29.0.0'\n    implementation 'com.android.support:design:29.0.1'\n    implementation 'androidx.appcompat:appcompat:1.0.0'\n    implementation 'androidx.core:core:1.0.0' /* <===  */ \n    implementation 'com.google.firebase:firebase-core:17.1.0'\n    implementation 'com.google.firebase:firebase-auth:19.0.0'\n    implementation 'com.google.firebase:firebase-database:19.0.0'\n    implementation 'com.google.firebase:firebase-auth:19.0.0'\n    implementation 'com.google.android.gms:play-services-auth:17.0.0'",
+              arguments = None
+            )
+          )
+        )
+      )
+    }
+  }
 }

--- a/src/test/scala/ai/privado/languageEngine/java/tagger/sink/DependencyTaggerTest.scala
+++ b/src/test/scala/ai/privado/languageEngine/java/tagger/sink/DependencyTaggerTest.scala
@@ -139,7 +139,8 @@ class DependencyTaggerTest extends JavaFrontendTestSuite with SinkExporterValida
     ).withDependencies(twilioDep).withRuleCache(ruleCache)
 
     "3p dependency should get added in processing section" in {
-      val outjson                                                = cpg.getPrivadoJson()
+      val outjson = cpg.getPrivadoJson()
+      getSinks(outjson).size shouldBe 2
       val sinkProcessing                                         = getSinkProcessings(outjson)
       val sinkProceMap: mutable.Map[String, SinkProcessingModel] = mutable.Map[String, SinkProcessingModel]()
       sinkProcessing.size shouldBe 2
@@ -382,7 +383,8 @@ class DependencyTaggerTest extends JavaFrontendTestSuite with SinkExporterValida
       .withRuleCache(ruleCache)
 
     "3p dependency should get added in processing section" in {
-      val outjson                                                = cpg.getPrivadoJson()
+      val outjson = cpg.getPrivadoJson()
+      getSinks(outjson).size shouldBe 3
       val sinkProcessing                                         = getSinkProcessings(outjson)
       val sinkProceMap: mutable.Map[String, SinkProcessingModel] = mutable.Map[String, SinkProcessingModel]()
       sinkProcessing.size shouldBe 3

--- a/src/test/scala/ai/privado/languageEngine/java/tagger/sink/DependencyTaggerTest.scala
+++ b/src/test/scala/ai/privado/languageEngine/java/tagger/sink/DependencyTaggerTest.scala
@@ -8,6 +8,8 @@ import ai.privado.model.*
 import ai.privado.model.exporter.{DataFlowSubCategoryPathExcerptModel, SinkProcessingModel}
 import ai.privado.testfixtures.JavaFrontendTestSuite
 
+import scala.collection.mutable
+
 class DependencyTaggerTest extends JavaFrontendTestSuite with SinkExporterValidator {
 
   "Java pom.xml simple use case" should {
@@ -28,8 +30,26 @@ class DependencyTaggerTest extends JavaFrontendTestSuite with SinkExporterValida
         "",
         Language.JAVA,
         Array()
+      ),
+      RuleInfo(
+        "ThirdParties.SDK.Google.Sheets",
+        "Google Sheets",
+        "Third Parties",
+        FilterProperty.METHOD_FULL_NAME,
+        Array("sheets.google.com"),
+        List(".*(com.google.apis).*"),
+        false,
+        "",
+        Map(),
+        NodeType.REGULAR,
+        "",
+        CatLevelOne.SINKS,
+        "",
+        Language.JAVA,
+        Array()
       )
     )
+
     val configAndRule = ConfigAndRules(sinks = dynamicRule)
     val ruleCache     = RuleCache().setRule(configAndRule)
     val twilioDep = List(
@@ -43,6 +63,18 @@ class DependencyTaggerTest extends JavaFrontendTestSuite with SinkExporterValida
         List("www.twilio.com"),
         List(),
         32,
+        "pom.xml"
+      ),
+      DependencyInfo(
+        "com.google.apis",
+        "google-api-services-sheets",
+        "v4-rev493-1.23.0",
+        "<artifactId>google-api-services-sheets</artifactId>",
+        "ThirdParties.SDK.Google.Sheets",
+        "Google Sheets",
+        List("sheets.google.com"),
+        List(),
+        42,
         "pom.xml"
       )
     )
@@ -86,6 +118,11 @@ class DependencyTaggerTest extends JavaFrontendTestSuite with SinkExporterValida
         |			<artifactId>spring-boot-starter-test</artifactId>
         |			<scope>test</scope>
         |		</dependency>
+        |  		<dependency>
+        |			<groupId>com.google.apis</groupId>
+        |			<artifactId>google-api-services-sheets</artifactId>
+        |			<version>v4-rev493-1.23.0</version>
+        |		</dependency>
         |	</dependencies>
         |	<build>
         |		<plugins>
@@ -100,9 +137,17 @@ class DependencyTaggerTest extends JavaFrontendTestSuite with SinkExporterValida
       "pom.xml"
     ).withDependencies(twilioDep).withRuleCache(ruleCache)
 
-    "Twilio dependency should get added in processing section" in {
-      val sinkProcessing = getSinkProcessings(cpg.getPrivadoJson())
-      sinkProcessing shouldBe List(
+    "3p dependency should get added in processing section" in {
+      val outjson                                                = cpg.getPrivadoJson()
+      val sinkProcessing                                         = getSinkProcessings(outjson)
+      val sinkProceMap: mutable.Map[String, SinkProcessingModel] = mutable.Map[String, SinkProcessingModel]()
+      sinkProcessing.size shouldBe 2
+      sinkProcessing.foreach(sink => {
+        sinkProceMap.put(sink.sinkId, sink)
+      })
+
+      val twilioSink = sinkProceMap.get("ThirdParties.SDK.twilio")
+      twilioSink shouldBe Some(
         SinkProcessingModel(
           sinkId = "ThirdParties.SDK.twilio",
           occurrences = List(
@@ -113,6 +158,24 @@ class DependencyTaggerTest extends JavaFrontendTestSuite with SinkExporterValida
               fileName = "pom.xml",
               excerpt =
                 "\t\t\t<groupId>org.springframework.boot</groupId>\n\t\t\t<artifactId>spring-boot-starter-web</artifactId>\n\t\t</dependency>\n\t\t<dependency>\n\t\t\t<groupId>com.twilio.sdk</groupId>\n\t\t\t<artifactId>twilio</artifactId> /* <===  */ \n\t\t\t<version>8.19.1</version>\n\t\t</dependency>\n\t\t<dependency>\n\t\t\t<groupId>org.springframework.boot</groupId>\n\t\t\t<artifactId>spring-boot-starter-test</artifactId>",
+              arguments = None
+            )
+          )
+        )
+      )
+
+      val gsheetSink = sinkProceMap.get("ThirdParties.SDK.Google.Sheets")
+      gsheetSink shouldBe Some(
+        SinkProcessingModel(
+          sinkId = "ThirdParties.SDK.Google.Sheets",
+          occurrences = List(
+            DataFlowSubCategoryPathExcerptModel(
+              sample = "<artifactId>google-api-services-sheets</artifactId>",
+              lineNumber = 42,
+              columnNumber = -1,
+              fileName = "pom.xml",
+              excerpt =
+                "\t\t\t<artifactId>spring-boot-starter-test</artifactId>\n\t\t\t<scope>test</scope>\n\t\t</dependency>\n  \t\t<dependency>\n\t\t\t<groupId>com.google.apis</groupId>\n\t\t\t<artifactId>google-api-services-sheets</artifactId> /* <===  */ \n\t\t\t<version>v4-rev493-1.23.0</version>\n\t\t</dependency>\n\t</dependencies>\n\t<build>\n\t\t<plugins>",
               arguments = None
             )
           )

--- a/src/test/scala/ai/privado/languageEngine/javascript/passes/config/JSPropertiesFilePassTest.scala
+++ b/src/test/scala/ai/privado/languageEngine/javascript/passes/config/JSPropertiesFilePassTest.scala
@@ -1,16 +1,16 @@
 package ai.privado.languageEngine.javascript.passes.config
 
 import ai.privado.cache.RuleCache
-import ai.privado.semantic.language.*
 import ai.privado.model.Language
-import ai.privado.utility.PropertyParserPass
+import ai.privado.passes.PropertyParserPass
+import ai.privado.semantic.language.*
 import better.files.File
 import io.joern.dataflowengineoss.layers.dataflows.{OssDataFlow, OssDataFlowOptions}
-import io.joern.jssrc2cpg.{Config, JsSrc2Cpg}
 import io.joern.jssrc2cpg.passes.ImportsPass
+import io.joern.jssrc2cpg.{Config, JsSrc2Cpg}
 import io.joern.x2cpg.X2Cpg
 import io.shiftleft.codepropertygraph.generated.Cpg
-import io.shiftleft.semanticcpg.language._
+import io.shiftleft.semanticcpg.language.*
 import io.shiftleft.semanticcpg.layers.LayerCreatorContext
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.matchers.should.Matchers

--- a/src/test/scala/ai/privado/languageEngine/ruby/config/RubyEnvPropertiesFilePassTest.scala
+++ b/src/test/scala/ai/privado/languageEngine/ruby/config/RubyEnvPropertiesFilePassTest.scala
@@ -1,12 +1,12 @@
 package ai.privado.languageEngine.ruby.config
 
 import ai.privado.cache.RuleCache
-import ai.privado.semantic.language.*
-import ai.privado.semantic.*
 import ai.privado.languageEngine.ruby.passes.config.RubyPropertyLinkerPass
 import ai.privado.model.Language
+import ai.privado.passes.PropertyParserPass
+import ai.privado.semantic.*
+import ai.privado.semantic.language.*
 import ai.privado.testfixtures.RubyFrontendTestSuite
-import ai.privado.utility.PropertyParserPass
 import better.files.File
 import io.joern.rubysrc2cpg.{Config, RubySrc2Cpg}
 import io.joern.x2cpg.X2Cpg.applyDefaultOverlays

--- a/src/test/scala/ai/privado/languageEngine/ruby/config/RubyPropertiesFilePassTestBase.scala
+++ b/src/test/scala/ai/privado/languageEngine/ruby/config/RubyPropertiesFilePassTestBase.scala
@@ -3,7 +3,7 @@ package ai.privado.languageEngine.ruby.config
 import ai.privado.cache.RuleCache
 import ai.privado.languageEngine.ruby.passes.config.RubyPropertyLinkerPass
 import ai.privado.model.Language
-import ai.privado.utility.PropertyParserPass
+import ai.privado.passes.PropertyParserPass
 import better.files.File
 import io.joern.rubysrc2cpg.{Config, RubySrc2Cpg}
 import io.joern.x2cpg.X2Cpg.applyDefaultOverlays

--- a/src/test/scala/ai/privado/languageEngine/ruby/config/RubyYamlPropertiesFilePassTest.scala
+++ b/src/test/scala/ai/privado/languageEngine/ruby/config/RubyYamlPropertiesFilePassTest.scala
@@ -1,11 +1,11 @@
 package ai.privado.languageEngine.ruby.config
 
 import ai.privado.cache.RuleCache
-import ai.privado.semantic.language.*
-import ai.privado.semantic.*
 import ai.privado.languageEngine.ruby.passes.config.RubyPropertyLinkerPass
 import ai.privado.model.Language
-import ai.privado.utility.PropertyParserPass
+import ai.privado.passes.PropertyParserPass
+import ai.privado.semantic.*
+import ai.privado.semantic.language.*
 import better.files.File
 import io.joern.rubysrc2cpg.{Config, RubySrc2Cpg}
 import io.joern.x2cpg.X2Cpg.applyDefaultOverlays

--- a/src/test/scala/ai/privado/languageEngine/ruby/monolith/MonolithTest.scala
+++ b/src/test/scala/ai/privado/languageEngine/ruby/monolith/MonolithTest.scala
@@ -1,14 +1,6 @@
 package ai.privado.languageEngine.ruby.monolith
 
-import ai.privado.cache.{
-  AppCache,
-  AuditCache,
-  DataFlowCache,
-  DatabaseDetailsCache,
-  RuleCache,
-  S3DatabaseDetailsCache,
-  TaggerCache
-}
+import ai.privado.cache.*
 import ai.privado.dataflow.Dataflow
 import ai.privado.entrypoint.PrivadoInput
 import ai.privado.exporter.monolith.MonolithExporter
@@ -17,17 +9,17 @@ import ai.privado.languageEngine.go.tagger.source.IdentifierTagger
 import ai.privado.languageEngine.ruby.passes.config.RubyPropertyLinkerPass
 import ai.privado.languageEngine.ruby.tagger.monolith.MonolithTagger
 import ai.privado.model.{Constants, Language}
+import ai.privado.passes.PropertyParserPass
 import ai.privado.rule.RuleInfoTestData
-import ai.privado.utility.PropertyParserPass
 import better.files.File
 import io.joern.dataflowengineoss.language.Path
 import io.joern.rubysrc2cpg.{Config, RubySrc2Cpg}
 import io.joern.x2cpg.X2Cpg.applyDefaultOverlays
 import io.shiftleft.codepropertygraph.generated.Cpg
+import io.shiftleft.semanticcpg.language.*
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
-import io.shiftleft.semanticcpg.language.*
 
 import scala.collection.mutable
 

--- a/src/test/scala/ai/privado/languageEngine/ruby/tagger/schema/RubyMongoSchemaMapperTest.scala
+++ b/src/test/scala/ai/privado/languageEngine/ruby/tagger/schema/RubyMongoSchemaMapperTest.scala
@@ -2,20 +2,12 @@ package ai.privado.languageEngine.ruby.tagger.schema
 
 import ai.privado.cache.{DatabaseDetailsCache, PropertyFilterCache, RuleCache}
 import ai.privado.languageEngine.ruby.RubyTestBase.*
+import ai.privado.model.*
+import ai.privado.passes.PropertyParserPass
+import ai.privado.rule.RuleInfoTestData
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
-import ai.privado.model.{
-  ConfigAndRules,
-  DatabaseColumn,
-  DatabaseDetails,
-  DatabaseSchema,
-  DatabaseTable,
-  Language,
-  SourceCodeModel
-}
-import ai.privado.rule.RuleInfoTestData
-import ai.privado.utility.PropertyParserPass
 
 class RubyMongoSchemaMapperTest extends AnyWordSpec with Matchers with BeforeAndAfterAll {
 

--- a/src/test/scala/ai/privado/passes/SQLPropertyParserTest.scala
+++ b/src/test/scala/ai/privado/passes/SQLPropertyParserTest.scala
@@ -1,19 +1,19 @@
 package ai.privado.passes
 
 import ai.privado.cache.RuleCache
-import ai.privado.semantic.language.*
+import ai.privado.model.Language
 import ai.privado.model.sql.SQLQueryType
+import ai.privado.passes.PropertyParserPass
+import ai.privado.semantic.language.*
 import better.files.File
+import io.joern.console.cpgcreation.guessLanguage
 import io.joern.jssrc2cpg.Config
 import io.joern.x2cpg.X2Cpg
 import io.shiftleft.codepropertygraph.generated.Cpg
+import io.shiftleft.semanticcpg.language.*
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
-import ai.privado.utility.PropertyParserPass
-import ai.privado.model.Language
-import io.joern.console.cpgcreation.guessLanguage
-import io.shiftleft.semanticcpg.language._
 
 class SQLPropertyParserTest extends AnyWordSpec with Matchers with BeforeAndAfterAll {
   "SQL Property parser" should {

--- a/src/test/scala/ai/privado/testfixtures/CFrontendTestSuite.scala
+++ b/src/test/scala/ai/privado/testfixtures/CFrontendTestSuite.scala
@@ -1,15 +1,8 @@
 package ai.privado.testfixtures
 
-import ai.privado.cache.{
-  AppCache,
-  AuditCache,
-  DataFlowCache,
-  DatabaseDetailsCache,
-  PropertyFilterCache,
-  RuleCache,
-  S3DatabaseDetailsCache
-}
+import ai.privado.cache.*
 import ai.privado.entrypoint.PrivadoInput
+import ai.privado.inputprocessor.DependencyInfo
 import ai.privado.languageEngine.base.processor.BaseProcessor
 import ai.privado.languageEngine.c.processor.CProcessor
 import ai.privado.model.Language
@@ -24,7 +17,8 @@ class TestCpgWithC(val fileSuffix: String, val language: Language.Value) extends
     s3DatabaseDetailsCache: S3DatabaseDetailsCache,
     appCache: AppCache,
     propertyFilterCache: PropertyFilterCache,
-    databaseDetailsCache: DatabaseDetailsCache
+    databaseDetailsCache: DatabaseDetailsCache,
+    dependencies: List[DependencyInfo]
   ): BaseProcessor = {
     new CProcessor(
       ruleCache,

--- a/src/test/scala/ai/privado/testfixtures/CSharpFrontendTestSuite.scala
+++ b/src/test/scala/ai/privado/testfixtures/CSharpFrontendTestSuite.scala
@@ -1,15 +1,8 @@
 package ai.privado.testfixtures
 
-import ai.privado.cache.{
-  AppCache,
-  AuditCache,
-  DataFlowCache,
-  DatabaseDetailsCache,
-  PropertyFilterCache,
-  RuleCache,
-  S3DatabaseDetailsCache
-}
+import ai.privado.cache.*
 import ai.privado.entrypoint.PrivadoInput
+import ai.privado.inputprocessor.DependencyInfo
 import ai.privado.languageEngine.base.processor.BaseProcessor
 import ai.privado.languageEngine.csharp.processor.CSharpProcessor
 import ai.privado.model.Language
@@ -24,7 +17,8 @@ class TestCpgWithCSharp(val fileSuffix: String, val language: Language.Value) ex
     s3DatabaseDetailsCache: S3DatabaseDetailsCache,
     appCache: AppCache,
     propertyFilterCache: PropertyFilterCache,
-    databaseDetailsCache: DatabaseDetailsCache
+    databaseDetailsCache: DatabaseDetailsCache,
+    dependencies: List[DependencyInfo]
   ): BaseProcessor = {
     new CSharpProcessor(
       ruleCache,
@@ -37,7 +31,8 @@ class TestCpgWithCSharp(val fileSuffix: String, val language: Language.Value) ex
       StatsRecorder(),
       returnClosedCpg = false,
       databaseDetailsCache,
-      propertyFilterCache
+      propertyFilterCache,
+      dependencies = dependencies
     )
   }
 }

--- a/src/test/scala/ai/privado/testfixtures/DefaultFrontendTestSuite.scala
+++ b/src/test/scala/ai/privado/testfixtures/DefaultFrontendTestSuite.scala
@@ -1,15 +1,8 @@
 package ai.privado.testfixtures
 
-import ai.privado.cache.{
-  AppCache,
-  AuditCache,
-  DataFlowCache,
-  DatabaseDetailsCache,
-  PropertyFilterCache,
-  RuleCache,
-  S3DatabaseDetailsCache
-}
+import ai.privado.cache.*
 import ai.privado.entrypoint.PrivadoInput
+import ai.privado.inputprocessor.DependencyInfo
 import ai.privado.languageEngine.base.processor.BaseProcessor
 import ai.privado.languageEngine.default.processor.DefaultProcessor
 import ai.privado.model.Language
@@ -24,7 +17,8 @@ class TestCpgWithDefaultLanguage(val fileSuffix: String, val language: Language.
     s3DatabaseDetailsCache: S3DatabaseDetailsCache,
     appCache: AppCache,
     propertyFilterCache: PropertyFilterCache,
-    databaseDetailsCache: DatabaseDetailsCache
+    databaseDetailsCache: DatabaseDetailsCache,
+    dependencies: List[DependencyInfo]
   ): BaseProcessor = {
     new DefaultProcessor(
       ruleCache,

--- a/src/test/scala/ai/privado/testfixtures/GoFrontendTestSuite.scala
+++ b/src/test/scala/ai/privado/testfixtures/GoFrontendTestSuite.scala
@@ -1,18 +1,11 @@
 package ai.privado.testfixtures
 
-import ai.privado.cache.{
-  AppCache,
-  AuditCache,
-  DataFlowCache,
-  DatabaseDetailsCache,
-  PropertyFilterCache,
-  RuleCache,
-  S3DatabaseDetailsCache
-}
+import ai.privado.cache.*
 import ai.privado.entrypoint.PrivadoInput
+import ai.privado.inputprocessor.DependencyInfo
 import ai.privado.languageEngine.base.processor.BaseProcessor
 import ai.privado.languageEngine.go.processor.GoProcessor
-import ai.privado.model.{CatLevelOne, Constants, FilterProperty, Language, NodeType, RuleInfo}
+import ai.privado.model.*
 import ai.privado.utility.StatsRecorder
 
 class TestCpgWithGo(val fileSuffix: String, val language: Language.Value) extends TestCpg {
@@ -25,7 +18,8 @@ class TestCpgWithGo(val fileSuffix: String, val language: Language.Value) extend
     s3DatabaseDetailsCache: S3DatabaseDetailsCache,
     appCache: AppCache,
     propertyFilterCache: PropertyFilterCache,
-    databaseDetailsCache: DatabaseDetailsCache
+    databaseDetailsCache: DatabaseDetailsCache,
+    dependencies: List[DependencyInfo]
   ): BaseProcessor = {
     new GoProcessor(
       ruleCache,
@@ -38,7 +32,8 @@ class TestCpgWithGo(val fileSuffix: String, val language: Language.Value) extend
       StatsRecorder(),
       returnClosedCpg = false,
       databaseDetailsCache,
-      propertyFilterCache
+      propertyFilterCache,
+      dependencies = dependencies
     )
   }
 }

--- a/src/test/scala/ai/privado/testfixtures/JavaFrontendTestSuite.scala
+++ b/src/test/scala/ai/privado/testfixtures/JavaFrontendTestSuite.scala
@@ -2,10 +2,11 @@ package ai.privado.testfixtures
 
 import ai.privado.cache.*
 import ai.privado.entrypoint.PrivadoInput
+import ai.privado.inputprocessor.DependencyInfo
 import ai.privado.languageEngine.base.processor.BaseProcessor
 import ai.privado.languageEngine.java.processor.JavaProcessor
-import ai.privado.utility.StatsRecorder
 import ai.privado.model.Language
+import ai.privado.utility.StatsRecorder
 
 class TestCpgWithJava(val fileSuffix: String, val language: Language.Value) extends TestCpg {
   protected def getLanguageProcessor(
@@ -16,7 +17,8 @@ class TestCpgWithJava(val fileSuffix: String, val language: Language.Value) exte
     s3DatabaseDetailsCache: S3DatabaseDetailsCache,
     appCache: AppCache,
     propertyFilterCache: PropertyFilterCache,
-    databaseDetailsCache: DatabaseDetailsCache
+    databaseDetailsCache: DatabaseDetailsCache,
+    dependencies: List[DependencyInfo]
   ): BaseProcessor = {
     new JavaProcessor(
       ruleCache,
@@ -29,7 +31,8 @@ class TestCpgWithJava(val fileSuffix: String, val language: Language.Value) exte
       StatsRecorder(),
       returnClosedCpg = false,
       databaseDetailsCache,
-      propertyFilterCache
+      propertyFilterCache,
+      dependencies = dependencies
     )
   }
 }

--- a/src/test/scala/ai/privado/testfixtures/JavaScriptFrontendTestSuite.scala
+++ b/src/test/scala/ai/privado/testfixtures/JavaScriptFrontendTestSuite.scala
@@ -2,9 +2,10 @@ package ai.privado.testfixtures
 
 import ai.privado.cache.*
 import ai.privado.entrypoint.PrivadoInput
+import ai.privado.inputprocessor.DependencyInfo
 import ai.privado.languageEngine.base.processor.BaseProcessor
 import ai.privado.languageEngine.javascript.processor.JavascriptProcessor
-import ai.privado.model.{CatLevelOne, Constants, FilterProperty, Language, NodeType, RuleInfo}
+import ai.privado.model.*
 import ai.privado.utility.StatsRecorder
 
 class TestCpgWithJavaScript(val fileSuffix: String, val language: Language.Value) extends TestCpg {
@@ -16,7 +17,8 @@ class TestCpgWithJavaScript(val fileSuffix: String, val language: Language.Value
     s3DatabaseDetailsCache: S3DatabaseDetailsCache,
     appCache: AppCache,
     propertyFilterCache: PropertyFilterCache,
-    databaseDetailsCache: DatabaseDetailsCache
+    databaseDetailsCache: DatabaseDetailsCache,
+    dependencies: List[DependencyInfo]
   ): BaseProcessor = {
     new JavascriptProcessor(
       ruleCache,
@@ -29,7 +31,8 @@ class TestCpgWithJavaScript(val fileSuffix: String, val language: Language.Value
       StatsRecorder(),
       returnClosedCpg = false,
       databaseDetailsCache,
-      propertyFilterCache
+      propertyFilterCache,
+      dependencies = dependencies
     )
   }
 }

--- a/src/test/scala/ai/privado/testfixtures/KotlinFrontendTestSuite.scala
+++ b/src/test/scala/ai/privado/testfixtures/KotlinFrontendTestSuite.scala
@@ -1,15 +1,8 @@
 package ai.privado.testfixtures
 
-import ai.privado.cache.{
-  AppCache,
-  AuditCache,
-  DataFlowCache,
-  DatabaseDetailsCache,
-  PropertyFilterCache,
-  RuleCache,
-  S3DatabaseDetailsCache
-}
+import ai.privado.cache.*
 import ai.privado.entrypoint.PrivadoInput
+import ai.privado.inputprocessor.DependencyInfo
 import ai.privado.languageEngine.base.processor.BaseProcessor
 import ai.privado.languageEngine.kotlin.processor.KotlinProcessor
 import ai.privado.model.Language
@@ -24,7 +17,8 @@ class TestCpgWithKotlin(val fileSuffix: String, val language: Language.Value) ex
     s3DatabaseDetailsCache: S3DatabaseDetailsCache,
     appCache: AppCache,
     propertyFilterCache: PropertyFilterCache,
-    databaseDetailsCache: DatabaseDetailsCache
+    databaseDetailsCache: DatabaseDetailsCache,
+    dependencies: List[DependencyInfo]
   ): BaseProcessor = {
     new KotlinProcessor(
       ruleCache,
@@ -37,7 +31,8 @@ class TestCpgWithKotlin(val fileSuffix: String, val language: Language.Value) ex
       StatsRecorder(),
       returnClosedCpg = false,
       databaseDetailsCache,
-      propertyFilterCache
+      propertyFilterCache,
+      dependencies = dependencies
     )
   }
 }

--- a/src/test/scala/ai/privado/testfixtures/LanguageFrontend.scala
+++ b/src/test/scala/ai/privado/testfixtures/LanguageFrontend.scala
@@ -2,6 +2,7 @@ package ai.privado.testfixtures
 
 import ai.privado.cache.*
 import ai.privado.entrypoint.PrivadoInput
+import ai.privado.inputprocessor.DependencyInfo
 import ai.privado.languageEngine.base.processor.BaseProcessor
 import ai.privado.model.Language
 import ai.privado.rule.RuleInfoTestData
@@ -21,6 +22,7 @@ trait LanguageFrontend {
   private var appCache: Option[AppCache]                             = None
   private var propertyFilterCache: Option[PropertyFilterCache]       = None
   private var databaseDetailsCache: Option[DatabaseDetailsCache]     = None
+  private var dependencies: Option[List[DependencyInfo]]             = None
 
   def setPrivadoInput(privadoInput: PrivadoInput): Unit = {
     if (this.privadoInput.isDefined) {
@@ -78,6 +80,13 @@ trait LanguageFrontend {
     this.databaseDetailsCache = Some(databaseDetailsCache)
   }
 
+  def setDependencies(dependencies: List[DependencyInfo]): Unit = {
+    if (this.dependencies.isDefined) {
+      throw new RuntimeException("Dependencies may only be set once per test")
+    }
+    this.dependencies = Some(dependencies)
+  }
+
   protected def getProcessor(sourceCodePath: java.io.File): BaseProcessor = {
     val privadoInput =
       this.privadoInput.getOrElse(PrivadoInput()).copy(sourceLocation = Set(sourceCodePath.getAbsolutePath))
@@ -93,7 +102,8 @@ trait LanguageFrontend {
       this.s3DatabaseDetailsCache.getOrElse(S3DatabaseDetailsCache()),
       appCache,
       this.propertyFilterCache.getOrElse(PropertyFilterCache()),
-      this.databaseDetailsCache.getOrElse(DatabaseDetailsCache())
+      this.databaseDetailsCache.getOrElse(DatabaseDetailsCache()),
+      this.dependencies.getOrElse(List())
     )
   }
 
@@ -105,6 +115,7 @@ trait LanguageFrontend {
     s3DatabaseDetailsCache: S3DatabaseDetailsCache,
     appCache: AppCache,
     propertyFilterCache: PropertyFilterCache,
-    databaseDetailsCache: DatabaseDetailsCache
+    databaseDetailsCache: DatabaseDetailsCache,
+    dependencies: List[DependencyInfo]
   ): BaseProcessor
 }

--- a/src/test/scala/ai/privado/testfixtures/PhpFrontendTestSuite.scala
+++ b/src/test/scala/ai/privado/testfixtures/PhpFrontendTestSuite.scala
@@ -1,15 +1,8 @@
 package ai.privado.testfixtures
 
-import ai.privado.cache.{
-  AppCache,
-  AuditCache,
-  DataFlowCache,
-  DatabaseDetailsCache,
-  PropertyFilterCache,
-  RuleCache,
-  S3DatabaseDetailsCache
-}
+import ai.privado.cache.*
 import ai.privado.entrypoint.PrivadoInput
+import ai.privado.inputprocessor.DependencyInfo
 import ai.privado.languageEngine.base.processor.BaseProcessor
 import ai.privado.languageEngine.php.processor.PhpProcessor
 import ai.privado.model.*
@@ -24,7 +17,8 @@ class TestCpgWithPhp(val fileSuffix: String, val language: Language.Value) exten
     s3DatabaseDetailsCache: S3DatabaseDetailsCache,
     appCache: AppCache,
     propertyFilterCache: PropertyFilterCache,
-    databaseDetailsCache: DatabaseDetailsCache
+    databaseDetailsCache: DatabaseDetailsCache,
+    dependencies: List[DependencyInfo]
   ): BaseProcessor = {
     new PhpProcessor(
       ruleCache,
@@ -37,7 +31,8 @@ class TestCpgWithPhp(val fileSuffix: String, val language: Language.Value) exten
       StatsRecorder(),
       returnClosedCpg = false,
       databaseDetailsCache,
-      propertyFilterCache
+      propertyFilterCache,
+      dependencies = dependencies
     )
   }
 }

--- a/src/test/scala/ai/privado/testfixtures/PythonFrontendTestSuite.scala
+++ b/src/test/scala/ai/privado/testfixtures/PythonFrontendTestSuite.scala
@@ -1,20 +1,12 @@
 package ai.privado.testfixtures
 
-import ai.privado.cache.{
-  AppCache,
-  AuditCache,
-  DataFlowCache,
-  DatabaseDetailsCache,
-  PropertyFilterCache,
-  RuleCache,
-  S3DatabaseDetailsCache
-}
+import ai.privado.cache.*
 import ai.privado.entrypoint.PrivadoInput
+import ai.privado.inputprocessor.DependencyInfo
 import ai.privado.languageEngine.base.processor.BaseProcessor
 import ai.privado.languageEngine.python.processor.PythonProcessor
-import ai.privado.model.Language
+import ai.privado.model.*
 import ai.privado.utility.StatsRecorder
-import ai.privado.model.{CatLevelOne, Constants, FilterProperty, NodeType, RuleInfo}
 
 class TestCpgWithPython(val fileSuffix: String, val language: Language.Value) extends TestCpg {
 
@@ -26,7 +18,8 @@ class TestCpgWithPython(val fileSuffix: String, val language: Language.Value) ex
     s3DatabaseDetailsCache: S3DatabaseDetailsCache,
     appCache: AppCache,
     propertyFilterCache: PropertyFilterCache,
-    databaseDetailsCache: DatabaseDetailsCache
+    databaseDetailsCache: DatabaseDetailsCache,
+    dependencies: List[DependencyInfo]
   ): BaseProcessor = new PythonProcessor(
     ruleCache,
     privadoInput,
@@ -38,7 +31,8 @@ class TestCpgWithPython(val fileSuffix: String, val language: Language.Value) ex
     StatsRecorder(),
     returnClosedCpg = false,
     databaseDetailsCache,
-    propertyFilterCache
+    propertyFilterCache,
+    dependencies = dependencies
   )
 
 }

--- a/src/test/scala/ai/privado/testfixtures/RubyFrontendTestSuite.scala
+++ b/src/test/scala/ai/privado/testfixtures/RubyFrontendTestSuite.scala
@@ -1,15 +1,8 @@
 package ai.privado.testfixtures
 
-import ai.privado.cache.{
-  AppCache,
-  AuditCache,
-  DataFlowCache,
-  DatabaseDetailsCache,
-  PropertyFilterCache,
-  RuleCache,
-  S3DatabaseDetailsCache
-}
+import ai.privado.cache.*
 import ai.privado.entrypoint.PrivadoInput
+import ai.privado.inputprocessor.DependencyInfo
 import ai.privado.languageEngine.base.processor.BaseProcessor
 import ai.privado.languageEngine.ruby.processor.RubyProcessor
 import ai.privado.model.Language
@@ -25,7 +18,8 @@ class TestCpgWithRuby(val fileSuffix: String, val language: Language.Value) exte
     s3DatabaseDetailsCache: S3DatabaseDetailsCache,
     appCache: AppCache,
     propertyFilterCache: PropertyFilterCache,
-    databaseDetailsCache: DatabaseDetailsCache
+    databaseDetailsCache: DatabaseDetailsCache,
+    dependencies: List[DependencyInfo]
   ): BaseProcessor = {
     new RubyProcessor(
       ruleCache,
@@ -38,7 +32,8 @@ class TestCpgWithRuby(val fileSuffix: String, val language: Language.Value) exte
       StatsRecorder(),
       returnClosedCpg = false,
       databaseDetailsCache,
-      propertyFilterCache
+      propertyFilterCache,
+      dependencies = dependencies
     )
   }
 }

--- a/src/test/scala/ai/privado/testfixtures/TestCpg.scala
+++ b/src/test/scala/ai/privado/testfixtures/TestCpg.scala
@@ -1,7 +1,8 @@
 package ai.privado.testfixtures
 
-import ai.privado.cache.{AppCache, AuditCache, DataFlowCache, PropertyFilterCache, RuleCache, S3DatabaseDetailsCache}
+import ai.privado.cache.*
 import ai.privado.entrypoint.PrivadoInput
+import ai.privado.inputprocessor.DependencyInfo
 import io.circe.Json
 import io.shiftleft.codepropertygraph.Cpg
 import overflowdb.Graph
@@ -47,6 +48,11 @@ abstract class TestCpg extends Cpg() with TestCodeWriter with LanguageFrontend {
 
   def withPropertyFilterCache(propertyFilterCache: PropertyFilterCache): this.type = {
     setPropertyFilterCache(propertyFilterCache)
+    this
+  }
+
+  def withDependencies(dependencies: List[DependencyInfo]): this.type = {
+    setDependencies(dependencies)
     this
   }
 


### PR DESCRIPTION
1. Moved input configuration processing-related code inside the new package `inputprocessor`
2. Dependency info JSON parser implementation along with unit test to parse JSON passed through external config.
3. Extend the dependency node to add additional required properties and file edge.
2. DependencyNode pass to create the dependency nodes in cpg
3. Unfinished refactoring of PropertyPass.
4. Dependency node tagging with dynamic rule id.
5. Required changes in export flow to consider dependency node for generating sink processing section.
6. Changes to take dependency information passed on through external rules passed and pass the deserialised DependencyInfo list to each language processor.
7. Corresponding changes in each language processor to invoke commonly configured Dependency node creation and tagging passes generically.
8. Had to make corresponding changes in the test suite in order to pass the DependencyInfo list while writing the unit test.