### PR TITLE
Dynamic Rule Merger Fix

### DIFF
--- a/src/main/scala/ai/privado/cache/RuleCache.scala
+++ b/src/main/scala/ai/privado/cache/RuleCache.scala
@@ -152,7 +152,6 @@ class RuleCache {
   }
 
   def checkIfMergedDynamicRuleExist(externalRuleId: String): Boolean = {
-    println("checking here --- " + externalRuleId + " result -- " + dynamicMergerRuleMap.contains(externalRuleId))
     dynamicMergerRuleMap.contains(externalRuleId)
   }
 

--- a/src/main/scala/ai/privado/cache/RuleCache.scala
+++ b/src/main/scala/ai/privado/cache/RuleCache.scala
@@ -32,11 +32,12 @@ import scala.collection.mutable
 class RuleCache {
   private var rule: ConfigAndRules =
     ConfigAndRules(List(), List(), List(), List(), List(), List(), List(), List(), List(), List())
-  private val ruleInfoMap       = mutable.HashMap[String, RuleInfo]()
-  private val policyOrThreatMap = mutable.HashMap[String, PolicyOrThreat]()
-  val internalRules             = mutable.HashMap[String, Int]()
-  val internalPolicies          = mutable.Set[String]()
-  private val storageRuleInfo   = mutable.ListBuffer[RuleInfo]()
+  private val ruleInfoMap          = mutable.HashMap[String, RuleInfo]()
+  private val policyOrThreatMap    = mutable.HashMap[String, PolicyOrThreat]()
+  val internalRules                = mutable.HashMap[String, Int]()
+  val internalPolicies             = mutable.Set[String]()
+  private val storageRuleInfo      = mutable.ListBuffer[RuleInfo]()
+  private val dynamicMergerRuleMap = mutable.HashMap[String, String]()
 
   // TODO, rename setRule to withRule as it return the ruleCache object and setters are Unit functions
   def setRule(rule: ConfigAndRules): RuleCache = {
@@ -144,5 +145,18 @@ class RuleCache {
         case _ => ""
       }
     }
+  }
+
+  def addIntoMergedDynamicRuleMapper(externalRuleId: String, internalRuleId: String): Unit = {
+    dynamicMergerRuleMap(externalRuleId) = internalRuleId
+  }
+
+  def checkIfMergedDynamicRuleExist(externalRuleId: String): Boolean = {
+    println("checking here --- " + externalRuleId + " result -- " + dynamicMergerRuleMap.contains(externalRuleId))
+    dynamicMergerRuleMap.contains(externalRuleId)
+  }
+
+  def getDynamicMappedInternalRule(externalRule: String): String = {
+    dynamicMergerRuleMap.getOrElse(externalRule, "")
   }
 }

--- a/src/main/scala/ai/privado/inputprocessor/DynamicRuleMerger.scala
+++ b/src/main/scala/ai/privado/inputprocessor/DynamicRuleMerger.scala
@@ -1,5 +1,6 @@
 package ai.privado.inputprocessor
 
+import ai.privado.cache.RuleCache
 import ai.privado.model.{ConfigAndRules, FilterProperty, RuleInfo}
 import org.slf4j.LoggerFactory
 
@@ -12,9 +13,12 @@ trait DynamicRuleMerger {
 
   def mergeDynamicRuleSinkForDependencyDiscovery(
     externalSinkRules: List[RuleInfo],
-    internalSinkRules: List[RuleInfo]
+    internalSinkRules: List[RuleInfo],
+    ruleCache: RuleCache
   ): List[RuleInfo] = {
     try {
+
+      val externalOtherRule = new ListBuffer[RuleInfo]
 
       val internalRuleMap = mutable.Map(
         internalSinkRules
@@ -23,28 +27,35 @@ trait DynamicRuleMerger {
       )
 
       externalSinkRules.foreach { externalRule =>
-        val externalDomain         = externalRule.domains.headOption.get
-        val externalRuleName       = externalRule.name
-        val externalFilterProperty = externalRule.filterProperty
+        if (externalRule.tags.contains("Discovery_Generated")) {
+          val externalId             = externalRule.id
+          val externalDomain         = externalRule.domains.headOption.get
+          val externalRuleName       = externalRule.name
+          val externalFilterProperty = externalRule.filterProperty
 
-        internalRuleMap.collectFirst {
-          case ((domain, name, filterProperty), rule)
-              if (domain == externalDomain || name == externalRuleName) && rule.id.contains(
-                "ThirdParties.SDK"
-              ) && filterProperty != FilterProperty.CODE =>
-            (domain, name, filterProperty, rule)
-        } match
-          case Some(_, _, _, matchingRule: RuleInfo) =>
-            val updatedRule = matchingRule.copy(patterns = matchingRule.patterns ++ externalRule.patterns)
-            internalRuleMap.update(
-              (matchingRule.domains.headOption.get, matchingRule.name, matchingRule.filterProperty),
-              updatedRule
-            )
-          case _ =>
-            internalRuleMap((externalDomain, externalRuleName, externalFilterProperty)) = externalRule
+          internalRuleMap.collectFirst {
+            case ((domain, name, filterProperty), rule)
+                if (domain == externalDomain || name == externalRuleName) && rule.id.contains(
+                  "ThirdParties.SDK"
+                ) && filterProperty != FilterProperty.CODE =>
+              (domain, name, filterProperty, rule)
+          } match
+            case Some(_, _, _, matchingRule: RuleInfo) =>
+              val updatedRule = matchingRule.copy(patterns = matchingRule.patterns ++ externalRule.patterns)
+              internalRuleMap.update(
+                (matchingRule.domains.headOption.get, matchingRule.name, matchingRule.filterProperty),
+                updatedRule
+              )
+              ruleCache.addIntoMergedDynamicRuleMapper(externalId, matchingRule.id)
+            case _ =>
+              internalRuleMap((externalDomain, externalRuleName, externalFilterProperty)) = externalRule
+              ruleCache.addIntoMergedDynamicRuleMapper(externalRuleName, externalRuleName)
+        } else {
+          externalOtherRule.append(externalRule)
+        }
       }
 
-      internalRuleMap.values.toList
+      internalRuleMap.values.toList ++ externalOtherRule.toList
     } catch {
       case e: Exception =>
         logger.error("Error while merging dynamic rules")

--- a/src/main/scala/ai/privado/inputprocessor/RuleProcessor.scala
+++ b/src/main/scala/ai/privado/inputprocessor/RuleProcessor.scala
@@ -313,7 +313,8 @@ trait RuleProcessor extends DynamicRuleMerger {
      */
     val exclusions = externalConfigAndRules.exclusions ++ internalConfigAndRules.exclusions
     val sources    = externalConfigAndRules.sources ++ internalConfigAndRules.sources
-    val sinks = mergeDynamicRuleSinkForDependencyDiscovery(externalConfigAndRules.sinks, internalConfigAndRules.sinks)
+    val sinks =
+      mergeDynamicRuleSinkForDependencyDiscovery(externalConfigAndRules.sinks, internalConfigAndRules.sinks, ruleCache)
     val collections  = externalConfigAndRules.collections ++ internalConfigAndRules.collections
     val policies     = externalConfigAndRules.policies ++ internalConfigAndRules.policies
     val threats      = externalConfigAndRules.threats ++ internalConfigAndRules.threats

--- a/src/main/scala/ai/privado/tagger/sink/DependencyNodeTagger.scala
+++ b/src/main/scala/ai/privado/tagger/sink/DependencyNodeTagger.scala
@@ -20,7 +20,11 @@ class DependencyNodeTagger(cpg: Cpg, dependencies: List[DependencyInfo], ruleCac
         .where(_.file.nameExact(dependency.filePath))
         .headOption match {
         case Some(dep) =>
-          ruleCache.getRuleInfo(dependency.ruleId) match {
+          val dependencyRuleId =
+            if (ruleCache.checkIfMergedDynamicRuleExist(dependency.ruleId))
+              ruleCache.getDynamicMappedInternalRule(dependency.ruleId)
+            else dependency.ruleId
+          ruleCache.getRuleInfo(dependencyRuleId) match {
             case Some(rule) => Utilities.addRuleTags(builder, dep, rule, ruleCache)
             case None =>
               logger.error(

--- a/src/test/scala/ai/privado/inputprocessor/DynamicRuleMergerTest.scala
+++ b/src/test/scala/ai/privado/inputprocessor/DynamicRuleMergerTest.scala
@@ -40,7 +40,7 @@ class DynamicRuleMergerTest extends JavaFrontendTestSuite, DynamicRuleMerger {
         List(".*(software.amazon.awssdk.services.s3).*"),
         false,
         "",
-        Map(),
+        Map("Discovery_Generated" -> "true"),
         NodeType.REGULAR,
         "",
         CatLevelOne.SINKS,
@@ -50,9 +50,10 @@ class DynamicRuleMergerTest extends JavaFrontendTestSuite, DynamicRuleMerger {
       )
     )
 
-    val finalSinkRule = mergeDynamicRuleSinkForDependencyDiscovery(dynamicRule, existingRule)
+    val ruleCache     = RuleCache()
+    val finalSinkRule = mergeDynamicRuleSinkForDependencyDiscovery(dynamicRule, existingRule, ruleCache)
     val configAndRule = ConfigAndRules(sinks = finalSinkRule)
-    val ruleCache     = RuleCache().setRule(configAndRule)
+    ruleCache.setRule(configAndRule)
 
     val cpg = code("""
         |import software.amazon.awssdk.services.s3.S3Client;
@@ -93,7 +94,7 @@ class DynamicRuleMergerTest extends JavaFrontendTestSuite, DynamicRuleMerger {
         List(".*(software.amazon.awssdk.services.s3).*"),
         false,
         "",
-        Map(),
+        Map("Discovery_Generated" -> "true"),
         NodeType.REGULAR,
         "",
         CatLevelOne.SINKS,
@@ -103,9 +104,10 @@ class DynamicRuleMergerTest extends JavaFrontendTestSuite, DynamicRuleMerger {
       )
     )
 
-    val finalSinkRule = mergeDynamicRuleSinkForDependencyDiscovery(dynamicRule, existingRule)
+    val ruleCache     = new RuleCache()
+    val finalSinkRule = mergeDynamicRuleSinkForDependencyDiscovery(dynamicRule, existingRule, ruleCache)
     val configAndRule = ConfigAndRules(sinks = finalSinkRule)
-    val ruleCache     = RuleCache().setRule(configAndRule)
+    ruleCache.setRule(configAndRule)
 
     val cpg = code("""
         |import software.amazon.awssdk.services.s3.S3Client;
@@ -147,7 +149,7 @@ class DynamicRuleMergerTest extends JavaFrontendTestSuite, DynamicRuleMerger {
         List(".*(software.amazon.awssdk.services.s3).*"),
         false,
         "",
-        Map(),
+        Map("Discovery_Generated" -> "true"),
         NodeType.REGULAR,
         "",
         CatLevelOne.SINKS,
@@ -157,9 +159,10 @@ class DynamicRuleMergerTest extends JavaFrontendTestSuite, DynamicRuleMerger {
       )
     )
 
-    val finalSinkRule = mergeDynamicRuleSinkForDependencyDiscovery(dynamicRule, existingRule)
+    val ruleCache     = new RuleCache()
+    val finalSinkRule = mergeDynamicRuleSinkForDependencyDiscovery(dynamicRule, existingRule, ruleCache)
     val configAndRule = ConfigAndRules(sinks = finalSinkRule)
-    val ruleCache     = RuleCache().setRule(configAndRule)
+    ruleCache.setRule(configAndRule)
 
     val cpg = code("""
         |import software.amazon.awssdk.services.s3.S3Client;
@@ -217,7 +220,7 @@ class DynamicRuleMergerTest extends JavaFrontendTestSuite, DynamicRuleMerger {
         List(".*(software.amazon.awssdk.services.s3).*"),
         false,
         "",
-        Map(),
+        Map("Discovery_Generated" -> "true"),
         NodeType.REGULAR,
         "",
         CatLevelOne.SINKS,
@@ -227,9 +230,11 @@ class DynamicRuleMergerTest extends JavaFrontendTestSuite, DynamicRuleMerger {
       )
     )
 
-    val finalSinkRule = mergeDynamicRuleSinkForDependencyDiscovery(dynamicFilterPropertyRule, existingCodeRule)
+    val ruleCache = new RuleCache()
+    val finalSinkRule =
+      mergeDynamicRuleSinkForDependencyDiscovery(dynamicFilterPropertyRule, existingCodeRule, ruleCache)
     val configAndRule = ConfigAndRules(sinks = finalSinkRule)
-    val ruleCache     = RuleCache().setRule(configAndRule)
+    ruleCache.setRule(configAndRule)
 
     val cpg = code("""
         |import software.amazon.awssdk.services.s3.S3Client;


### PR DESCRIPTION
When we merge an external rule with an internal one, it's possible that both merging rules don't have the same ID. In cases where the domain or name matches, we merge the external rule with the internal one, but when tagging the dependency node, we only have the external rule ID. So, it's important to map which external rule was merged with which internal rule.

We have created the `DynamicMergerRuleMap` to store the merging information.