### PR TITLE
Dynamic rule fix

### DIFF
--- a/src/main/scala/ai/privado/entrypoint/DynamicRuleMerger.scala
+++ b/src/main/scala/ai/privado/entrypoint/DynamicRuleMerger.scala
@@ -18,7 +18,9 @@ trait DynamicRuleMerger {
     try {
 
       val internalRuleMap = mutable.Map(
-        internalSinkRules.map(rule => ((rule.domains.headOption.get, rule.name, rule.filterProperty), rule))*
+        internalSinkRules
+          .filter(rule => rule.domains.nonEmpty && rule.name.nonEmpty)
+          .map(rule => ((rule.domains.headOption.get, rule.name, rule.filterProperty), rule)): _*
       )
 
       externalSinkRules.foreach { externalRule =>


### PR DESCRIPTION
Earlier, it was throwing an error because the domain was empty for some of the sink rules like `Logs`, `Internal APIs`, `Cookie`. So, I added a filter to those rules where the domain or name is empty, because our merging logic relies on these two parameters, and they need to be present.